### PR TITLE
Refactor RegexMatcher's constructor

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -39,10 +39,6 @@ public class RegexMatcher implements IOperator {
     private Schema sourceTupleSchema;
     private Schema spanSchema;
     
-    private String luceneQueryStr;
-    private Query luceneQuery;
-    
-	private Analyzer luceneAnalyzer;
 	private IOperator inputOperator;
     
     private List<Span> spanList;
@@ -61,7 +57,6 @@ public class RegexMatcher implements IOperator {
     	this.regexPredicate = (RegexPredicate) predicate;
     	this.regex = regexPredicate.getRegex();
     	this.fieldNameList = regexPredicate.getFieldNameList();
-    	this.luceneAnalyzer = regexPredicate.getLuceneAnalyzer();
     			
 		// try Java Regex first
 		try {
@@ -242,10 +237,6 @@ public class RegexMatcher implements IOperator {
 
     public Schema getSpanSchema() {
     	return spanSchema;
-    }
-    
-    public String getLueneQueryString() {
-    	return this.luceneQueryStr;
     }
     
     public String getRegex() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -73,12 +73,6 @@ public class RegexMatcher implements IOperator {
 	    	}
 		}		
     }
-    
-    public RegexMatcher(IPredicate predicate, IOperator inputOperator) throws DataFlowException {
-        this(predicate);
-        this.inputOperator = inputOperator;
-    }
-    
 	
 	
     @Override

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -57,19 +57,12 @@ public class RegexMatcher implements IOperator {
 	private java.util.regex.Pattern javaPattern;
 	
 	
-    public RegexMatcher(IPredicate predicate) throws DataFlowException{
-    	this (predicate, true);
-    }
-
-    public RegexMatcher(IPredicate predicate, boolean useTranslator) throws DataFlowException{
+    public RegexMatcher(IPredicate predicate) throws DataFlowException {
     	this.regexPredicate = (RegexPredicate) predicate;
     	this.regex = regexPredicate.getRegex();
     	this.fieldNameList = regexPredicate.getFieldNameList();
     	this.luceneAnalyzer = regexPredicate.getLuceneAnalyzer();
-    	
-		this.sourceTupleSchema = regexPredicate.getDataStore().getSchema();
-		this.spanSchema = Utils.createSpanSchema(this.sourceTupleSchema);
-		
+    			
 		// try Java Regex first
 		try {
 			this.javaPattern = java.util.regex.Pattern.compile(regex);
@@ -81,38 +74,16 @@ public class RegexMatcher implements IOperator {
 				this.regexEngine = RegexEngine.RE2J;
 			// if RE2J also fails, throw exception
 	    	} catch (com.google.re2j.PatternSyntaxException re2jException) {
-				throw new DataFlowException(javaException.getMessage());
+				throw new DataFlowException(javaException.getMessage(), javaException);
 	    	}
-		}
-		
-		this.luceneQueryStr =  DataConstants.SCAN_QUERY;
-		// try to translate if useTranslator is true 
-		if (useTranslator) {
-			try {
-				this.luceneQueryStr = RegexToGramQueryTranslator.translate(regex).getLuceneQueryString();
-			} catch (com.google.re2j.PatternSyntaxException e) {
-			}
-		}
-    	
-    	try {
-    		this.luceneQuery = generateLuceneQuery(fieldNameList, luceneQueryStr);
-    	} catch (ParseException e) {
-    		throw new DataFlowException(e.getMessage());
-    	}
-    	    	
-		DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery,
-				this.luceneQueryStr, regexPredicate.getDataStore(),
-				regexPredicate.getAttributeList(), luceneAnalyzer);
-		this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
-		
+		}		
     }
     
+    public RegexMatcher(IPredicate predicate, IOperator inputOperator) throws DataFlowException {
+        this(predicate);
+        this.inputOperator = inputOperator;
+    }
     
-	private Query generateLuceneQuery(List<String> fields, String queryStr) throws ParseException {
-		String[] fieldsArray = new String[fields.size()];
-		QueryParser parser = new MultiFieldQueryParser(fields.toArray(fieldsArray), luceneAnalyzer);
-		return parser.parse(queryStr);
-	}
 	
 	
     @Override
@@ -247,6 +218,7 @@ public class RegexMatcher implements IOperator {
         if (this.inputOperator == null) {
             throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
         }
+        
         try {
             inputOperator.open();
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -63,8 +63,9 @@ public class RegexMatcherTestHelper {
 				regex, Arrays.asList(new Attribute[]{attribute}), 
 				luceneAnalyzer);
 		
-		IndexBasedSourceOperator indexSource = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
-		regexMatcher = new RegexMatcher(regexPredicate, indexSource);
+		IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
+		regexMatcher = new RegexMatcher(regexPredicate);
+		regexMatcher.setInputOperator(indexInputOperator);
 		regexMatcher.open();
 		ITuple nextTuple = null;
 		while ((nextTuple = regexMatcher.getNextTuple()) != null) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -15,6 +15,7 @@ import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -59,10 +60,11 @@ public class RegexMatcherTestHelper {
 	public void runTest(String regex, Attribute attribute, boolean useTranslator) throws Exception {
 		results.clear();
 		RegexPredicate regexPredicate = new RegexPredicate(
-				regex, dataStore, Arrays.asList(new Attribute[]{attribute}), 
+				regex, Arrays.asList(new Attribute[]{attribute}), 
 				luceneAnalyzer);
-
-		regexMatcher = new RegexMatcher(regexPredicate, useTranslator);
+		
+		IndexBasedSourceOperator indexSource = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
+		regexMatcher = new RegexMatcher(regexPredicate, indexSource);
 		regexMatcher.open();
 		ITuple nextTuple = null;
 		while ((nextTuple = regexMatcher.getNextTuple()) != null) {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -17,6 +17,7 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
 import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
+import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -114,9 +115,10 @@ public class RegexMatcherPerformanceTest {
 		// analyzer should generate grams all in lower case to build a lower
 		// case index.
 		Analyzer luceneAnalyzer = DataConstants.getTrigramAnalyzer();
-		RegexPredicate regexPredicate = new RegexPredicate(regex, dataStore, Arrays.asList(attributeList), luceneAnalyzer);
+		RegexPredicate regexPredicate = new RegexPredicate(regex, Arrays.asList(attributeList), luceneAnalyzer);
+		IndexBasedSourceOperator indexSource = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
 
-		RegexMatcher regexMatcher = new RegexMatcher(regexPredicate, true);
+		RegexMatcher regexMatcher = new RegexMatcher(regexPredicate, indexSource);
 
 		long startMatchTime = System.currentTimeMillis();
 		regexMatcher.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -116,9 +116,10 @@ public class RegexMatcherPerformanceTest {
 		// case index.
 		Analyzer luceneAnalyzer = DataConstants.getTrigramAnalyzer();
 		RegexPredicate regexPredicate = new RegexPredicate(regex, Arrays.asList(attributeList), luceneAnalyzer);
-		IndexBasedSourceOperator indexSource = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
+		IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(regexPredicate.generateDataReaderPredicate(dataStore));
 
-		RegexMatcher regexMatcher = new RegexMatcher(regexPredicate, indexSource);
+		RegexMatcher regexMatcher = new RegexMatcher(regexPredicate);
+		regexMatcher.setInputOperator(indexInputOperator);
 
 		long startMatchTime = System.currentTimeMillis();
 		regexMatcher.open();


### PR DESCRIPTION
Move logic of translating regex to Lucene query from RegexMatcher to RegexPredicate. RegexPredicate needs the query to further generate a DataReaderPredicate.

Now caller must explicitly call setInputOperator().