### PR TITLE
Refactor KeywordMatcher Constructor

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -179,7 +179,18 @@ public class KeywordPredicate implements IPredicate {
 		
 		return new MatchAllDocsQuery();
 	}
-
+	
+	
+	public DataReaderPredicate generateDataReaderPredicate(IDataStore dataStore) {
+	    DataReaderPredicate predicate = new DataReaderPredicate(
+	            this.luceneQuery,
+	            this.query,
+	            dataStore,
+	            this.attributeList,
+	            this.luceneAnalyzer);
+	    predicate.setIsSpanInformationAdded(true);
+	    return predicate;
+	}
 	
 	
 	public KeywordMatchingType getOperatorType() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -43,7 +43,6 @@ public class KeywordPredicate implements IPredicate {
 	private HashSet<String> queryTokenSet;
 	private ArrayList<String> queryTokensWithStopwords;
 	private Analyzer luceneAnalyzer;
-	private IDataStore dataStore;
 	private KeywordMatchingType operatorType;
 
 	/*
@@ -51,7 +50,7 @@ public class KeywordPredicate implements IPredicate {
 	 * searched in TextField, we would consider both tokens New and York; if
 	 * searched in String field we search for Exact string.
 	 */
-	public KeywordPredicate(String query, IDataStore dataStore, List<Attribute> attributeList, Analyzer luceneAnalyzer, 
+	public KeywordPredicate(String query, List<Attribute> attributeList, Analyzer luceneAnalyzer, 
 			KeywordMatchingType operatorType) throws DataFlowException {
 		try {
 			this.query = query;
@@ -61,7 +60,6 @@ public class KeywordPredicate implements IPredicate {
 			
 			this.attributeList = attributeList;
 			this.operatorType = operatorType;
-			this.dataStore = dataStore;
 			
 			this.luceneAnalyzer = luceneAnalyzer;
 			this.luceneQuery = createLuceneQueryObject();
@@ -215,11 +213,5 @@ public class KeywordPredicate implements IPredicate {
 	public Analyzer getLuceneAnalyzer() {
 		return luceneAnalyzer;
 	}
-
-	public DataReaderPredicate getDataReaderPredicate() {
-		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, this.query,
-				this.dataStore, this.attributeList, this.luceneAnalyzer);
-		return dataReaderPredicate;
-	}
-
+	
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -81,10 +81,7 @@ public class DictionaryMatcher implements IOperator {
                             KeywordMatchingType.CONJUNCTION_INDEXBASED);
                 }
                 
-                DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                        keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                        predicate.getDataStore(), keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
                 inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
                 inputOperator.open();
             }
@@ -158,10 +155,7 @@ public class DictionaryMatcher implements IOperator {
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						keywordMatchingType);
     			
-                DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                        keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                        predicate.getDataStore(), keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
     			inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
     			inputOperator.open();
     		}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -82,7 +82,10 @@ public class DictionaryMatcher implements IOperator {
                 }
                 
                 IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
-                inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
+                KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+                keywordMatcher.setInputOperator(indexInputOperator);
+                inputOperator = keywordMatcher;
+                
                 inputOperator.open();
             }
             
@@ -156,7 +159,10 @@ public class DictionaryMatcher implements IOperator {
 						keywordMatchingType);
     			
                 IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
-    			inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
+    	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+    	        keywordMatcher.setInputOperator(indexInputOperator);
+                inputOperator = keywordMatcher;
+                
     			inputOperator.open();
     		}
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -54,9 +54,6 @@ public class DictionaryMatcher implements IOperator {
      */
     @Override
     public void open() throws DataFlowException {
-    	if (this.inputOperator == null) {
-    		throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
-    	}
         try {
         	currentDictionaryEntry = predicate.getNextDictionaryEntry();
             if (currentDictionaryEntry == null) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -62,17 +62,17 @@ public class DictionaryMatcher implements IOperator {
             
 			if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
 				KeywordPredicate keywordPredicate = new KeywordPredicate(
-						currentDictionaryEntry, predicate.getDataStore(),
+						currentDictionaryEntry,
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						KeywordMatchingType.PHRASE_INDEXBASED);
-				inputOperator = new KeywordMatcher(keywordPredicate);
+				inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
 				inputOperator.open();
 			} else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
 				KeywordPredicate keywordPredicate = new KeywordPredicate(
-						currentDictionaryEntry, predicate.getDataStore(),
+						currentDictionaryEntry,
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						KeywordMatchingType.CONJUNCTION_INDEXBASED);
-				inputOperator = new KeywordMatcher(keywordPredicate);
+				inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
 				inputOperator.open();
 			} else {
                 inputOperator = predicate.getScanSourceOperator();
@@ -140,12 +140,12 @@ public class DictionaryMatcher implements IOperator {
     			}
     			
 				KeywordPredicate keywordPredicate = new KeywordPredicate(
-						currentDictionaryEntry, predicate.getDataStore(),
+						currentDictionaryEntry,
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						keywordMatchingType);
     			
     			inputOperator.close();
-    			inputOperator = new KeywordMatcher(keywordPredicate);
+    			inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
     			inputOperator.open();
     		}
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -21,6 +21,8 @@ import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 
 /**
  * @author Sudeep (inkudo)
@@ -60,24 +62,34 @@ public class DictionaryMatcher implements IOperator {
             	throw new DataFlowException("Dictionary is empty");
             }
             
-			if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
-				KeywordPredicate keywordPredicate = new KeywordPredicate(
-						currentDictionaryEntry,
-						predicate.getAttributeList(), predicate.getAnalyzer(),
-						KeywordMatchingType.PHRASE_INDEXBASED);
-				inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
-				inputOperator.open();
-			} else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-				KeywordPredicate keywordPredicate = new KeywordPredicate(
-						currentDictionaryEntry,
-						predicate.getAttributeList(), predicate.getAnalyzer(),
-						KeywordMatchingType.CONJUNCTION_INDEXBASED);
-				inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
-				inputOperator.open();
-			} else {
+            if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
                 inputOperator = predicate.getScanSourceOperator();
                 inputOperator.open();
+            } else {
+                KeywordPredicate keywordPredicate = null;
+                if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+                    keywordPredicate = new KeywordPredicate(
+                            currentDictionaryEntry,
+                            predicate.getAttributeList(), predicate.getAnalyzer(),
+                            KeywordMatchingType.PHRASE_INDEXBASED);
+                    
+
+                } else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+                    keywordPredicate = new KeywordPredicate(
+                            currentDictionaryEntry,
+                            predicate.getAttributeList(), predicate.getAnalyzer(),
+                            KeywordMatchingType.CONJUNCTION_INDEXBASED);
+                }
+                
+                DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                        keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                        predicate.getDataStore(), keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+                inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
+                inputOperator.open();
             }
+            
+
             
         } catch (Exception e) {
             throw new DataFlowException(e.getMessage(), e);
@@ -139,13 +151,18 @@ public class DictionaryMatcher implements IOperator {
     				keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
     			}
     			
+                inputOperator.close();
+    			
 				KeywordPredicate keywordPredicate = new KeywordPredicate(
 						currentDictionaryEntry,
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						keywordMatchingType);
     			
-    			inputOperator.close();
-    			inputOperator = new KeywordMatcher(keywordPredicate, predicate.getDataStore());
+                DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                        keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                        predicate.getDataStore(), keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+    			inputOperator = new KeywordMatcher(keywordPredicate, indexInputOperator);
     			inputOperator.open();
     		}
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -20,6 +20,7 @@ import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.field.Span;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.storage.DataReaderPredicate;
@@ -35,6 +36,7 @@ public class KeywordMatcher implements IOperator {
     private IOperator inputOperator;
     private String query;
 
+    /*
     public KeywordMatcher(IPredicate predicate, IDataStore dataStore) {
         this(predicate);
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.predicate.getQueryObject(), this.predicate.getQuery(),
@@ -42,6 +44,7 @@ public class KeywordMatcher implements IOperator {
         dataReaderPredicate.setIsSpanInformationAdded(true);
         this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }
+     */
     
     public KeywordMatcher(IPredicate predicate) {
         this.predicate = (KeywordPredicate)predicate;
@@ -154,6 +157,7 @@ public class KeywordMatcher implements IOperator {
     
     
     private ITuple processPhrase(ITuple currentTuple) throws DataFlowException {
+        System.out.println(Utils.getTupleString(currentTuple));
     	List<Span> spanList = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
     	
     	for (Attribute attribute : this.predicate.getAttributeList()) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -36,11 +36,21 @@ public class KeywordMatcher implements IOperator {
     private String query;
 
     public KeywordMatcher(IPredicate predicate, IDataStore dataStore) {
-        this.predicate = (KeywordPredicate)predicate;
+        this(predicate);
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.predicate.getQueryObject(), this.predicate.getQuery(),
                 dataStore, this.predicate.getAttributeList(), this.predicate.getLuceneAnalyzer());
         dataReaderPredicate.setIsSpanInformationAdded(true);
         this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+    }
+    
+    public KeywordMatcher(IPredicate predicate) {
+        this.predicate = (KeywordPredicate)predicate;
+        this.query = this.predicate.getQuery();
+    }
+    
+    public KeywordMatcher(IPredicate predicate, IOperator inputOperator) {
+        this(predicate);
+        this.inputOperator = inputOperator;
     }
 
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -40,11 +40,6 @@ public class KeywordMatcher implements IOperator {
         this.predicate = (KeywordPredicate)predicate;
         this.query = this.predicate.getQuery();
     }
-    
-    public KeywordMatcher(IPredicate predicate, IOperator inputOperator) {
-        this(predicate);
-        this.inputOperator = inputOperator;
-    }
 
     
     @Override

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -14,6 +14,7 @@ import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
@@ -34,9 +35,10 @@ public class KeywordMatcher implements IOperator {
     private IOperator inputOperator;
     private String query;
 
-    public KeywordMatcher(IPredicate predicate) {
+    public KeywordMatcher(IPredicate predicate, IDataStore dataStore) {
         this.predicate = (KeywordPredicate)predicate;
-        DataReaderPredicate dataReaderPredicate = this.predicate.getDataReaderPredicate();
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.predicate.getQueryObject(), this.predicate.getQuery(),
+                dataStore, this.predicate.getAttributeList(), this.predicate.getLuceneAnalyzer());
         dataReaderPredicate.setIsSpanInformationAdded(true);
         this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -35,16 +35,6 @@ public class KeywordMatcher implements IOperator {
     private final KeywordPredicate predicate;
     private IOperator inputOperator;
     private String query;
-
-    /*
-    public KeywordMatcher(IPredicate predicate, IDataStore dataStore) {
-        this(predicate);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.predicate.getQueryObject(), this.predicate.getQuery(),
-                dataStore, this.predicate.getAttributeList(), this.predicate.getLuceneAnalyzer());
-        dataReaderPredicate.setIsSpanInformationAdded(true);
-        this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
-    }
-     */
     
     public KeywordMatcher(IPredicate predicate) {
         this.predicate = (KeywordPredicate)predicate;
@@ -157,7 +147,6 @@ public class KeywordMatcher implements IOperator {
     
     
     private ITuple processPhrase(ITuple currentTuple) throws DataFlowException {
-        System.out.println(Utils.getTupleString(currentTuple));
     	List<Span> spanList = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
     	
     	for (Attribute attribute : this.predicate.getAttributeList()) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -17,6 +17,7 @@ import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
@@ -243,6 +244,9 @@ public class RegexMatcher implements IOperator {
     
     @Override
     public void open() throws DataFlowException {
+        if (this.inputOperator == null) {
+            throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+        }
         try {
             inputOperator.open();
         } catch (Exception e) {
@@ -254,7 +258,9 @@ public class RegexMatcher implements IOperator {
     @Override
     public void close() throws DataFlowException {
         try {
-            inputOperator.close();
+            if (inputOperator != null) {
+                inputOperator.close();   
+            }
         } catch (Exception e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -158,27 +158,31 @@ public class JoinTest {
 		switch (type) {
 		case "index":
 			if (whichOperator == "outer") {
-				predicate = new KeywordPredicate(query, dataStoreForOuter, modifiedAttributeList,
+				predicate = new KeywordPredicate(query, modifiedAttributeList,
 						analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
+		        return new KeywordMatcher(predicate, dataStoreForOuter);
 			} else if (whichOperator == "inner") {
-				predicate = new KeywordPredicate(query, dataStoreForInner, modifiedAttributeList,
+				predicate = new KeywordPredicate(query, modifiedAttributeList,
 						analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
+                return new KeywordMatcher(predicate, dataStoreForInner);
 			}
 			break;
 		case "phrase":
 			if (whichOperator == "outer") {
-				predicate = new KeywordPredicate(query, dataStoreForOuter, modifiedAttributeList,
+				predicate = new KeywordPredicate(query, modifiedAttributeList,
 						analyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+                return new KeywordMatcher(predicate, dataStoreForOuter);
 			} else if (whichOperator == "inner") {
-				predicate = new KeywordPredicate(query, dataStoreForInner, modifiedAttributeList,
+				predicate = new KeywordPredicate(query, modifiedAttributeList,
 						analyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+                return new KeywordMatcher(predicate, dataStoreForInner);
 			}
 			break;
 
 		default:
 			break;
 		}
-		return new KeywordMatcher(predicate);
+		return null;
 	}
 
 	// A helper method to populate tuples' list to query upon. Currently
@@ -832,10 +836,10 @@ public class JoinTest {
 				"outer");
 		query = "kind";
 		IPredicate predicate = new KeywordPredicate(query,
-				dataStore, modifiedAttributeList, analyzer,
+				modifiedAttributeList, analyzer,
 				DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED
 				);
-		keywordMatcherInner = new KeywordMatcher(predicate);
+		keywordMatcherInner = new KeywordMatcher(predicate, dataStore);
 
 		Attribute idAttr = attributeList.get(0);
 		Attribute reviewAttr = attributeList.get(4);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -188,8 +188,9 @@ public class JoinTest {
 		}
 		
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
-		
+        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
 		return keywordMatcher;
 	}
 
@@ -849,8 +850,9 @@ public class JoinTest {
 				);
 		
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-        keywordMatcherInner = new KeywordMatcher(keywordPredicate, indexInputOperator);
-
+        keywordMatcherInner = new KeywordMatcher(keywordPredicate);
+        keywordMatcherInner.setInputOperator(indexInputOperator);
+        
 		Attribute idAttr = attributeList.get(0);
 		Attribute reviewAttr = attributeList.get(4);
 		List<ITuple> resultList = getJoinResults(keywordMatcherOuter,

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -187,10 +187,7 @@ public class JoinTest {
 			break;
 		}
 		
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
 		
 		return keywordMatcher;
@@ -851,10 +848,7 @@ public class JoinTest {
 				DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED
 				);
 		
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
         keywordMatcherInner = new KeywordMatcher(keywordPredicate, indexInputOperator);
 
 		Attribute idAttr = attributeList.get(0);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -77,7 +77,10 @@ public class KeywordMatcherTest {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
@@ -77,10 +76,7 @@ public class KeywordMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -74,8 +74,8 @@ public class KeywordMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
-        keywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        keywordMatcher = new KeywordMatcher(predicate, dataStore);
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -31,7 +31,9 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -74,8 +76,12 @@ public class KeywordMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
-        keywordMatcher = new KeywordMatcher(predicate, dataStore);
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer, DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -77,10 +77,7 @@ public class PhraseMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 
@@ -328,10 +325,7 @@ public class PhraseMatcherTest {
 
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 
@@ -386,10 +380,7 @@ public class PhraseMatcherTest {
 
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 
@@ -455,10 +446,7 @@ public class PhraseMatcherTest {
 
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -78,7 +78,10 @@ public class PhraseMatcherTest {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
         keywordMatcher.open();
 
 
@@ -326,7 +329,10 @@ public class PhraseMatcherTest {
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
@@ -381,7 +387,10 @@ public class PhraseMatcherTest {
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
@@ -447,7 +456,10 @@ public class PhraseMatcherTest {
         //Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(medDataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
+        
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -31,7 +31,9 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -42,7 +44,7 @@ import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 public class PhraseMatcherTest {
 
-    private KeywordMatcher KeywordMatcher;
+    private KeywordMatcher keywordMatcher;
     private IDataWriter dataWriter;
     private DataStore dataStore;
     private Analyzer luceneAnalyzer;
@@ -74,14 +76,19 @@ public class PhraseMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate, dataStore);
-        KeywordMatcher.open();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher.open();
+
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
 
-        while ((nextTuple = KeywordMatcher.getNextTuple()) != null) {
+        while ((nextTuple = keywordMatcher.getNextTuple()) != null) {
             results.add(nextTuple);
         }
 
@@ -320,14 +327,18 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
-        KeywordMatcher.open();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
 
-        while ((nextTuple = KeywordMatcher.getNextTuple()) != null) {
+        while ((nextTuple = keywordMatcher.getNextTuple()) != null) {
             results.add(nextTuple);
         }
         //Perform Check
@@ -374,14 +385,18 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
-        KeywordMatcher.open();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
 
-        while ((nextTuple = KeywordMatcher.getNextTuple()) != null) {
+        while ((nextTuple = keywordMatcher.getNextTuple()) != null) {
             results.add(nextTuple);
         }
         //Perform Check
@@ -439,14 +454,18 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
-        KeywordMatcher.open();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                medDataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
 
-        while ((nextTuple = KeywordMatcher.getNextTuple()) != null) {
+        while ((nextTuple = keywordMatcher.getNextTuple()) != null) {
             results.add(nextTuple);
         }
         //Perform Check

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -74,8 +74,8 @@ public class PhraseMatcherTest {
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        KeywordMatcher = new KeywordMatcher(predicate, dataStore);
         KeywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
@@ -320,8 +320,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, medDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
         KeywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
@@ -342,9 +342,9 @@ public class PhraseMatcherTest {
      */
     @Test
     public void testWordInMultipleFieldsQueryWithStopWords4() throws Exception {
-    	DataStore MedDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
+    	DataStore medDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
         Analyzer MedAnalyzer = new StandardAnalyzer();
-        DataWriter MedDataWriter = new DataWriter(MedDataStore, MedAnalyzer);
+        DataWriter MedDataWriter = new DataWriter(medDataStore, MedAnalyzer);
         MedDataWriter.clearData();
     	MedDataWriter.writeData(keywordTestConstants.getSampleMedlineRecord());
         //Prepare Query
@@ -374,8 +374,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
         KeywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
@@ -396,9 +396,9 @@ public class PhraseMatcherTest {
      */
     @Test
     public void testWordInMultipleFieldsQueryWithStopWords5() throws Exception {
-    	DataStore MedDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
+    	DataStore medDataStore = new DataStore("../index/test", keywordTestConstants.SCHEMA_MEDLINE);
         Analyzer MedAnalyzer = new StandardAnalyzer();
-        DataWriter MedDataWriter = new DataWriter(MedDataStore, MedAnalyzer);
+        DataWriter MedDataWriter = new DataWriter(medDataStore, MedAnalyzer);
         MedDataWriter.clearData();
     	MedDataWriter.writeData(keywordTestConstants.getSampleMedlineRecord());
         //Prepare Query
@@ -439,8 +439,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         //Perform Query
-        IPredicate predicate = new KeywordPredicate(query, MedDataStore, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
-        KeywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, MedAnalyzer, DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        KeywordMatcher = new KeywordMatcher(predicate, medDataStore);
         KeywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -75,8 +75,8 @@ public class SubstringMatcherTest {
     
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, dataStore, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
-        KeywordMatcher = new KeywordMatcher(predicate);
+        IPredicate predicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
+        KeywordMatcher = new KeywordMatcher(predicate, dataStore);
         KeywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -78,10 +78,7 @@ public class SubstringMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
         keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
         keywordMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -79,7 +79,8 @@ public class SubstringMatcherTest {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
         IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setInputOperator(indexInputOperator);
         keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -31,7 +31,9 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -43,7 +45,7 @@ import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 public class SubstringMatcherTest {
 	
-	private KeywordMatcher KeywordMatcher;
+	private KeywordMatcher keywordMatcher;
     private IDataWriter dataWriter;
     private DataStore dataStore;
     private Analyzer luceneAnalyzer;
@@ -75,14 +77,18 @@ public class SubstringMatcherTest {
     
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
-        KeywordMatcher = new KeywordMatcher(predicate, dataStore);
-        KeywordMatcher.open();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer, DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+        keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+        keywordMatcher.open();
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
 
-        while ((nextTuple = KeywordMatcher.getNextTuple()) != null) {
+        while ((nextTuple = keywordMatcher.getNextTuple()) != null) {
             results.add(nextTuple);
         }
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -154,8 +154,8 @@ public class KeywordMatcherPerformanceTest {
 		Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 
 		for (String query : queryList) {
-			IPredicate predicate = new KeywordPredicate(query, dataStore, Arrays.asList(attributeList), luceneAnalyzer, opType);
-			KeywordMatcher keywordMatcher = new KeywordMatcher(predicate);
+			IPredicate predicate = new KeywordPredicate(query, Arrays.asList(attributeList), luceneAnalyzer, opType);
+			KeywordMatcher keywordMatcher = new KeywordMatcher(predicate, dataStore);
 
 			long startMatchTime = System.currentTimeMillis();
 			keywordMatcher.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -157,10 +157,7 @@ public class KeywordMatcherPerformanceTest {
 
 		for (String query : queryList) {
 	        KeywordPredicate keywordPredicate = new KeywordPredicate(query, Arrays.asList(attributeList), luceneAnalyzer, opType);
-	        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-	                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
-	                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
-	        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+            IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
 	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
 
 			long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -25,8 +25,10 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
 
 /**
@@ -154,8 +156,12 @@ public class KeywordMatcherPerformanceTest {
 		Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 
 		for (String query : queryList) {
-			IPredicate predicate = new KeywordPredicate(query, Arrays.asList(attributeList), luceneAnalyzer, opType);
-			KeywordMatcher keywordMatcher = new KeywordMatcher(predicate, dataStore);
+	        KeywordPredicate keywordPredicate = new KeywordPredicate(query, Arrays.asList(attributeList), luceneAnalyzer, opType);
+	        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+	                keywordPredicate.getQueryObject(), keywordPredicate.getQuery(),
+	                dataStore, keywordPredicate.getAttributeList(), keywordPredicate.getLuceneAnalyzer());
+	        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
+	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
 
 			long startMatchTime = System.currentTimeMillis();
 			keywordMatcher.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -158,7 +158,8 @@ public class KeywordMatcherPerformanceTest {
 		for (String query : queryList) {
 	        KeywordPredicate keywordPredicate = new KeywordPredicate(query, Arrays.asList(attributeList), luceneAnalyzer, opType);
             IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
-	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate, indexInputOperator);
+	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+	        keywordMatcher.setInputOperator(indexInputOperator);
 
 			long startMatchTime = System.currentTimeMillis();
 			keywordMatcher.open();


### PR DESCRIPTION
Remove the old constructor with `DataStore` in predicate.
Caller now must first create an `IndexBasedSourceOperator`, then give it to `KeywordMatcher`
