### PR TITLE
Cleanup unchecked cast

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/field/ListField.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/field/ListField.java
@@ -32,9 +32,11 @@ public class ListField<T> implements IField {
             return true;
         if (obj == null)
             return false;
-        if (getClass() != obj.getClass())
-            return false; 
-        ListField<Object> other = (ListField<Object>) obj;
+        if (! (obj instanceof ListField<?>)) {
+        	return false;
+        }
+        
+        ListField<?> other = (ListField<?>) obj;
         if (list == null) {
             if (other.list != null)
                 return false;

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.common.utils;
 import java.io.StringReader;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -50,9 +51,8 @@ public class Utils {
             case TEXT:
                 field = new TextField(fieldValue);
                 break;
-
-            default:
-                break;
+			case LIST:
+				throw new RuntimeException("Can't get list field");
         }
         return field;
     }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.common.utils;
 import java.io.StringReader;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -14,8 +13,8 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.IndexOptions;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
@@ -51,8 +50,9 @@ public class Utils {
             case TEXT:
                 field = new TextField(fieldValue);
                 break;
-			case LIST:
-				throw new RuntimeException("Can't get list field");
+
+            default:
+                break;
         }
         return field;
     }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -13,8 +13,8 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.ListField;
@@ -29,13 +28,8 @@ public class RegexMatcherTest {
 	// Helper function to print results for debugging purposes
 	private void printResults(List<ITuple> results) {
 		for (ITuple result : results) {
-			IField spanListField = result.getField(SchemaConstants.SPAN_LIST);
-			if (!(spanListField instanceof ListField<?>)) {
-				return;
-			}
-			
-			List<Span> spanList = ((ListField<Span>) spanListField).getValue();
-			for (Span i : spanList) {
+			List<Span> a = ((ListField<Span>) result.getField("spanList")).getValue();
+			for (Span i : a) {
 				System.out.printf("start: %d, end: %d, fieldName: %s, key: %s, value: %s\n", 
 						i.getStart(), i.getEnd(), i.getFieldName(), i.getKey(), i.getValue());
 			}
@@ -344,6 +338,5 @@ public class RegexMatcherTest {
 	}
 	
 }
-
 
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.ListField;
@@ -28,8 +29,13 @@ public class RegexMatcherTest {
 	// Helper function to print results for debugging purposes
 	private void printResults(List<ITuple> results) {
 		for (ITuple result : results) {
-			List<Span> a = ((ListField<Span>) result.getField("spanList")).getValue();
-			for (Span i : a) {
+			IField spanListField = result.getField(SchemaConstants.SPAN_LIST);
+			if (!(spanListField instanceof ListField<?>)) {
+				return;
+			}
+			
+			List<Span> spanList = ((ListField<Span>) spanListField).getValue();
+			for (Span i : spanList) {
 				System.out.printf("start: %d, end: %d, fieldName: %s, key: %s, value: %s\n", 
 						i.getStart(), i.getEnd(), i.getFieldName(), i.getKey(), i.getValue());
 			}


### PR DESCRIPTION
Only one unchecked cast is fixed.

The rest are all casting from IField to ListField<T>.
for ListField<T> , the generic type T cannot be checked at runtime. (generic type information will be erased at runtime).