### PR TITLE
Setup Jenkins server for performance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # TextDB
 Text-centric data management system
 
+travis-ci
 [![Build Status](https://travis-ci.org/TextDB/textdb.svg?branch=master)](https://travis-ci.org/TextDB/textdb)
+
+Jenkins
+[![Build Status](http://ipubmed2.ics.uci.edu:8081/view/All/job/textdb/badge/icon)](http://ipubmed2.ics.uci.edu:8081/view/All/job/textdb/)

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -16,7 +16,6 @@
         <textdb.version>1.0-SNAPSHOT</textdb.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.exec.skip>false</maven.exec.skip>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -39,6 +38,19 @@
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>exec-maven-plugin</artifactId>
                   <version>1.5.0</version>
+                  <executions>
+                      <execution>
+                          <phase>test</phase>
+                          <goals>
+                              <goal>java</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+                  <configuration>
+                      <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
+                      <!--skip the execution here-->
+                      <skip>true</skip>
+                  </configuration>
               </plugin>
           </plugins>
       </pluginManagement>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -49,9 +49,10 @@
                       <skip>true</skip>
                       <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
                       <arguments>
-                        <argument>./textdb-perftest/data-files/</argument>
+                        <argument>./textdb-perftest/data-files/results/</argument>
                         <argument>./textdb-perftest/index/standard/</argument>
                         <argument>./textdb-perftest/index/trigram/</argument>
+                        <argument>./textdb-perftest/data-files/queries/</argument>
                       </arguments>
                   </configuration>
               </plugin>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -43,33 +43,17 @@
                           <goals>
                               <goal>java</goal>
                           </goals>
-                          <configuration>
-                              <skip>true</skip>
-                              <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
-                              <arguments>
-                                <argument>./textdb-perftest/data-files/</argument>
-                                <argument>./textdb-perftest/index/standard/</argument>
-                                <argument>./textdb-perftest/index/trigram/</argument>
-                              </arguments>
-                          </configuration>
-                      </execution>
-                      <execution>
-                        <phase>test</phase>
-                        <goals>
-                          <goal>java</goal>
-                        </goals>
-                        <configuration>
-                            <skip>true</skip>
-                            <mainClass>edu.ics.uci.textdb.perftest.runme.RunPerftests</mainClass>
-                            <arguments>
-                              <argument>./textdb-perftest/data-files/results/</argument>
-                              <argument>./textdb-perftest/index/standard/</argument>
-                              <argument>./textdb-perftest/index/trigram/</argument>
-                              <argument>./textdb-perftest/data-files/queries/</argument>
-                            </arguments>
-                        </configuration>
                       </execution>
                   </executions>
+                  <configuration>
+                      <skip>true</skip>
+                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
+                      <arguments>
+                        <argument>./textdb-perftest/data-files/</argument>
+                        <argument>./textdb-perftest/index/standard/</argument>
+                        <argument>./textdb-perftest/index/trigram/</argument>
+                      </arguments>
+                  </configuration>
               </plugin>
           </plugins>
       </pluginManagement>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -31,6 +31,35 @@
     </dependencyManagement>
 
     <build>
+      <pluginManagement>
+          <plugins>
+              <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>exec-maven-plugin</artifactId>
+                  <version>1.5.0</version>
+                  <executions>
+                      <execution>
+                          <phase>test</phase>
+                          <goals>
+                              <goal>java</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+                  <configuration>
+                      <skip>true</skip>
+                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
+                      <arguments>
+                        <argument>./textdb-perftest/data-files/</argument>
+                        <argument>./textdb-perftest/index/standard/</argument>
+                        <argument>./textdb-perftest/index/trigram/</argument>
+                      </arguments>
+                  </configuration>
+              </plugin>
+          </plugins>
+      </pluginManagement>
+
+
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -31,35 +31,6 @@
     </dependencyManagement>
 
     <build>
-      <pluginManagement>
-          <plugins>
-              <plugin>
-                  <groupId>org.codehaus.mojo</groupId>
-                  <artifactId>exec-maven-plugin</artifactId>
-                  <version>1.5.0</version>
-                  <executions>
-                      <execution>
-                          <phase>test</phase>
-                          <goals>
-                              <goal>java</goal>
-                          </goals>
-                      </execution>
-                  </executions>
-                  <configuration>
-                      <skip>true</skip>
-                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
-                      <arguments>
-                        <argument>./textdb-perftest/data-files/</argument>
-                        <argument>./textdb-perftest/index/standard/</argument>
-                        <argument>./textdb-perftest/index/trigram/</argument>
-                      </arguments>
-                  </configuration>
-              </plugin>
-          </plugins>
-      </pluginManagement>
-
-
-
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -31,6 +31,33 @@
     </dependencyManagement>
 
     <build>
+      <pluginManagement>
+          <plugins>
+              <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>exec-maven-plugin</artifactId>
+                  <version>1.5.0</version>
+                  <executions>
+                      <execution>
+                          <phase>test</phase>
+                          <goals>
+                              <goal>java</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+                  <configuration>
+                      <skip>true</skip>
+                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
+                      <arguments>
+                        <argument>./textdb-perftest/data-files/</argument>
+                        <argument>./textdb-perftest/index/standard/</argument>
+                        <argument>./textdb-perftest/index/trigram/</argument>
+                      </arguments>
+                  </configuration>
+              </plugin>
+          </plugins>
+      </pluginManagement>
+      
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -47,8 +47,8 @@
                       </execution>
                   </executions>
                   <configuration>
-                      <!--skip the execution here  -->
-                      <skip>true</skip>
+                      <!--skip the execution here-->
+                      <exec.skip>true</exec.skip>
                   </configuration>
               </plugin>
           </plugins>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -16,6 +16,7 @@
         <textdb.version>1.0-SNAPSHOT</textdb.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.exec.skip>false</maven.exec.skip>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -38,10 +39,6 @@
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>exec-maven-plugin</artifactId>
                   <version>1.5.0</version>
-                  <configuration>
-                      <!--skip the execution here-->
-                      <skip>true</skip>
-                  </configuration>
               </plugin>
           </plugins>
       </pluginManagement>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -47,7 +47,7 @@
                       </execution>
                   </executions>
                   <configuration>
-                      <mainClass></mainClass>
+                      <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
                       <!--skip the execution here-->
                       <skip>true</skip>
                   </configuration>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -47,14 +47,8 @@
                       </execution>
                   </executions>
                   <configuration>
+                      <!--skip the execution here  -->
                       <skip>true</skip>
-                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
-                      <arguments>
-                        <argument>./textdb-perftest/data-files/results/</argument>
-                        <argument>./textdb-perftest/index/standard/</argument>
-                        <argument>./textdb-perftest/index/trigram/</argument>
-                        <argument>./textdb-perftest/data-files/queries/</argument>
-                      </arguments>
                   </configuration>
               </plugin>
           </plugins>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -38,16 +38,7 @@
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>exec-maven-plugin</artifactId>
                   <version>1.5.0</version>
-                  <executions>
-                      <execution>
-                          <phase>test</phase>
-                          <goals>
-                              <goal>java</goal>
-                          </goals>
-                      </execution>
-                  </executions>
                   <configuration>
-                      <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
                       <!--skip the execution here-->
                       <skip>true</skip>
                   </configuration>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -30,7 +30,7 @@
         </dependencies>
     </dependencyManagement>
 
-    <!-- plugin for trigerring performance test-->
+    <!-- plugin for triggering performance test-->
     <build>
       <pluginManagement>
           <plugins>
@@ -47,7 +47,7 @@
                       </execution>
                   </executions>
                   <configuration>
-                      <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
+                      <mainClass>edu.uci.ics.textdb.perftest.runme.RunTests</mainClass>
                       <!--skip the execution here-->
                       <skip>true</skip>
                   </configuration>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -47,8 +47,9 @@
                       </execution>
                   </executions>
                   <configuration>
+                      <mainClass></mainClass>
                       <!--skip the execution here-->
-                      <exec.skip>true</exec.skip>
+                      <skip>true</skip>
                   </configuration>
               </plugin>
           </plugins>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -30,6 +30,7 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- plugin for trigerring performance test-->
     <build>
       <pluginManagement>
           <plugins>

--- a/textdb/pom.xml
+++ b/textdb/pom.xml
@@ -43,21 +43,37 @@
                           <goals>
                               <goal>java</goal>
                           </goals>
+                          <configuration>
+                              <skip>true</skip>
+                              <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
+                              <arguments>
+                                <argument>./textdb-perftest/data-files/</argument>
+                                <argument>./textdb-perftest/index/standard/</argument>
+                                <argument>./textdb-perftest/index/trigram/</argument>
+                              </arguments>
+                          </configuration>
+                      </execution>
+                      <execution>
+                        <phase>test</phase>
+                        <goals>
+                          <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                            <mainClass>edu.ics.uci.textdb.perftest.runme.RunPerftests</mainClass>
+                            <arguments>
+                              <argument>./textdb-perftest/data-files/results/</argument>
+                              <argument>./textdb-perftest/index/standard/</argument>
+                              <argument>./textdb-perftest/index/trigram/</argument>
+                              <argument>./textdb-perftest/data-files/queries/</argument>
+                            </arguments>
+                        </configuration>
                       </execution>
                   </executions>
-                  <configuration>
-                      <skip>true</skip>
-                      <mainClass>edu.ics.uci.textdb.perftest.runme.WriteIndex</mainClass>
-                      <arguments>
-                        <argument>./textdb-perftest/data-files/</argument>
-                        <argument>./textdb-perftest/index/standard/</argument>
-                        <argument>./textdb-perftest/index/trigram/</argument>
-                      </arguments>
-                  </configuration>
               </plugin>
           </plugins>
       </pluginManagement>
-      
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -57,6 +57,8 @@ public class RegexMatcher implements IOperator {
     	this.regexPredicate = (RegexPredicate) predicate;
     	this.regex = regexPredicate.getRegex();
     	this.fieldNameList = regexPredicate.getFieldNameList();
+    	
+    	
     			
 		// try Java Regex first
 		try {
@@ -84,8 +86,9 @@ public class RegexMatcher implements IOperator {
             }  
             
             this.spanList = computeMatches(sourceTuple);
-            
             if (spanList != null && spanList.size() != 0) { // a list of matches found
+                System.out.println(spanList.size());
+
             	List<IField> fields = sourceTuple.getFields();
             	return constructSpanTuple(fields, this.spanList);
             } else { // no match found
@@ -208,8 +211,10 @@ public class RegexMatcher implements IOperator {
             throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
         }
         
+        
         try {
             inputOperator.open();
+            this.spanSchema = Utils.createSpanSchema(this.inputOperator.getOutputSchema());
         } catch (Exception e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);

--- a/textdb/textdb-perftest/README.md
+++ b/textdb/textdb-perftest/README.md
@@ -1,15 +1,22 @@
 NOTE: Don't remove the file named .gitignore in any directory! 
-
+		Read the comments in the files mentioned here!
+		
 Step 1-Prepare Data Set:
 
 By default, there is a small data set named "abstract_100.txt" in ./data-files/.
-If you want to get results from more data sets, please put the data files into ./data-files/. 
+If you want to get results from more data sets, please put the data files into ./data-files/,
+or specify another path to the data sets when run WriteIndex.java in the next step. 
 
 More data sets can be found at:
 https://github.com/TextDB/textdb/wiki/Data-Sets
  
 Step 2-Prepare Index:
 In order to write index, run WriteIndex.java file in edu.uci.ics.textdb.perftest.run package.
+
+By default, indices are stored in ./index/standard/ and ./index/trigram/.
+If you want to store the indices to somewhere else, you can specify the 
+standard index path or trigram index path when run WriteIndex.
+
 NOTE: Once index is created, it can be reused (no writing index needed in the future)!!!!
 		However, if you make changes to your data set(s), writing index is still needed.
 
@@ -20,15 +27,24 @@ The default regex queries are defined in RunPerftests.java.
 
 If you are satisfied with the default queries, then move onto Step 4.
 
-If you want to use your own queries, please put query files to ./data-files/queries/ 
-or change the regex queries listed in RunPerftests.java.
+If you want to use your own queries, please put query files to ./data-files/queries/ or
+specify the query file's path when run RunPerftests in the next step.
+
+If you want to use your own regex queries, please change the regex queries listed in RunPerftests.java.
+
 In RunPerftests.java, you can see some operator performance tests take in a query file as a parameter.
 Please change the query file name to the one you want.
  
 Step 4-Run Performance Tests:
 In order to run the performance tests, please run RunPerftests.java file in edu.uci.ics.textdb.perftest.run package.
 
+If indices are stored at somewhere other than ./index/standard/ and ./index/trigram/, please
+specify the standard index path and trigram index path before running the class.
+
+If you have a specific location for the test results to be stored, please specify it before running the class.
+
 Step 5-Review Test Results:
-Performance test results can be found in the corresponding folders in ./data-files/results/.
+Performance test results can be found in the corresponding folders in ./data-files/results/
+or the result folder you previously specify.
 For example, test results for dictionary matcher can be found in ./data-files/results/queries/.
  

--- a/textdb/textdb-perftest/README.md
+++ b/textdb/textdb-perftest/README.md
@@ -5,7 +5,7 @@ Step 1-Prepare Data Set:
 
 By default, there is a small data set named "abstract_100.txt" in ./data-files/.
 If you want to get results from more data sets, please put the data files into ./data-files/,
-or specify another path to the data sets when run WriteIndex.java in the next step. 
+or specify another path to the data sets when running WriteIndex.java in the next step. 
 
 More data sets can be found at:
 https://github.com/TextDB/textdb/wiki/Data-Sets
@@ -15,7 +15,7 @@ In order to write index, run WriteIndex.java file in edu.uci.ics.textdb.perftest
 
 By default, indices are stored in ./index/standard/ and ./index/trigram/.
 If you want to store the indices to somewhere else, you can specify the 
-standard index path or trigram index path when run WriteIndex.
+standard index path or trigram index path when running WriteIndex.
 
 NOTE: Once index is created, it can be reused (no writing index needed in the future)!!!!
 		However, if you make changes to your data set(s), writing index is still needed.
@@ -28,7 +28,7 @@ The default regex queries are defined in RunPerftests.java.
 If you are satisfied with the default queries, then move onto Step 4.
 
 If you want to use your own queries, please put query files to ./data-files/queries/ or
-specify the query file's path when run RunPerftests in the next step.
+specify the query file's path when running RunPerftests in the next step.
 
 If you want to use your own regex queries, please change the regex queries listed in RunPerftests.java.
 

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -103,11 +103,12 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
+                    <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
                     <arguments>
-                      <argument>./textdb-perftest/data-files/</argument>
+                      <argument>./textdb-perftest/data-files/results/</argument>
                       <argument>./textdb-perftest/index/standard/</argument>
                       <argument>./textdb-perftest/index/trigram/</argument>
+                      <argument>./textdb-perftest/data-files/queries/</argument>
                     </arguments>
                     <skip>false</skip>
                 </configuration>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -6,7 +6,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    
+
     <artifactId>textdb-perftest</artifactId>
     <name>textdb-perftest</name>
     <url>http://maven.apache.org</url>
@@ -15,14 +15,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
@@ -38,13 +38,13 @@
             <artifactId>lucene-queryparser</artifactId>
             <version>${lucene.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>${org.json.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>edu.uci.ics.textdb</groupId>
             <artifactId>textdb-api</artifactId>
@@ -65,7 +65,7 @@
             <artifactId>textdb-storage</artifactId>
             <version>${textdb.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
@@ -88,5 +88,32 @@
 
     </dependencies>
     <build>
+        <pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
+                    <arguments>
+                      <argument>./textdb-perftest/data-files/</argument>
+                      <argument>./textdb-perftest/index/standard/</argument>
+                      <argument>./textdb-perftest/index/trigram/</argument>
+                    </arguments>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+        </pluginManagement>
     </build>
+
 </project>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -100,33 +100,17 @@
                         <goals>
                             <goal>java</goal>
                         </goals>
-                        <configuration>
-                            <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
-                            <arguments>
-                              <argument>./textdb-perftest/data-files/</argument>
-                              <argument>./textdb-perftest/index/standard/</argument>
-                              <argument>./textdb-perftest/index/trigram/</argument>
-                            </arguments>
-                            <skip>false</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                      <phase>test</phase>
-                      <goals>
-                        <goal>java</goal>
-                      </goals>
-                      <configuration>
-                          <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
-                          <arguments>
-                            <argument>./textdb-perftest/data-files/results/</argument>
-                            <argument>./textdb-perftest/index/standard/</argument>
-                            <argument>./textdb-perftest/index/trigram/</argument>
-                            <argument>./textdb-perftest/data-files/queries/</argument>
-                          </arguments>
-                          <skip>false</skip>
-                      </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
+                    <arguments>
+                      <argument>./textdb-perftest/data-files/</argument>
+                      <argument>./textdb-perftest/index/standard/</argument>
+                      <argument>./textdb-perftest/index/trigram/</argument>
+                    </arguments>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
         </pluginManagement>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -88,7 +88,7 @@
 
     </dependencies>
 
-    <!-- plugin for trigerring performance test-->
+    <!-- plugin for triggering performance test-->
     <build>
         <pluginManagement>
         <plugins>
@@ -105,8 +105,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
+                    <mainClass>edu.uci.ics.textdb.perftest.runme.RunTests</mainClass>
                     <arguments>
+                      <argument>./textdb-perftest/data-files/</argument>
                       <argument>./textdb-perftest/data-files/results/</argument>
                       <argument>./textdb-perftest/index/standard/</argument>
                       <argument>./textdb-perftest/index/trigram/</argument>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -112,6 +112,7 @@
                       <argument>./textdb-perftest/index/trigram/</argument>
                       <argument>./textdb-perftest/data-files/queries/</argument>
                     </arguments>
+                    <!-- do not skip the execution here -->
                     <skip>false</skip>
                 </configuration>
             </plugin>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -100,17 +100,33 @@
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
+                            <arguments>
+                              <argument>./textdb-perftest/data-files/</argument>
+                              <argument>./textdb-perftest/index/standard/</argument>
+                              <argument>./textdb-perftest/index/trigram/</argument>
+                            </arguments>
+                            <skip>false</skip>
+                        </configuration>
                     </execution>
+                    <execution>
+                      <phase>test</phase>
+                      <goals>
+                        <goal>java</goal>
+                      </goals>
+                      <configuration>
+                          <mainClass>edu.uci.ics.textdb.perftest.runme.RunPerftests</mainClass>
+                          <arguments>
+                            <argument>./textdb-perftest/data-files/results/</argument>
+                            <argument>./textdb-perftest/index/standard/</argument>
+                            <argument>./textdb-perftest/index/trigram/</argument>
+                            <argument>./textdb-perftest/data-files/queries/</argument>
+                          </arguments>
+                          <skip>false</skip>
+                      </configuration>
+                    </execuation>
                 </executions>
-                <configuration>
-                    <mainClass>edu.uci.ics.textdb.perftest.runme.WriteIndex</mainClass>
-                    <arguments>
-                      <argument>./textdb-perftest/data-files/</argument>
-                      <argument>./textdb-perftest/index/standard/</argument>
-                      <argument>./textdb-perftest/index/trigram/</argument>
-                    </arguments>
-                    <skip>false</skip>
-                </configuration>
             </plugin>
         </plugins>
         </pluginManagement>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -87,6 +87,8 @@
 
 
     </dependencies>
+
+    <!-- plugin for trigerring performance test-->
     <build>
         <pluginManagement>
         <plugins>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -112,7 +112,7 @@
                       <argument>./textdb-perftest/index/trigram/</argument>
                       <argument>./textdb-perftest/data-files/queries/</argument>
                     </arguments>
-                    <!-- do not skip the execution here -->
+                    <!-- do not skip the execution here-->
                     <skip>false</skip>
                 </configuration>
             </plugin>

--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -125,7 +125,7 @@
                           </arguments>
                           <skip>false</skip>
                       </configuration>
-                    </execuation>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
@@ -21,8 +21,8 @@ import edu.uci.ics.textdb.perftest.fuzzytokenmatcher.*;
 public class RunPerftests {
 
 	/**
-	 * Run all performance tests. 
-	 * 
+	 *  Run all performance tests. 
+	 *  file folder path (where data set stored)
 	 *  Passed in below arguments:
 	 * 	result folder path (where performance test results stored)
 	 * 	standard index folder path (where standard index stored)

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
@@ -12,6 +12,7 @@ import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.perftest.keywordmatcher.*;
 import edu.uci.ics.textdb.perftest.nlpextractor.NlpExtractorPerformanceTest;
 import edu.uci.ics.textdb.perftest.regexmatcher.RegexMatcherPerformanceTest;
+import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.perftest.dictionarymatcher.*;
 import edu.uci.ics.textdb.perftest.fuzzytokenmatcher.*;
 
@@ -25,6 +26,13 @@ public class RunPerftests {
 	 *
 	 */
 	public static void main(String[] args) {
+		if(args.length!=0){
+			PerfTestUtils.setResultFolder(args[0]);
+			PerfTestUtils.setStandardIndexFolder(args[1]);
+			PerfTestUtils.setTrigramIndexFolder(args[2]);
+			PerfTestUtils.setQueryFolder(args[3]);
+		}
+		
 		try {
 			List<Double> thresholds = Arrays.asList(0.8,0.65,0.5,0.35);
 			List<String> regexQueries = Arrays.asList("mosquitos?", "v[ir]{2}[us]{2}",

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
@@ -62,6 +62,7 @@ public class RunPerftests {
 			e.printStackTrace();
 		} catch (Exception e) {
 			e.printStackTrace();
+			
 		}
 	}
 }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
@@ -16,10 +16,22 @@ import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.perftest.dictionarymatcher.*;
 import edu.uci.ics.textdb.perftest.fuzzytokenmatcher.*;
 
+
+
 public class RunPerftests {
 
 	/**
 	 * Run all performance tests. 
+	 * 
+	 *  Passed in below arguments:
+	 * 	result folder path (where performance test results stored)
+	 * 	standard index folder path (where standard index stored)
+	 * 	trigram index folder path (where trigram index stored)
+	 * 	queries folder path (where query files stored)
+	 * 
+	 * If above arguments are not passed in, default paths will be used (refer to PerfTestUtils.java)
+	 * If some of the arguments are not applicable, define them as empty string. 
+	 * 
 	 * Make necessary changes for arguments, 
 	 * such as query file name, threshold list, iteration number and
 	 * regexQueries

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunTests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunTests.java
@@ -1,0 +1,49 @@
+package edu.uci.ics.textdb.perftest.runme;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.StorageException;
+import edu.uci.ics.textdb.perftest.dictionarymatcher.DictionaryMatcherPerformanceTest;
+import edu.uci.ics.textdb.perftest.fuzzytokenmatcher.FuzzyTokenMatcherPerformanceTest;
+import edu.uci.ics.textdb.perftest.keywordmatcher.KeywordMatcherPerformanceTest;
+import edu.uci.ics.textdb.perftest.nlpextractor.NlpExtractorPerformanceTest;
+import edu.uci.ics.textdb.perftest.regexmatcher.RegexMatcherPerformanceTest;
+import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
+
+public class RunTests {
+	public static void main(String[] args) {
+		if(args.length!=0){
+			PerfTestUtils.setFileFolder(args[0]);
+			PerfTestUtils.setResultFolder(args[1]);
+			PerfTestUtils.setStandardIndexFolder(args[2]);
+			PerfTestUtils.setTrigramIndexFolder(args[3]);
+			PerfTestUtils.setQueryFolder(args[4]);
+		}
+		
+		try {
+			
+			PerfTestUtils.writeStandardAnalyzerIndices();
+			PerfTestUtils.writeTrigramIndices();
+			
+			List<Double> thresholds = Arrays.asList(0.8,0.65,0.5,0.35);
+			List<String> regexQueries = Arrays.asList("mosquitos?", "v[ir]{2}[us]{2}",
+					"market(ing)?", "medic(ine|al|ation|are|aid)?",
+					"[A-Z][aeiou|AEIOU][A-Za-z]*"
+					);
+			
+			KeywordMatcherPerformanceTest.runTest("sample_queries.txt", 1);
+			DictionaryMatcherPerformanceTest.runTest("sample_queries.txt", 1);
+			FuzzyTokenMatcherPerformanceTest.runTest("sample_queries.txt", 1, thresholds);
+			RegexMatcherPerformanceTest.runTest(regexQueries, 2);
+			NlpExtractorPerformanceTest.runTest(1);
+
+		} catch (StorageException | DataFlowException | IOException e) {
+			e.printStackTrace();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
@@ -6,7 +6,9 @@ package edu.uci.ics.textdb.perftest.runme;
 
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 
- 
+/*
+ * Run this class to write all necessary index for performance tests!
+ * */
 public class WriteIndex {
 	public static void main(String[] args) {
 		if(args.length !=0){

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
@@ -6,9 +6,7 @@ package edu.uci.ics.textdb.perftest.runme;
 
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 
-/*
- * Run this class to write all necessary index for performance tests!
- * */
+ 
 public class WriteIndex {
 	public static void main(String[] args) {
 		if(args.length !=0){

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
@@ -8,8 +8,18 @@ import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 
 /*
  * Run this class to write all necessary index for performance tests!
+ * 
+ * Passed in below arguments:
+ * 	file folder path (where data set stored)
+ * 	standard index folder path (where standard index stored)
+ * 	trigram index folder path (where trigram index stored)
+ * 
+ * If above arguments are not passed in, default paths will be used (refer to PerfTestUtils.java)
+ * If some of the arguments are not applicable, define them as empty string. 
+ * 
  * */
 public class WriteIndex {
+
 	public static void main(String[] args) {
 		if(args.length !=0){
 			PerfTestUtils.setFileFolder(args[0]);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/WriteIndex.java
@@ -11,6 +11,11 @@ import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
  * */
 public class WriteIndex {
 	public static void main(String[] args) {
+		if(args.length !=0){
+			PerfTestUtils.setFileFolder(args[0]);
+			PerfTestUtils.setStandardIndexFolder(args[1]);
+			PerfTestUtils.setTrigramIndexFolder(args[2]);
+		}
 
 		try {
 			PerfTestUtils.writeStandardAnalyzerIndices();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -23,12 +23,58 @@ import edu.uci.ics.textdb.storage.DataStore;
 
 public class PerfTestUtils {
 
-	public static final String fileFolder = "./data-files/";
-	public static final String standardIndexFolder = "./index/standard/";
-	public static final String trigramIndexFolder = "./index/trigram/";
-	public static final String resultFolder = "./data-files/results/";
-	public static final String queryFolder = "./data-files/queries/";
-
+	/**
+	 * These default paths work only when the program is run from
+	 * the directory, textdb-perftest
+	 * */
+	public static String fileFolder = "./data-files/";
+	public static String standardIndexFolder = "./index/standard/";
+	public static String trigramIndexFolder = "./index/trigram/";
+	public static String resultFolder = "./data-files/results/";
+	public static String queryFolder = "./data-files/queries/";
+	
+	/**
+	 * The purpose for below setters:
+	 * 
+	 * When the program is not run from the directory, textdb-perftest,
+	 * all path need to be reset so that the program can recognize the paths.
+	 *  
+	 *  For examplem, the default ./data-files/ works well when the program is run from textdb-perftest,
+	 *  but the program is run from the outermost folder of the project, the directory should be 
+	 *  ./textdb-perftest/data-files/
+	 */
+	public static void setFileFolder(String filefolder){
+		if(!filefolder.trim().isEmpty()){
+			fileFolder = filefolder;
+		}
+	}
+	
+	public static void setStandardIndexFolder(String indexFolder){
+		if(!indexFolder.trim().isEmpty()){
+			standardIndexFolder = indexFolder;
+		}
+		
+	}
+	
+	public static void setTrigramIndexFolder(String indexFolder){
+		if(!indexFolder.trim().isEmpty()){
+			trigramIndexFolder = indexFolder;
+		}
+		
+	}
+	
+	
+	public static void setQueryFolder(String queryfolder){
+		if(!queryfolder.trim().isEmpty()){
+			queryFolder = queryfolder;
+		}
+	}
+	
+	public static void setResultFolder(String resultfolder){
+		if(!resultfolder.trim().isEmpty()){
+			resultFolder = resultfolder;
+		}
+	}
 	/**
 	 * 
 	 * @param testResults,

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -56,7 +56,7 @@ public class PerfTestUtils {
 		
 	}
 	
-	public static void setTrigramIndexFolder(String indexFolder){
+	public static void setTrigramIndexFolder(String indexFolder) {
 		if(!indexFolder.trim().isEmpty()){
 			trigramIndexFolder = indexFolder;
 		}


### PR DESCRIPTION
All paths can be passed in as program arguments when users run WriteIndex or RunPerftests.
exec-maven-plugin is added to ./textdb/pom.xml and ./textdb/textdb-perfteset/pom.xml.