### PR TITLE
[Issue #89] (Team 1) Refactor DataReader and IndexBasedSourceOperator

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/IPredicate.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/IPredicate.java
@@ -5,5 +5,4 @@ package edu.uci.ics.textdb.api.common;
  */
 public interface IPredicate {
 
-    boolean satisfy(ITuple tuple);
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/DataConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/DataConstants.java
@@ -7,7 +7,7 @@ package edu.uci.ics.textdb.common.constants;
  * @author sandeepreddy602
  *
  */
-public class LuceneConstants {
+public class DataConstants {
     public static final String INDEX_DIR = "../index";
     public static final String SCAN_QUERY = "*:*";
     public static final int MAX_RESULTS = 100;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.Query;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IPredicate;
-import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.utils.Utils;
 
@@ -50,12 +49,6 @@ public class KeywordPredicate implements IPredicate{
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
         }
-    }
-
-    public boolean satisfy(ITuple tuple) {
-
-        //This method is necessary for the interface implementation, and it's really not used.
-        return true;
     }
 
     /**

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -2,17 +2,19 @@ package edu.uci.ics.textdb.dataflow.common;
 
 import java.util.ArrayList;
 import java.util.List;
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.utils.Utils;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+
+import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.utils.Utils;
 
 /**
  *  @author prakul
@@ -50,7 +52,6 @@ public class KeywordPredicate implements IPredicate{
         }
     }
 
-    @Override
     public boolean satisfy(ITuple tuple) {
 
         //This method is necessary for the interface implementation, and it's really not used.

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -41,7 +41,6 @@ public class RegexPredicate implements IPredicate{
     	return regex;
     }
 
-    @Override
     public boolean satisfy(ITuple tuple) {
         if(tuple == null){
             return false;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -1,25 +1,33 @@
 package edu.uci.ics.textdb.dataflow.source;
 
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.reader.DataReader;
 
 /**
  * Created by chenli on 3/28/16.
  */
-public class IndexSearchSourceOperator implements ISourceOperator {
+public class IndexBasedSourceOperator implements ISourceOperator {
 
 	private IDataReader dataReader;
-
-	public IndexSearchSourceOperator(IDataReader dataReader) throws DataFlowException {
-		this.dataReader = dataReader;
+	private DataReaderPredicate predicate;
+	private int cursor = CLOSED;
+	
+	public IndexBasedSourceOperator(IPredicate predicate){
+	    this.predicate = (DataReaderPredicate)predicate;
 	}
 
 	@Override
 	public void open() throws DataFlowException {
 		try {
+		    dataReader = new DataReader(predicate);
 			dataReader.open();
+			cursor = OPENED;
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new DataFlowException(e.getMessage(), e);
@@ -28,6 +36,9 @@ public class IndexSearchSourceOperator implements ISourceOperator {
 
 	@Override
 	public ITuple getNextTuple() throws DataFlowException {
+	    if(cursor == CLOSED){
+	        throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
+	    }
 		try {
 			return dataReader.getNextTuple();
 		} catch (Exception e) {
@@ -44,6 +55,11 @@ public class IndexSearchSourceOperator implements ISourceOperator {
 			e.printStackTrace();
 			throw new DataFlowException(e.getMessage(), e);
 		}
+	}
+	
+	public void setPredicate(IPredicate predicate){
+	    this.predicate = (DataReaderPredicate)predicate;
+	    cursor = CLOSED;
 	}
 
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -57,7 +57,7 @@ public class IndexBasedSourceOperator implements ISourceOperator {
 		}
 	}
 	
-	public void setPredicate(IPredicate predicate){
+	public void resetPredicate(IPredicate predicate){
 	    this.predicate = (DataReaderPredicate)predicate;
 	    cursor = CLOSED;
 	}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -51,12 +51,18 @@ public class IndexBasedSourceOperator implements ISourceOperator {
 	public void close() throws DataFlowException {
 		try {
 			dataReader.close();
+			cursor = CLOSED;
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new DataFlowException(e.getMessage(), e);
 		}
 	}
 	
+	/**
+	 * Resets the predicate and resets the cursor. 
+	 * The caller needs to reopen the operator once the predicate is reset.
+	 * @param predicate
+	 */
 	public void resetPredicate(IPredicate predicate){
 	    this.predicate = (DataReaderPredicate)predicate;
 	    cursor = CLOSED;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -18,12 +18,13 @@ import org.junit.Test;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IDictionary;
 import edu.uci.ics.textdb.api.common.IField;
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.field.DataTuple;
@@ -36,9 +37,10 @@ import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.LuceneDataStore;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.DataStore;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
  * @author rajeshyarlagadda
@@ -47,21 +49,23 @@ import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
 public class DictionaryMatcherTest {
 
     private DictionaryMatcher dictionaryMatcher;
-    private LuceneDataStore dataStore;
+    private DataStore dataStore;
     private IDataWriter dataWriter;
     private IDataReader dataReader;
     private Analyzer analyzer;
     private Query query;
+    private IPredicate dataReaderPredicate;
 
     @Before
     public void setUp() throws Exception {
 
-        dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
+        dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
         analyzer = new StandardAnalyzer();
-        dataWriter = new LuceneDataWriter(dataStore, analyzer);
+        dataWriter = new DataWriter(dataStore, analyzer);
         QueryParser queryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), analyzer);
-        query = queryParser.parse(LuceneConstants.SCAN_QUERY);
-        dataReader = new LuceneDataReader(dataStore, query);
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        dataReader = new DataReader(dataReaderPredicate);
         dataWriter.clearData();
         dataWriter.writeData(TestConstants.getSamplePeopleTuples());
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -53,7 +53,7 @@ public class DictionaryMatcherTest {
     private IDataWriter dataWriter;
     private IDataReader dataReader;
     private Analyzer analyzer;
-    private Query query;
+    private Query luceneQuery;
     private IPredicate dataReaderPredicate;
 
     @Before
@@ -62,9 +62,9 @@ public class DictionaryMatcherTest {
         dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
         analyzer = new StandardAnalyzer();
         dataWriter = new DataWriter(dataStore, analyzer);
-        QueryParser queryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), analyzer);
-        query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        QueryParser luceneQueryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), analyzer);
+        luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, luceneQuery);
         dataReader = new DataReader(dataReaderPredicate);
         dataWriter.clearData();
         dataWriter.writeData(TestConstants.getSamplePeopleTuples());

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -22,7 +22,6 @@ import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -38,11 +37,10 @@ import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
-import edu.uci.ics.textdb.dataflow.source.IndexSearchSourceOperator;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.reader.DataReader;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
@@ -55,7 +53,7 @@ public class KeywordMatcherTest {
     private KeywordMatcher keywordMatcher;
     private IDataWriter dataWriter;
     private DataStore dataStore;
-    private IndexSearchSourceOperator indexSearchSourceOperator;
+    private IndexBasedSourceOperator indexSearchSourceOperator;
     private Analyzer analyzer;
     private Query queryObj;
     private Schema schema;
@@ -135,8 +133,7 @@ public class KeywordMatcherTest {
             queryObj = createQueryObject(query, attributeList);
         }
         dataReaderPredicate = new DataReaderPredicate(dataStore, queryObj);
-        IDataReader dataReader = new DataReader(dataReaderPredicate);
-        indexSearchSourceOperator = new IndexSearchSourceOperator(dataReader);
+        indexSearchSourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
         keywordMatcher = new KeywordMatcher(predicate, indexSearchSourceOperator);
         keywordMatcher.open();
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/neextractor/NamedEntityExtractorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/neextractor/NamedEntityExtractorTest.java
@@ -1,29 +1,30 @@
 package edu.uci.ics.textdb.dataflow.neextractor;
 
-import edu.uci.ics.textdb.api.common.ITuple;
-import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import java.util.ArrayList;
+import java.util.List;
 
-import edu.uci.ics.textdb.api.storage.IDataReader;
-import edu.uci.ics.textdb.api.storage.IDataStore;
-import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
-import edu.uci.ics.textdb.dataflow.neextrator.NamedEntityExtractor;
-import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
-import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.LuceneDataStore;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
-
-import org.apache.lucene.analysis.Analyzer;
 import org.junit.After;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import edu.uci.ics.textdb.api.common.IPredicate;
+import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.storage.IDataReader;
+import edu.uci.ics.textdb.api.storage.IDataStore;
+import edu.uci.ics.textdb.api.storage.IDataWriter;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.dataflow.neextrator.NamedEntityExtractor;
+import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
+import edu.uci.ics.textdb.dataflow.utils.TestUtils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.DataStore;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
  * @author Feng [sam0227]
@@ -37,6 +38,8 @@ public class NamedEntityExtractorTest {
 
     private Query query;
     private Analyzer analyzer;
+
+    private IPredicate dataReaderPredicate;
 
 
     @After
@@ -157,14 +160,15 @@ public class NamedEntityExtractorTest {
      */
 
     public ISourceOperator getSourceOperator(Schema schema, List<ITuple> data) throws Exception {
-        dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, schema);
+        dataStore = new DataStore(DataConstants.INDEX_DIR, schema);
         analyzer = new StandardAnalyzer();
-        dataWriter = new LuceneDataWriter(dataStore, analyzer);
+        dataWriter = new DataWriter(dataStore, analyzer);
         dataWriter.writeData(data);
 
         QueryParser queryParser = new QueryParser(NEExtractorTestConstants.ATTRIBUTES_ONE_SENTENCE.get(0).getFieldName(), analyzer);
-        query = queryParser.parse(LuceneConstants.SCAN_QUERY);
-        dataReader = new LuceneDataReader(dataStore, query);
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        dataReader = new DataReader(dataReaderPredicate);
 
         ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataReader);
         return sourceOperator;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -15,13 +15,14 @@ import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
-import edu.uci.ics.textdb.storage.LuceneDataStore;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.DataStore;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 
 /**
@@ -39,11 +40,12 @@ public class RegexMatcherTestHelper {
 	private List<ITuple> results;
     private Analyzer analyzer;
     private Query query;
+    private IPredicate dataReaderPredicate;
 	
 	public RegexMatcherTestHelper(Schema schema, List<ITuple> data) throws Exception {
-		dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, schema);
+		dataStore = new DataStore(DataConstants.INDEX_DIR, schema);
 		analyzer = new  StandardAnalyzer();
-        dataWriter = new LuceneDataWriter(dataStore, analyzer);
+        dataWriter = new DataWriter(dataStore, analyzer);
 		dataWriter.clearData();
 		dataWriter.writeData(data);	
 		results = new ArrayList<ITuple>();
@@ -61,8 +63,9 @@ public class RegexMatcherTestHelper {
 		results.clear();
 		QueryParser queryParser = new QueryParser(
                 TestConstants.FIRST_NAME, analyzer);
-        query = queryParser.parse(LuceneConstants.SCAN_QUERY);
-        dataReader = new LuceneDataReader(dataStore, query);
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        dataReader = new DataReader(dataReaderPredicate);
 
 		IPredicate predicate = new RegexPredicate(regex, fieldName);
 		ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataReader);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -152,11 +152,11 @@ public class IndexBasedSourceOperatorTest {
 	 * @throws DataFlowException
 	 */
 	@Test(expected=DataFlowException.class)
-	public void testSetPredicate() throws ParseException, DataFlowException{
+	public void testResetPredicate() throws ParseException, DataFlowException{
 	    constructIndexBasedSourceOperator(TestConstants.DESCRIPTION + ":angry");
 	    indexBasedSourceOperator.open();
 	    indexBasedSourceOperator.getNextTuple();
-	    indexBasedSourceOperator.setPredicate(dataReaderPredicate);
+	    indexBasedSourceOperator.resetPredicate(dataReaderPredicate);
 	    indexBasedSourceOperator.getNextTuple();
 	}
 }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexSearchSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexSearchSourceOperatorTest.java
@@ -6,7 +6,6 @@ package edu.uci.ics.textdb.dataflow.source;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Schema;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -17,17 +16,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.LuceneDataStore;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.DataStore;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
  * @author akshaybetala
@@ -39,13 +40,14 @@ public class IndexSearchSourceOperatorTest {
 	private IndexSearchSourceOperator indexSearchSourceOperator;
 	private IDataStore dataStore;
 	private Analyzer analyzer;
+    private IPredicate dataReaderPredicate;
 
 
 	@Before
 	public void setUp() throws Exception {
-		dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
+		dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
 		analyzer = new StandardAnalyzer();
-		dataWriter = new LuceneDataWriter(dataStore, analyzer);
+		dataWriter = new DataWriter(dataStore, analyzer);
 		dataWriter.clearData();
 		dataWriter.writeData(TestConstants.getSamplePeopleTuples());
 
@@ -61,7 +63,8 @@ public class IndexSearchSourceOperatorTest {
 		String defaultField = TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName();
 		QueryParser queryParser = new QueryParser(defaultField, analyzer);
 		Query queryObject = queryParser.parse(query);
-		IDataReader dataReader = new LuceneDataReader(dataStore, queryObject);
+		dataReaderPredicate = new DataReaderPredicate(dataStore, queryObject);
+		IDataReader dataReader = new DataReader(dataReaderPredicate);
 		indexSearchSourceOperator = new IndexSearchSourceOperator(dataReader);
 		indexSearchSourceOperator.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
@@ -16,17 +16,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.LuceneDataStore;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
+import edu.uci.ics.textdb.storage.DataStore;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
  * @author sandeepreddy602
@@ -40,16 +42,18 @@ public class ScanBasedSourceOperatorTest {
     private IDataStore dataStore;
     private Analyzer analyzer;
     private Query query;
+    private IPredicate dataReaderPredicate;
     
     @Before
     public void setUp() throws Exception{
-        dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
+        dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
         analyzer = new  StandardAnalyzer();
-        dataWriter = new LuceneDataWriter(dataStore, analyzer );
+        dataWriter = new DataWriter(dataStore, analyzer );
         QueryParser queryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), analyzer);
-        query = queryParser.parse(LuceneConstants.SCAN_QUERY);
-        dataReader = new LuceneDataReader(dataStore, query);
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        dataReader = new DataReader(dataReaderPredicate);
         
         dataWriter.clearData();
         dataWriter.writeData(TestConstants.getSamplePeopleTuples());

--- a/textdb/textdb-sandbox/src/main/java/edu/uci/ics/textdb/sandbox/team3/team3lucenequeryexample/LuceneNgramQueryExample.java
+++ b/textdb/textdb-sandbox/src/main/java/edu/uci/ics/textdb/sandbox/team3/team3lucenequeryexample/LuceneNgramQueryExample.java
@@ -21,7 +21,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 
 /* 
  * This example shows that lucene can process manually translated boolean expressions.   
@@ -44,7 +44,7 @@ public class LuceneNgramQueryExample {
 				return new TokenStreamComponents(source);
 			}
 		};
-		Directory indexDir = FSDirectory.open(Paths.get(LuceneConstants.INDEX_DIR));
+		Directory indexDir = FSDirectory.open(Paths.get(DataConstants.INDEX_DIR));
 		IndexWriterConfig config = new IndexWriterConfig(analyzer);
 		indexWriter = new IndexWriter(indexDir, config);
 	}
@@ -78,7 +78,7 @@ public class LuceneNgramQueryExample {
 	
 	public TopDocs search(String queryText, int numOfTopHit) throws Exception{
 		searcher = new IndexSearcher(
-				DirectoryReader.open(FSDirectory.open(Paths.get(LuceneConstants.INDEX_DIR))));
+				DirectoryReader.open(FSDirectory.open(Paths.get(DataConstants.INDEX_DIR))));
 		
         QueryParser parser = new QueryParser("data", analyzer);
 		Query query = parser.parse(queryText);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -10,18 +10,18 @@ import edu.uci.ics.textdb.api.storage.IDataStore;
  */
 public class DataReaderPredicate implements IPredicate {
     private IDataStore dataStore;
-    private Query query;
+    private Query luceneQuery;
 
-    public DataReaderPredicate(IDataStore dataStore, Query query){
+    public DataReaderPredicate(IDataStore dataStore, Query luceneQuery){
         this.dataStore = dataStore;
-        this.query = query;
+        this.luceneQuery = luceneQuery;
     }
 
     public IDataStore getDataStore() {
         return dataStore;
     }
 
-    public Query getQuery() {
-        return query;
+    public Query getLuceneQuery() {
+        return luceneQuery;
     }
 }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -1,0 +1,27 @@
+package edu.uci.ics.textdb.storage;
+
+import org.apache.lucene.search.Query;
+
+import edu.uci.ics.textdb.api.common.IPredicate;
+import edu.uci.ics.textdb.api.storage.IDataStore;
+
+/**
+ * Created by sandeepreddy602 on 05-06-2016.
+ */
+public class DataReaderPredicate implements IPredicate {
+    private IDataStore dataStore;
+    private Query query;
+
+    public DataReaderPredicate(IDataStore dataStore, Query query){
+        this.dataStore = dataStore;
+        this.query = query;
+    }
+
+    public IDataStore getDataStore() {
+        return dataStore;
+    }
+
+    public Query getQuery() {
+        return query;
+    }
+}

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataStore.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataStore.java
@@ -3,12 +3,12 @@ package edu.uci.ics.textdb.storage;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 
-public class LuceneDataStore implements IDataStore {
+public class DataStore implements IDataStore {
     private String dataDirectory;
     private int numDocuments;
     private Schema schema;
 
-    public LuceneDataStore(String dataDirectory, Schema schema) {
+    public DataStore(String dataDirectory, Schema schema) {
         this.dataDirectory = dataDirectory;
         this.schema = schema;
     }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -11,12 +11,7 @@ import java.util.List;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -25,30 +20,30 @@ import org.apache.lucene.store.FSDirectory;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.IField;
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataReader;
-import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.utils.Utils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 
 /**
  * @author sandeepreddy602
  *
  */
-public class LuceneDataReader implements IDataReader{
-    
-    private IDataStore dataStore;
-    private int cursor = -1;
+public class DataReader implements IDataReader{
+
+    private int cursor = CLOSED;
     private IndexSearcher indexSearcher;
     private ScoreDoc[] scoreDocs;
     private IndexReader indexReader;
-    private Query query;
-    
-    public LuceneDataReader(IDataStore dataStore, Query query) {
-        this.dataStore = dataStore;
-        this.query = query;
+    private DataReaderPredicate dataReaderPredicate;
+
+    public DataReader(IPredicate dataReaderPredicate) {
+        this.dataReaderPredicate = (DataReaderPredicate)dataReaderPredicate;
     }
     
     @Override
@@ -56,17 +51,18 @@ public class LuceneDataReader implements IDataReader{
 
 
         try {
-            Directory directory = FSDirectory.open(Paths.get(dataStore.getDataDirectory()));
+            String dataDirectory = dataReaderPredicate.getDataStore().getDataDirectory();
+            Directory directory = FSDirectory.open(Paths.get(dataDirectory));
             indexReader = DirectoryReader.open(directory);
                 		
             indexSearcher = new IndexSearcher(indexReader);
-            TopDocs topDocs = indexSearcher.search(query, Integer.MAX_VALUE);
+            TopDocs topDocs = indexSearcher.search(dataReaderPredicate.getQuery(), Integer.MAX_VALUE);
             scoreDocs = topDocs.scoreDocs;
             cursor = OPENED;
         } catch (IOException e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
-        }              
+        }
     }
 
     @Override
@@ -81,13 +77,14 @@ public class LuceneDataReader implements IDataReader{
             Document document = indexSearcher.doc(scoreDocs[cursor++].doc);
             
             List<IField> fields = new ArrayList<IField>();
-            for (Attribute  attr : dataStore.getSchema().getAttributes()) {
+            Schema schema = dataReaderPredicate.getDataStore().getSchema();
+            for (Attribute  attr : schema.getAttributes()) {
                 FieldType fieldType = attr.getFieldType();
                 String fieldValue = document.get(attr.getFieldName());
                 fields.add(Utils.getField(fieldType, fieldValue));
             }
             
-            DataTuple dataTuple = new DataTuple(dataStore.getSchema(), fields.toArray(new IField[fields.size()]));
+            DataTuple dataTuple = new DataTuple(schema, fields.toArray(new IField[fields.size()]));
             return dataTuple;
         } catch (IOException e) {
             e.printStackTrace();

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/writer/DataWriter.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/writer/DataWriter.java
@@ -34,20 +34,20 @@ public class DataWriter implements IDataWriter{
     
     @Override
     public void clearData() throws StorageException{
-        IndexWriter indexWriter = null;
+        IndexWriter luceneIndexWriter = null;
         try {
             Directory directory = FSDirectory.open(Paths
                     .get(dataStore.getDataDirectory()));
             IndexWriterConfig conf = new IndexWriterConfig(analyzer);
-            indexWriter = new IndexWriter(directory, conf);
-            indexWriter.deleteAll();
+            luceneIndexWriter = new IndexWriter(directory, conf);
+            luceneIndexWriter.deleteAll();
         } catch (Exception e) {
             e.printStackTrace();
             throw new StorageException(e.getMessage(), e);
         } finally {
-            if (indexWriter != null) {
+            if (luceneIndexWriter != null) {
                 try {
-                    indexWriter.close();
+                    luceneIndexWriter.close();
                 } catch (IOException e) {
                     e.printStackTrace();
                     throw new StorageException(e.getMessage(), e);
@@ -59,18 +59,18 @@ public class DataWriter implements IDataWriter{
     
     @Override
     public void writeData(List<ITuple> tuples) throws StorageException {
-        IndexWriter indexWriter = null;
+        IndexWriter luceneIndexWriter = null;
         try {
             Directory directory = FSDirectory.open(Paths
                     .get(dataStore.getDataDirectory()));
             Analyzer analyzer = new StandardAnalyzer();
             IndexWriterConfig conf = new IndexWriterConfig(analyzer);
-            indexWriter = new IndexWriter(directory, conf);
+            luceneIndexWriter = new IndexWriter(directory, conf);
             
             for (ITuple sampleTuple : tuples) {
 
                 Document document = getDocument(dataStore.getSchema(), sampleTuple);
-                indexWriter.addDocument(document);
+                luceneIndexWriter.addDocument(document);
             }
             dataStore.incrementNumDocuments(tuples.size());
 
@@ -78,9 +78,9 @@ public class DataWriter implements IDataWriter{
             e.printStackTrace();
             throw new StorageException(e.getMessage(), e);
         } finally {
-            if (indexWriter != null) {
+            if (luceneIndexWriter != null) {
                 try {
-                    indexWriter.close();
+                    luceneIndexWriter.close();
                 } catch (IOException e) {
                     e.printStackTrace();
                     throw new StorageException(e.getMessage(), e);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/writer/DataWriter.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/writer/DataWriter.java
@@ -22,12 +22,12 @@ import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.common.utils.Utils;
 
-public class LuceneDataWriter implements IDataWriter{
+public class DataWriter implements IDataWriter{
     
     private IDataStore dataStore;
     private Analyzer analyzer;
 
-    public LuceneDataWriter(IDataStore dataStore, Analyzer analyzer) {
+    public DataWriter(IDataStore dataStore, Analyzer analyzer) {
         this.dataStore = dataStore;
         this.analyzer = analyzer;
     }

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
@@ -16,15 +16,15 @@ import edu.uci.ics.textdb.common.constants.TestConstants;
 public class DataReaderPredicateTest {
     private DataReaderPredicate dataReaderPredicate;
     private IDataStore dataStore;
-    private Query query;
+    private Query luceneQuery;
     
     @Before
     public void setUp() throws ParseException{
         dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
-        QueryParser queryParser = new QueryParser(
+        QueryParser luceneQueryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), new  StandardAnalyzer());
-        query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, luceneQuery);
     }
     
     @Test
@@ -32,7 +32,7 @@ public class DataReaderPredicateTest {
         IDataStore dataStoreReturned = dataReaderPredicate.getDataStore();
         Assert.assertSame(dataStore, dataStoreReturned);
         
-        Query queryReturned = dataReaderPredicate.getQuery();
-        Assert.assertSame(query, queryReturned);
+        Query queryReturned = dataReaderPredicate.getLuceneQuery();
+        Assert.assertSame(luceneQuery, queryReturned);
     }
 }

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
@@ -1,0 +1,38 @@
+package edu.uci.ics.textdb.storage;
+
+import junit.framework.Assert;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.storage.IDataStore;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.TestConstants;
+
+public class DataReaderPredicateTest {
+    private DataReaderPredicate dataReaderPredicate;
+    private IDataStore dataStore;
+    private Query query;
+    
+    @Before
+    public void setUp() throws ParseException{
+        dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
+        QueryParser queryParser = new QueryParser(
+                TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), new  StandardAnalyzer());
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+    }
+    
+    @Test
+    public void testGetters(){
+        IDataStore dataStoreReturned = dataReaderPredicate.getDataStore();
+        Assert.assertSame(dataStore, dataStoreReturned);
+        
+        Query queryReturned = dataReaderPredicate.getQuery();
+        Assert.assertSame(query, queryReturned);
+    }
+}

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -13,31 +13,34 @@ import org.apache.lucene.search.Query;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.LuceneConstants;
+import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
-import edu.uci.ics.textdb.storage.reader.LuceneDataReader;
-import edu.uci.ics.textdb.storage.writer.LuceneDataWriter;
+import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.writer.DataWriter;
 
-public class LuceneDataWriterReaderTest {
+public class DataWriterReaderTest {
     private IDataWriter dataWriter;
     private IDataReader dataReader;
     private IDataStore dataStore;
+    private IPredicate dataReaderPredicate;
     private Analyzer analyzer;
     private Query query;
     
     @Before
     public void setUp() throws ParseException{
-        dataStore = new LuceneDataStore(LuceneConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
+        dataStore = new DataStore(DataConstants.INDEX_DIR, TestConstants.SCHEMA_PEOPLE);
         analyzer = new  StandardAnalyzer();
-        dataWriter = new LuceneDataWriter(dataStore, analyzer );
+        dataWriter = new DataWriter(dataStore, analyzer );
         QueryParser queryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), analyzer);
-        query = queryParser.parse(LuceneConstants.SCAN_QUERY);
-        dataReader = new LuceneDataReader(dataStore, query);
+        query = queryParser.parse(DataConstants.SCAN_QUERY);
+        dataReaderPredicate = new DataReaderPredicate(dataStore, query);
+        dataReader = new DataReader(dataReaderPredicate);
     }
     
     @Test


### PR DESCRIPTION
Summary of Changes:

- `LuceneDataReader` --> `DataReader`; `LuceneDataWriter` --> `DataWriter`; `LuceneDataStore` --> `DataStore`; `LuceneDataWriterReaderTest `--> `DataWriterReaderTest`; `LuceneConstants `--> `DataConstants`.
- Added `DataReaderPredicate `which implements `IPredicate`.
- Removed `satisy()` method from `IPredicate`.
- `IndexSearchSourceOperator `--> `IndexBasedSourceOperator`;  `IndexSearchSourceOperatorTest `--> `IndexBasedSourceOperatorTest`
- Changed `IndexBasedSourceOperator `constructor to accept `IPredicate`.
- Exposed a new method in `IndexBasedSourceOperator `to reset `Predicate`

@chenlica @JavierJia Please review the changes.