### PR TITLE
Unify order of parameters for predicates

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
@@ -34,8 +34,8 @@ public class DictionaryPredicate implements IPredicate {
     New and York; if searched in String field we search for Exact string.
      */
 
-    public DictionaryPredicate(IDictionary dictionary, Analyzer luceneAnalyzer, List<Attribute> attributeList,
-            KeywordMatchingType srcOpType, IDataStore dataStore) {
+    public DictionaryPredicate(IDictionary dictionary, IDataStore dataStore, List<Attribute> attributeList,
+    		Analyzer luceneAnalyzer, KeywordMatchingType srcOpType) {
 
         this.dictionary = dictionary;
         this.luceneAnalyzer = luceneAnalyzer;
@@ -79,7 +79,7 @@ public class DictionaryPredicate implements IPredicate {
     public IOperator getScanSourceOperator() throws ParseException, DataFlowException {
         QueryParser luceneQueryParser = new QueryParser(attributeList.get(0).getFieldName(), luceneAnalyzer);
         Query luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
-        IPredicate dataReaderPredicate = new DataReaderPredicate(dataStore, luceneQuery,DataConstants.SCAN_QUERY,luceneAnalyzer,attributeList);
+        IPredicate dataReaderPredicate = new DataReaderPredicate(luceneQuery,DataConstants.SCAN_QUERY, dataStore, attributeList, luceneAnalyzer);
         IDataReader dataReader = new DataReader(dataReaderPredicate);
 
         IOperator operator = new ScanBasedSourceOperator(dataReader);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -37,7 +37,7 @@ public class FuzzyTokenPredicate implements IPredicate {
     private int threshold;
     private boolean isSpanInformationAdded;
     
-    public FuzzyTokenPredicate(String query, List<Attribute> attributeList, Analyzer analyzer,IDataStore dataStore, double thresholdRatio, boolean isSpanInformationAdded) throws DataFlowException{
+    public FuzzyTokenPredicate(String query, IDataStore dataStore, List<Attribute> attributeList, Analyzer analyzer, double thresholdRatio, boolean isSpanInformationAdded) throws DataFlowException{
         try {
         	this.thresholdRatio = thresholdRatio;
         	this.dataStore = dataStore;
@@ -105,8 +105,8 @@ public class FuzzyTokenPredicate implements IPredicate {
     }
 
     public DataReaderPredicate getDataReaderPredicate() {
-    	DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.dataStore, this.luceneQuery,
-                this.query, this.luceneAnalyzer, this.attributeList);
+    	DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery,this.query,
+    			this.dataStore, this.attributeList, this.luceneAnalyzer);
     	dataReaderPredicate.setIsSpanInformationAdded(this.isSpanInformationAdded);
     	return dataReaderPredicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -51,8 +51,8 @@ public class KeywordPredicate implements IPredicate {
 	 * searched in TextField, we would consider both tokens New and York; if
 	 * searched in String field we search for Exact string.
 	 */
-	public KeywordPredicate(String query, List<Attribute> attributeList, KeywordMatchingType operatorType,
-			Analyzer luceneAnalyzer, IDataStore dataStore) throws DataFlowException {
+	public KeywordPredicate(String query, IDataStore dataStore, List<Attribute> attributeList, Analyzer luceneAnalyzer, 
+			KeywordMatchingType operatorType) throws DataFlowException {
 		try {
 			this.query = query;
 			this.queryTokenList = Utils.tokenizeQuery(luceneAnalyzer, query);
@@ -217,8 +217,8 @@ public class KeywordPredicate implements IPredicate {
 	}
 
 	public DataReaderPredicate getDataReaderPredicate() {
-		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.dataStore, this.luceneQuery, this.query,
-				this.luceneAnalyzer, this.attributeList);
+		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, this.query,
+				this.dataStore, this.attributeList, this.luceneAnalyzer);
 		return dataReaderPredicate;
 	}
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -27,7 +27,7 @@ public class RegexPredicate implements IPredicate {
 	private Analyzer luceneAnalyzer;
 	private IDataStore dataStore;
 
-	public RegexPredicate(String regex, List<Attribute> attributeList, Analyzer analyzer, IDataStore dataStore) {
+	public RegexPredicate(String regex, IDataStore dataStore, List<Attribute> attributeList, Analyzer analyzer) {
 		this.regex = regex;
 		this.luceneAnalyzer = analyzer;
 		this.dataStore = dataStore;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -58,17 +58,21 @@ public class DictionaryMatcher implements IOperator {
             	throw new DataFlowException("Dictionary is empty");
             }
             
-            if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
-                KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry, predicate.getAttributeList(),
-                        KeywordMatchingType.PHRASE_INDEXBASED, predicate.getAnalyzer(), predicate.getDataStore());
-                sourceOperator = new KeywordMatcher(keywordPredicate);
-                sourceOperator.open();
-            } else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-                KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry, predicate.getAttributeList(),
-                        KeywordMatchingType.CONJUNCTION_INDEXBASED, predicate.getAnalyzer(), predicate.getDataStore());
-                sourceOperator = new KeywordMatcher(keywordPredicate);
-                sourceOperator.open();
-            } else {
+			if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+				KeywordPredicate keywordPredicate = new KeywordPredicate(
+						currentDictionaryEntry, predicate.getDataStore(),
+						predicate.getAttributeList(), predicate.getAnalyzer(),
+						KeywordMatchingType.PHRASE_INDEXBASED);
+				sourceOperator = new KeywordMatcher(keywordPredicate);
+				sourceOperator.open();
+			} else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+				KeywordPredicate keywordPredicate = new KeywordPredicate(
+						currentDictionaryEntry, predicate.getDataStore(),
+						predicate.getAttributeList(), predicate.getAnalyzer(),
+						KeywordMatchingType.CONJUNCTION_INDEXBASED);
+				sourceOperator = new KeywordMatcher(keywordPredicate);
+				sourceOperator.open();
+			} else {
                 sourceOperator = predicate.getScanSourceOperator();
                 sourceOperator.open();
             }
@@ -133,8 +137,10 @@ public class DictionaryMatcher implements IOperator {
     				keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
     			}
     			
-    			KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry, predicate.getAttributeList(),
-    					keywordMatchingType, predicate.getAnalyzer(), predicate.getDataStore());
+				KeywordPredicate keywordPredicate = new KeywordPredicate(
+						currentDictionaryEntry, predicate.getDataStore(),
+						predicate.getAttributeList(), predicate.getAnalyzer(),
+						keywordMatchingType);
     			
     			sourceOperator.close();
     			sourceOperator = new KeywordMatcher(keywordPredicate);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -99,8 +99,9 @@ public class RegexMatcher implements IOperator {
     		throw new DataFlowException(e.getMessage());
     	}
     	    	
-		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(regexPredicate.getDataStore(), 
-				this.luceneQuery, this.luceneQueryStr, luceneAnalyzer, regexPredicate.getAttributeList());
+		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery,
+				this.luceneQueryStr, regexPredicate.getDataStore(),
+				regexPredicate.getAttributeList(), luceneAnalyzer);
 		this.sourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
 		
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -70,7 +70,7 @@ public class DictionaryMatcherTest {
     public List<ITuple> getQueryResults(IDictionary dictionary, KeywordMatchingType srcOpType,
             List<Attribute> attributes) throws Exception {
 
-    	IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, luceneAnalyzer, attributes, srcOpType , dataStore);
+    	IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, srcOpType);
     	dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
     	dictionaryMatcher.open();
         ITuple nextTuple = null;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
@@ -63,7 +63,7 @@ public class FuzzyTokenMatcherTest {
     
     public List<ITuple> getQueryResults(String query,double threshold, ArrayList<Attribute> attributeList, boolean isSpanInformationAdded) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new FuzzyTokenPredicate(query, attributeList, analyzer, dataStore, threshold, isSpanInformationAdded);
+        IPredicate predicate = new FuzzyTokenPredicate(query, dataStore, attributeList, analyzer, threshold, isSpanInformationAdded);
         fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);
         fuzzyTokenMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -133,25 +133,25 @@ public class JoinTest {
 		IPredicate predicate = null;
 		switch (type) {
 		case "substring":
-			if(whichOperator == "outer") {
-				predicate = new KeywordPredicate(query, attributeList, 
-						DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED, analyzer, 
-						dataStoreForOuter);
-			} else if(whichOperator == "inner") {
-				predicate = new KeywordPredicate(query, attributeList, 
-						DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED, analyzer, 
-						dataStoreForInner);
+			if (whichOperator == "outer") {
+				predicate = new KeywordPredicate(query, dataStoreForOuter,
+						attributeList, analyzer,
+						DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
+			} else if (whichOperator == "inner") {
+				predicate = new KeywordPredicate(query, dataStoreForInner,
+						attributeList, analyzer,
+						DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
 			}
 			break;
 		case "phrase":
-			if(whichOperator == "outer") {
-				predicate = new KeywordPredicate(query, attributeList, 
-						DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, analyzer, 
-						dataStoreForOuter);
-			} else if(whichOperator == "inner") {
-				predicate = new KeywordPredicate(query, attributeList, 
-						DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, analyzer, 
-						dataStoreForInner);
+			if (whichOperator == "outer") {
+				predicate = new KeywordPredicate(query, dataStoreForOuter,
+						attributeList, analyzer,
+						DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+			} else if (whichOperator == "inner") {
+				predicate = new KeywordPredicate(query, dataStoreForInner,
+						attributeList, analyzer,
+						DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 			}
 			break;
 
@@ -296,8 +296,8 @@ public class JoinTest {
 		query = "this writer writes well";
 		double thresholdRatio = 0.25;
 		boolean isSpanInformationAdded = false;
-		IPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(query, attributeList, 
-				analyzer, dataStoreForInner, thresholdRatio, isSpanInformationAdded);
+		IPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(query, dataStoreForInner, 
+				attributeList, analyzer, thresholdRatio, isSpanInformationAdded);
 		FuzzyTokenMatcher fuzzyMatcherInner = new FuzzyTokenMatcher(fuzzyPredicateInner);
 
 		Attribute idAttr = attributeList.get(0);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -74,7 +74,7 @@ public class KeywordMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED, analyzer, dataStore);
+        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         keywordMatcher = new KeywordMatcher(predicate);
         keywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -284,9 +284,9 @@ public class PhraseMatcherTest {
      */
     @Test
     public void testWordInMultipleFieldsQueryWithStopWords3() throws Exception {
-    	DataStore MedDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
+    	DataStore medDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
         Analyzer MedAnalyzer = new StandardAnalyzer();
-        DataWriter MedDataWriter = new DataWriter(MedDataStore, MedAnalyzer);
+        DataWriter MedDataWriter = new DataWriter(medDataStore, MedAnalyzer);
         MedDataWriter.clearData();
     	MedDataWriter.writeData(keywordTestConstants.getSampleMedlineRecord());
         //Prepare Query
@@ -320,7 +320,7 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        IPredicate predicate = new KeywordPredicate(query, medDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -74,7 +74,7 @@ public class PhraseMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, luceneAnalyzer, dataStore);
+        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 
@@ -320,7 +320,7 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, MedAnalyzer, MedDataStore);
+        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 
@@ -374,7 +374,7 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, MedAnalyzer, MedDataStore);
+        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 
@@ -439,7 +439,7 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, MedAnalyzer, MedDataStore);
+        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -75,7 +75,7 @@ public class SubstringMatcherTest {
     
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED, luceneAnalyzer, dataStore);
+        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
         KeywordMatcher = new KeywordMatcher(predicate);
         KeywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
@@ -271,8 +271,8 @@ public class NlpExtractorTest {
 
         QueryParser queryParser = new QueryParser(NlpExtractorTestConstants.ATTRIBUTES_ONE_SENTENCE.get(0).getFieldName(), analyzer);
         query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, query, DataConstants.SCAN_QUERY,
-                analyzer, Arrays.asList(NlpExtractorTestConstants.ATTRIBUTES_ONE_SENTENCE.get(0)));
+        dataReaderPredicate = new DataReaderPredicate(query, DataConstants.SCAN_QUERY, dataStore,
+                Arrays.asList(NlpExtractorTestConstants.ATTRIBUTES_ONE_SENTENCE.get(0)), analyzer);
         dataReader = new DataReader(dataReaderPredicate);
 
         ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataReader);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -59,8 +59,8 @@ public class RegexMatcherTestHelper {
 	public void runTest(String regex, Attribute attribute, boolean useTranslator) throws Exception {
 		results.clear();
 		RegexPredicate regexPredicate = new RegexPredicate(
-				regex, Arrays.asList(new Attribute[]{attribute}), 
-				luceneAnalyzer, dataStore);
+				regex, dataStore, Arrays.asList(new Attribute[]{attribute}), 
+				luceneAnalyzer);
 
 		regexMatcher = new RegexMatcher(regexPredicate, useTranslator);
 		regexMatcher.open();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -61,8 +61,8 @@ public class IndexBasedSourceOperatorTest {
 	    String defaultField = TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName();
         QueryParser queryParser = new QueryParser(defaultField, luceneAnalyzer);
         Query queryObject = queryParser.parse(query);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, queryObject,
-				query, luceneAnalyzer, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE[0]));
+        dataReaderPredicate = new DataReaderPredicate(queryObject, query,
+        		dataStore, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE[0]), luceneAnalyzer);
 
         indexBasedSourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
 	}

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
@@ -53,8 +53,8 @@ public class ScanBasedSourceOperatorTest {
         QueryParser queryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), lucneAnalyzer);
         query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, query,
-                DataConstants.SCAN_QUERY, lucneAnalyzer, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE[0]));
+        dataReaderPredicate = new DataReaderPredicate(query, DataConstants.SCAN_QUERY,
+                dataStore, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE[0]), lucneAnalyzer);
         dataReader = new DataReader(dataReaderPredicate);
         
         dataWriter.clearData();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -136,8 +136,7 @@ public class DictionaryMatcherPerformanceTest {
 		List<Attribute> attributes = Arrays.asList(MedlineIndexWriter.ABSTRACT_ATTR);
 
 		IDictionary dictionary = new Dictionary(queryList);
-		IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, luceneAnalyzer, attributes, opType,
-				dataStore);
+		IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, opType);
 		DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
 
 		long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -141,8 +141,8 @@ public class FuzzyTokenMatcherPerformanceTest {
 		Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 
 		for (String query : queryList) {
-			IPredicate predicate = new FuzzyTokenPredicate(query, Arrays.asList(attributeList), luceneAnalyzer,
-					dataStore, threshold, true);
+			IPredicate predicate = new FuzzyTokenPredicate(query, dataStore, Arrays.asList(attributeList),
+					luceneAnalyzer, threshold, true);
 			FuzzyTokenMatcher fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);
 
 			long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -154,8 +154,7 @@ public class KeywordMatcherPerformanceTest {
 		Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 
 		for (String query : queryList) {
-			IPredicate predicate = new KeywordPredicate(query, Arrays.asList(attributeList), opType, luceneAnalyzer,
-					dataStore);
+			IPredicate predicate = new KeywordPredicate(query, dataStore, Arrays.asList(attributeList), luceneAnalyzer, opType);
 			KeywordMatcher keywordMatcher = new KeywordMatcher(predicate);
 
 			long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -122,8 +122,8 @@ public class NlpExtractorPerformanceTest {
 		QueryParser queryParser = new QueryParser(MedlineIndexWriter.ABSTRACT_ATTR.getFieldName(), analyzer);
 		Query query = queryParser.parse(DataConstants.SCAN_QUERY);
 
-		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(dataStore, query, DataConstants.SCAN_QUERY,
-				analyzer, attributeList);
+		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(query, DataConstants.SCAN_QUERY,
+				dataStore, attributeList, analyzer);
 		IDataReader dataReader = new DataReader(dataReaderPredicate);
 		ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataReader);
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -114,8 +114,7 @@ public class RegexMatcherPerformanceTest {
 		// analyzer should generate grams all in lower case to build a lower
 		// case index.
 		Analyzer luceneAnalyzer = DataConstants.getTrigramAnalyzer();
-		RegexPredicate regexPredicate = new RegexPredicate(regex, Arrays.asList(attributeList), luceneAnalyzer,
-				dataStore);
+		RegexPredicate regexPredicate = new RegexPredicate(regex, dataStore, Arrays.asList(attributeList), luceneAnalyzer);
 
 		RegexMatcher regexMatcher = new RegexMatcher(regexPredicate, true);
 

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -20,7 +20,7 @@ public class DataReaderPredicate implements IPredicate {
     private List<Attribute> attributeList;
     private boolean isSpanInformationAdded = false;
 
-    public DataReaderPredicate(IDataStore dataStore, Query luceneQuery, String queryString, Analyzer analyzer, List<Attribute> attributeList){
+    public DataReaderPredicate(Query luceneQuery, String queryString, IDataStore dataStore, List<Attribute> attributeList, Analyzer analyzer){
         this.dataStore = dataStore;
         this.luceneQuery = luceneQuery;
         this.luceneAnalyzer = analyzer;

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
@@ -26,7 +26,7 @@ public class DataReaderPredicateTest {
         QueryParser luceneQueryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), new  StandardAnalyzer());
         luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, luceneQuery,DataConstants.SCAN_QUERY,new StandardAnalyzer(), Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE));
+        dataReaderPredicate = new DataReaderPredicate(luceneQuery,DataConstants.SCAN_QUERY, dataStore, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE), new StandardAnalyzer());
     }
     
     @Test

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -40,7 +40,7 @@ public class DataWriterReaderTest {
         QueryParser queryParser = new QueryParser(
                 TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), luceneAnalyzer);
         query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(dataStore, query, DataConstants.SCAN_QUERY, luceneAnalyzer, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE));
+        dataReaderPredicate = new DataReaderPredicate(query, DataConstants.SCAN_QUERY, dataStore, Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE), luceneAnalyzer);
         dataReader = new DataReader(dataReaderPredicate);
     }
     


### PR DESCRIPTION
Currently different predicates have different orders of parameters. This PR is to unify them to have a consistent order of parameters:
```
predicate(Query, DataStore, AttributeList, Analyzer, OtherParameters)

IPredicate predicate = new KeywordPredicate(query, dataStore, Arrays.asList(attributeList), luceneAnalyzer, opType);
```
