### PR TITLE
Change KeywordMatcher's logic according to the new DataReader design.

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -22,7 +22,7 @@ public class Schema {
         fieldNameVsIndex = new HashMap<String, Integer>();
         for (int count = 0; count < attributes.size(); count++) {
             String fieldName = attributes.get(count).getFieldName();
-            fieldNameVsIndex.put(fieldName.toLowerCase(), count);
+            fieldNameVsIndex.put(fieldName, count);
         }
     }
 
@@ -30,9 +30,14 @@ public class Schema {
         return attributes;
     }
     
-    public int getIndex(String fieldName){
-        return fieldNameVsIndex.get(fieldName.toLowerCase());
+    public Integer getIndex(String fieldName){
+        return fieldNameVsIndex.get(fieldName);
     }
+    
+    public boolean containsField(String fieldName) {
+        return fieldNameVsIndex.keySet().contains(fieldName);
+    }
+    
     
     @Override
     public int hashCode() {

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -36,7 +36,7 @@ public class SchemaTest {
          		
          int expectedIndex1 = 0;		
          int expectedIndex2 = 1;		
-         int retrievedIndex1 = schema.getIndex(fieldName1.toUpperCase());		
+         int retrievedIndex1 = schema.getIndex(fieldName1);		
          int retrievedIndex2 = schema.getIndex(fieldName2);		
          Assert.assertEquals(expectedIndex1, retrievedIndex1);		
          Assert.assertEquals(expectedIndex2, retrievedIndex2);		

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -117,24 +117,32 @@ public class Utils {
         IField[] fieldsDuplicate = fieldListDuplicate.toArray(new IField[fieldListDuplicate.size()]);
         return new DataTuple(spanSchema, fieldsDuplicate);
     }
-
+    
     /**
-     *
-     * @param schema
-     * @about Creating a new schema object, and adding SPAN_LIST_ATTRIBUTE to
-     *        the schema. SPAN_LIST_ATTRIBUTE is of type List
-     */
-    public static Schema createSpanSchema(Schema schema) {
-        List<Attribute> dataTupleAttributes = schema.getAttributes();
-        //spanAttributes contains all attributes of dataTupleAttributes and an additional SPAN_LIST_ATTRIBUTE
-        Attribute[] spanAttributes = new Attribute[dataTupleAttributes.size() + 1];
-        for (int count = 0; count < dataTupleAttributes.size(); count++) {
-            spanAttributes[count] = dataTupleAttributes.get(count);
-        }
-        spanAttributes[spanAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
-        Schema spanSchema = new Schema(spanAttributes);
-        return spanSchema;
-    }
+    *
+    * @param schema
+    * @about Creating a new schema object, and adding SPAN_LIST_ATTRIBUTE to
+    *        the schema. SPAN_LIST_ATTRIBUTE is of type List
+    */
+   public static Schema createSpanSchema(Schema schema) {
+       return addAttributeToSchema(schema, SchemaConstants.SPAN_LIST_ATTRIBUTE);
+   }
+   
+   /**
+    * Add an attribute to an existing schema (if the attribute doesn't exist).
+    * @param schema
+    * @param attribute
+    * @return new schema
+    */
+   public static Schema addAttributeToSchema(Schema schema, Attribute attribute) {
+       if (schema.containsField(attribute.getFieldName())) {
+           return schema;
+       }
+       List<Attribute> attributes = new ArrayList<>(schema.getAttributes());
+       attributes.add(attribute);
+       Schema newSchema = new Schema(attributes.toArray(new Attribute[attributes.size()]));
+       return newSchema;   
+   }
 
     /**
      * Tokenizes the query string using the given analyser

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -127,7 +127,7 @@ public class KeywordMatcher implements IOperator {
     private ITuple computeConjunctionMatchingResult(ITuple sourceTuple) throws DataFlowException {    	
         List<Span> payload = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
         List<Span> relevantSpans = filterRelevantSpans(payload);
-        List<Span> matchResults = new ArrayList<>();
+        List<Span> matchingResults = new ArrayList<>();
     	
     	for (Attribute attribute : this.predicate.getAttributeList()) {
     		String fieldName = attribute.getFieldName();
@@ -143,7 +143,7 @@ public class KeywordMatcher implements IOperator {
     		if (fieldType == FieldType.STRING) {
                 if (fieldValue.equals(query)) {
                     Span span = new Span(fieldName, 0, query.length(), query, fieldValue);
-                    matchResults.add(span);
+                    matchingResults.add(span);
                 }
     		}
     		
@@ -154,13 +154,13 @@ public class KeywordMatcher implements IOperator {
         				.collect(Collectors.toList());
         		
         		if (isAllQueryTokensPresent(fieldSpanList, predicate.getQueryTokenSet())) {
-        		    matchResults.addAll(fieldSpanList);
+        		    matchingResults.addAll(fieldSpanList);
         		}
     		}
     		
     	}
     	
-    	if (matchResults.isEmpty()) {
+    	if (matchingResults.isEmpty()) {
     		return null;
     	}
     	
@@ -168,7 +168,7 @@ public class KeywordMatcher implements IOperator {
         payload.clear();  // TODO: delete this line after DataReader's changes
     	
         List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
-        spanList.addAll(matchResults);
+        spanList.addAll(matchingResults);
         
     	return sourceTuple;
     }
@@ -177,7 +177,7 @@ public class KeywordMatcher implements IOperator {
     private ITuple computePhraseMatchingResult(ITuple sourceTuple) throws DataFlowException {
         List<Span> payload = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
         List<Span> relevantSpans = filterRelevantSpans(payload);
-        List<Span> matchResults = new ArrayList<>();
+        List<Span> matchingResults = new ArrayList<>();
 
     	for (Attribute attribute : this.predicate.getAttributeList()) {
     		String fieldName = attribute.getFieldName();
@@ -192,7 +192,7 @@ public class KeywordMatcher implements IOperator {
 			// for STRING type, the query should match the fieldValue completely
     		if (fieldType == FieldType.STRING) {
                 if (fieldValue.equals(query)) {
-                    matchResults.add(new Span(fieldName, 0, query.length(), query, fieldValue));
+                    matchingResults.add(new Span(fieldName, 0, query.length(), query, fieldValue));
                 }
     		}
     		
@@ -250,13 +250,13 @@ public class KeywordMatcher implements IOperator {
                     int combinedSpanEndIndex = fieldSpanList.get(iter+queryTokenList.size()-1).getEnd();
 
                     Span combinedSpan = new Span(fieldName, combinedSpanStartIndex, combinedSpanEndIndex, query, fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
-                    matchResults.add(combinedSpan);
+                    matchingResults.add(combinedSpan);
                     iter = iter + queryTokenList.size();                       
                 }		
     		}	
     	}
     	    	
-    	if (matchResults.isEmpty()) {
+    	if (matchingResults.isEmpty()) {
     		return null;
     	}
     	
@@ -264,14 +264,14 @@ public class KeywordMatcher implements IOperator {
         payload.clear();  // TODO: delete this line after DataReader's changes
     	
         List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
-        spanList.addAll(matchResults);
+        spanList.addAll(matchingResults);
     	
     	return sourceTuple;
     }
     
     
     private ITuple computeSubstringMatchingResult(ITuple sourceTuple) throws DataFlowException {
-        List<Span> matchResults = new ArrayList<>();       
+        List<Span> matchingResults = new ArrayList<>();       
     	
     	for (Attribute attribute : this.predicate.getAttributeList()) {
     		String fieldName = attribute.getFieldName();
@@ -287,7 +287,7 @@ public class KeywordMatcher implements IOperator {
 			// for STRING type, the query should match the fieldValue completely
     		if (fieldType == FieldType.STRING) {
                 if (fieldValue.equals(query)) {
-                    matchResults.add(new Span(fieldName, 0, query.length(), query, fieldValue));
+                    matchingResults.add(new Span(fieldName, 0, query.length(), query, fieldValue));
                 }
     		}
     		
@@ -299,12 +299,12 @@ public class KeywordMatcher implements IOperator {
     				int start = matcher.start();
     				int end = matcher.end();
 
-    				matchResults.add(new Span(fieldName, start, end, query, fieldValue.substring(start, end)));
+    				matchingResults.add(new Span(fieldName, start, end, query, fieldValue.substring(start, end)));
     			}
     		}
     		
     	}
-    	if (matchResults.isEmpty()) {
+    	if (matchingResults.isEmpty()) {
     		return null;
     	}
     	
@@ -313,7 +313,7 @@ public class KeywordMatcher implements IOperator {
     	payload.clear();  // TODO: delete this line after DataReader's changes
     	
         List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
-        spanList.addAll(matchResults);
+        spanList.addAll(matchingResults);
     	
     	return sourceTuple;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -61,7 +61,6 @@ public class KeywordMatcher implements IOperator {
     	}
         try {
             inputOperator.open();
-            inputOperator.open();
             inputSchema = inputOperator.getOutputSchema();
             
             if (! inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
@@ -365,6 +364,22 @@ public class KeywordMatcher implements IOperator {
     @Override
     public Schema getOutputSchema() {
         return inputOperator.getOutputSchema();
+    }
+    
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+    
+    public int getLimit() {
+        return limit;
+    }
+    
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+    
+    public int getOffset() {
+        return offset;
     }
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -87,8 +87,6 @@ public class RegexMatcher implements IOperator {
             
             this.spanList = computeMatches(sourceTuple);
             if (spanList != null && spanList.size() != 0) { // a list of matches found
-                System.out.println(spanList.size());
-
             	List<IField> fields = sourceTuple.getFields();
             	return constructSpanTuple(fields, this.spanList);
             } else { // no match found

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -210,6 +210,7 @@ public class RegexMatcher implements IOperator {
         
         try {
             inputOperator.open();
+            this.spanSchema = Utils.createSpanSchema(this.inputOperator.getOutputSchema());
         } catch (Exception e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);


### PR DESCRIPTION
Previously, KeywordMatcher assumes that DataReader performs a keyword match on the origin tuple and provides KeywordMatcher a span list that only contains relevant result.

Now we removed this assumption. KeywordMatcher now assumes that the spanList is not necessarily relevant, and will perform a keyword match on the spanList first.


