### PR TITLE
fix regex uppercase-lowercase problem

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexToGramQueryTranslator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexToGramQueryTranslator.java
@@ -47,6 +47,8 @@ public class RegexToGramQueryTranslator {
 		GramBooleanQuery simplifiedDNF = GramBooleanQuery.simplifyDNF(dnf);
 		
 	    TranslatorUtils.escapeSpecialCharacters(simplifiedDNF);
+	    
+	    //Since the inverted index relies on lower-case grams, we need to convert the characters to lower case.
 	    TranslatorUtils.toLowerCase(simplifiedDNF);
 		
 		return simplifiedDNF;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexToGramQueryTranslator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexToGramQueryTranslator.java
@@ -47,6 +47,7 @@ public class RegexToGramQueryTranslator {
 		GramBooleanQuery simplifiedDNF = GramBooleanQuery.simplifyDNF(dnf);
 		
 	    TranslatorUtils.escapeSpecialCharacters(simplifiedDNF);
+	    TranslatorUtils.toLowerCase(simplifiedDNF);
 		
 		return simplifiedDNF;
 	}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/TranslatorUtils.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/TranslatorUtils.java
@@ -184,5 +184,15 @@ public class TranslatorUtils {
 		}
 
 	}
+	
+	static void toLowerCase(GramBooleanQuery query){
+		if (query.operator == QueryOp.LEAF) {
+			query.leaf = query.leaf.toLowerCase();
+		} else {
+			for (GramBooleanQuery subQuery : query.subQuerySet) {
+				toLowerCase(subQuery);
+			}
+		}
+	}
 
 }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -31,7 +31,7 @@ import edu.uci.ics.textdb.storage.DataStore;
 public class RegexMatcherPerformanceTest {
 	
 	public static void main(String[] args) throws StorageException, IOException, DataFlowException {
-		samplePerformanceTest("C:\\Users\\dennis126\\Desktop\\Summer2017\\labLUNA\\MedlineDataset\\abstract_100K.txt", ".\\index");	
+		samplePerformanceTest("./data-files/abstract_100.txt", "./index");	
 	}
 
 	public static void samplePerformanceTest(String filePath, String indexPath) 
@@ -39,6 +39,7 @@ public class RegexMatcherPerformanceTest {
 		
 		Analyzer luceneAnalyzer = CustomAnalyzer.builder()
 				.withTokenizer(NGramTokenizerFactory.class, new String[]{"minGramSize", "3", "maxGramSize", "3"})
+				//Since the inverted index relies on lower-case grams, we need to convert the characters to lower case.
 				.addTokenFilter(LowerCaseFilterFactory.class)
 				.build();
 		
@@ -46,8 +47,8 @@ public class RegexMatcherPerformanceTest {
 		
 		DataStore dataStore = new DataStore(indexPath, MedlineReader.SCHEMA_MEDLINE);
 
-		//not need this if indexes already exist
-//		MedlineIndexWriter.writeMedlineToIndex(filePath, dataStore, luceneAnalyzer);
+		//Write into index. The following line is not necessary if index already exist.
+		MedlineIndexWriter.writeMedlineToIndex(filePath, dataStore, luceneAnalyzer);
 		
 		long endIndexTime = System.currentTimeMillis();
 		double indexTime = (endIndexTime - startIndexTime)/1000.0;
@@ -55,8 +56,7 @@ public class RegexMatcherPerformanceTest {
 		
 		
 //		String regex = "\\bmedic(ine|al|ation|are|aid)?\\b";
-//		String regex = "[Mm]arket";
-		String regex = "[Vv][ir]{2}[us]{2}";
+		String regex = "[Mm]arket";
 		
 		Attribute[] attributeList = new Attribute[]{ MedlineReader.ABSTRACT_ATTR };
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -37,9 +37,9 @@ public class RegexMatcherPerformanceTest {
 	public static void samplePerformanceTest(String filePath, String indexPath) 
 			throws StorageException, IOException, DataFlowException {
 		
+		// analyzer should generate trigrams all in lower case to build a lower case index. 
 		Analyzer luceneAnalyzer = CustomAnalyzer.builder()
 				.withTokenizer(NGramTokenizerFactory.class, new String[]{"minGramSize", "3", "maxGramSize", "3"})
-				//Since the inverted index relies on lower-case grams, we need to convert the characters to lower case.
 				.addTokenFilter(LowerCaseFilterFactory.class)
 				.build();
 		

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -2,16 +2,23 @@ package edu.uci.ics.textdb.perftest.regexmatcher;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
 
 import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.StorageException;
+import edu.uci.ics.textdb.common.field.ListField;
+import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
 import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
+import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.medline.MedlineReader;
 import edu.uci.ics.textdb.storage.DataStore;
 
@@ -24,7 +31,7 @@ import edu.uci.ics.textdb.storage.DataStore;
 public class RegexMatcherPerformanceTest {
 	
 	public static void main(String[] args) throws StorageException, IOException, DataFlowException {
-		samplePerformanceTest("./data-files/ipubmed_abs_present.json", "./index");	
+		samplePerformanceTest("C:\\Users\\dennis126\\Desktop\\Summer2017\\labLUNA\\MedlineDataset\\abstract_100K.txt", ".\\index");	
 	}
 
 	public static void samplePerformanceTest(String filePath, String indexPath) 
@@ -32,12 +39,14 @@ public class RegexMatcherPerformanceTest {
 		
 		Analyzer luceneAnalyzer = CustomAnalyzer.builder()
 				.withTokenizer(NGramTokenizerFactory.class, new String[]{"minGramSize", "3", "maxGramSize", "3"})
+				.addTokenFilter(LowerCaseFilterFactory.class)
 				.build();
 		
 		long startIndexTime = System.currentTimeMillis(); 
 		
 		DataStore dataStore = new DataStore(indexPath, MedlineReader.SCHEMA_MEDLINE);
 
+		//not need this if indexes already exist
 //		MedlineIndexWriter.writeMedlineToIndex(filePath, dataStore, luceneAnalyzer);
 		
 		long endIndexTime = System.currentTimeMillis();
@@ -45,8 +54,10 @@ public class RegexMatcherPerformanceTest {
 		System.out.printf("index time: %.4f seconds\n", indexTime);
 		
 		
-		String regex = "\\bmedic(ine|al|ation|are|aid)?\\b";
-
+//		String regex = "\\bmedic(ine|al|ation|are|aid)?\\b";
+//		String regex = "[Mm]arket";
+		String regex = "[Vv][ir]{2}[us]{2}";
+		
 		Attribute[] attributeList = new Attribute[]{ MedlineReader.ABSTRACT_ATTR };
 
 		RegexPredicate regexPredicate = new RegexPredicate(
@@ -72,8 +83,11 @@ public class RegexMatcherPerformanceTest {
 		long startMatchTime = System.currentTimeMillis();
 
 		int counter = 0;
-		while ((regexMatcher.getNextTuple()) != null) {
-			counter++;
+		ITuple result = null;
+		while ((result = regexMatcher.getNextTuple()) != null) {
+//			System.out.println(Utils.getTupleString(result));
+			List<Span> spanList = ((ListField<Span>) result.getField(SchemaConstants.SPAN_LIST)).getValue();
+            counter += spanList.size();
 		}
 		
 		long endMatchTime = System.currentTimeMillis();


### PR DESCRIPTION
There was a problem when using regex with mixed uppercase and lowercase characters. The reason is the uppercase-lowercase inconsistency between query and index. We converted both query and index to all lower case in this PR.