### PR TITLE
modify dataReader to only tokenize query when span information is needed

### DIFF
--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -72,25 +72,28 @@ public class DataReader implements IDataReader{
             TopDocs topDocs = luceneIndexSearcher.search(dataReaderPredicate.getLuceneQuery(), Integer.MAX_VALUE);
             scoreDocs = topDocs.scoreDocs;
             cursor = OPENED;
-
-            this.queryTokens = Utils.tokenizeQuery(dataReaderPredicate.getLuceneAnalyzer(),dataReaderPredicate.getQueryString());
-
-            // sort the query tokens, as the term vector are also sorted.
-            // This makes the seek faster.
-            this.queryTokens.sort(String.CASE_INSENSITIVE_ORDER);
-
-            // The terms in the term vector are stored as ByteRef,
-            // hence convert token from String format to ByteRef and then search.
-
-            this.queryTokensInBytesRef = new ArrayList<>();
-            for(String token: queryTokens) {
-                BytesRef byteRef = new BytesRef(token.toLowerCase().getBytes());
-                this.queryTokensInBytesRef.add(byteRef);
-            }
-
-            this.attributeList = dataReaderPredicate.getAttributeList();
+            
             this.schema = dataReaderPredicate.getDataStore().getSchema();
-            this.spanSchema = Utils.createSpanSchema(schema);
+
+            if (this.dataReaderPredicate.getIsSpanInformationAdded()) {
+                this.queryTokens = Utils.tokenizeQuery(dataReaderPredicate.getLuceneAnalyzer(),dataReaderPredicate.getQueryString());
+
+                // sort the query tokens, as the term vector are also sorted.
+                // This makes the seek faster.
+                this.queryTokens.sort(String.CASE_INSENSITIVE_ORDER);
+
+                // The terms in the term vector are stored as ByteRef,
+                // hence convert token from String format to ByteRef and then search.
+
+                this.queryTokensInBytesRef = new ArrayList<>();
+                for(String token: queryTokens) {
+                    BytesRef byteRef = new BytesRef(token.toLowerCase().getBytes());
+                    this.queryTokensInBytesRef.add(byteRef);
+                }
+
+                this.attributeList = dataReaderPredicate.getAttributeList();
+                this.spanSchema = Utils.createSpanSchema(schema);
+            }
 
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
I added an if statement in DataReader.open
If the span information is not asked, then it won't tokenize the query.