### PR TITLE
Add getOutputSchema to IOperator

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/IOperator.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/IOperator.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.textdb.api.dataflow;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 
 /**
  * Created by chenli on 3/25/16.
@@ -15,4 +16,6 @@ public interface IOperator {
     ITuple getNextTuple() throws Exception;
 
     void close() throws Exception;
+    
+    Schema getOutputSchema();
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -266,4 +266,10 @@ public class DictionaryMatcher implements IOperator {
 	public void setInputOperator(IOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
+
+
+    @Override
+    public Schema getOutputSchema() {
+        return spanSchema;
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -12,6 +12,7 @@ import edu.uci.ics.textdb.api.common.IField;
  */
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -26,6 +27,8 @@ import edu.uci.ics.textdb.storage.DataReaderPredicate;
 public class FuzzyTokenMatcher implements IOperator{
     private final FuzzyTokenPredicate predicate;
     private IOperator inputOperator;
+    
+    private Schema outputSchema;
 
 	private List<Attribute> attributeList;
     private int threshold;
@@ -47,6 +50,7 @@ public class FuzzyTokenMatcher implements IOperator{
             attributeList = predicate.getAttributeList();
             threshold = predicate.getThreshold();
             queryTokens = predicate.getQueryTokens();
+            outputSchema = inputOperator.getOutputSchema();
     	} catch (Exception e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
@@ -113,4 +117,9 @@ public class FuzzyTokenMatcher implements IOperator{
 	public void setInputOperator(ISourceOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -271,4 +271,9 @@ public class Join implements IOperator {
 
 		return nextTuple;
 	}
+
+    @Override
+    public Schema getOutputSchema() {
+        return innerOperator.getOutputSchema();
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -12,6 +12,7 @@ import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataStore;
@@ -301,5 +302,11 @@ public class KeywordMatcher implements IOperator {
 	public void setInputOperator(ISourceOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
+
+
+    @Override
+    public Schema getOutputSchema() {
+        return inputOperator.getOutputSchema();
+    }
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -374,4 +374,10 @@ public class NlpExtractor implements IOperator {
 	public void setInputOperator(ISourceOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
+
+
+    @Override
+    public Schema getOutputSchema() {
+        return returnSchema;
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
@@ -104,4 +104,10 @@ public class QueryRewriter implements IOperator{
         this.searchQuery = null;
         this.sourceTuple = null;
     }
+
+    @Override
+    public Schema getOutputSchema() {
+        // query rewriter has no schema
+        return null;
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -244,4 +244,10 @@ public class RegexMatcher implements IOperator {
 	public void setInputOperator(ISourceOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
+
+
+    @Override
+    public Schema getOutputSchema() {
+        return spanSchema;
+    }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/FileSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/FileSourceOperator.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Scanner;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 
 /**
@@ -22,10 +23,12 @@ public class FileSourceOperator implements ISourceOperator {
 	private File file;
 	private Scanner scanner;
 	private ToTuple toTupleFunc;
+	private Schema outputSchema;
 
-	public FileSourceOperator(String filePath, ToTuple toTupleFunc) {
+	public FileSourceOperator(String filePath, ToTuple toTupleFunc, Schema schema) {
 		this.file = new File(filePath);
 		this.toTupleFunc = toTupleFunc;
+		this.outputSchema = schema;
 	}
 
 	@Override
@@ -52,5 +55,10 @@ public class FileSourceOperator implements ISourceOperator {
 			this.scanner.close();
 		}
 	}
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
 	
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -2,6 +2,7 @@ package edu.uci.ics.textdb.dataflow.source;
 
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
@@ -67,6 +68,11 @@ public class IndexBasedSourceOperator implements ISourceOperator {
 	    this.predicate = (DataReaderPredicate)predicate;
 	    cursor = CLOSED;
 	}
+
+    @Override
+    public Schema getOutputSchema() {
+        return dataReader.getOutputSchema();
+    }
 
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.textdb.dataflow.source;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
@@ -44,5 +45,11 @@ public class ScanBasedSourceOperator implements ISourceOperator {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        // TODO Auto-generated method stub
+        return dataReader.getOutputSchema();
     }
 }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -82,7 +82,7 @@ public class MedlineIndexWriter {
 	 */	
 	public static Plan getMedlineIndexPlan(String filePath, IDataStore dataStore, Analyzer luceneAnalyzer) throws Exception {
 		IndexSink medlineIndexSink = new IndexSink(dataStore.getDataDirectory(), dataStore.getSchema(), luceneAnalyzer);		
-		ISourceOperator fileSourceOperator  = new FileSourceOperator(filePath, (s -> recordToTuple(s)));
+		ISourceOperator fileSourceOperator  = new FileSourceOperator(filePath, (s -> recordToTuple(s)), dataStore.getSchema());
 		medlineIndexSink.setInputOperator(fileSourceOperator);
 	
 		Plan writeIndexPlan = new Plan(medlineIndexSink);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -204,5 +204,14 @@ public class DataReader implements IDataReader{
             }
         }
     }
+
+    @Override
+    public Schema getOutputSchema() {
+        if (dataReaderPredicate.getIsSpanInformationAdded()) {
+            return spanSchema;
+        } else {
+            return schema;
+        }
+    }
     
 }


### PR DESCRIPTION
IOperator is the interface of all operators. A new function, getOutputSchema() is added to it, and all operators are changed accordingly.

All changes made in this PR are temporary, as more changes will be made to underlying DataReader. 
In later PRs, each operators will be carefully reviewed and their output schema will be dependent on their semantic/behavior.