### PR TITLE
Change DataReader's interface to return payload instead of spanList.

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/SchemaConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/SchemaConstants.java
@@ -11,6 +11,9 @@ import edu.uci.ics.textdb.api.common.FieldType;
  *
  */
 public class SchemaConstants {
+    public static final String PAYLOAD = "payload";
+    public static final Attribute PAYLOAD_ATTRIBUTE = new Attribute(PAYLOAD, FieldType.LIST);
+    
     public static final String SPAN_LIST = "spanList";
     public static final Attribute SPAN_LIST_ATTRIBUTE = new Attribute(SPAN_LIST, FieldType.LIST);
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -271,6 +272,29 @@ public class Utils {
     	sb.append("token offset: "+span.getTokenOffset()+"\n");
     	
     	return sb.toString();
+    }
+
+    public static List<ITuple> removePayload(List<ITuple> tupleList) {
+        List<ITuple> tupleListWithoutPayload = 
+                tupleList.stream().map(tuple -> removePayload(tuple))
+                .collect(Collectors.toList());
+        return tupleListWithoutPayload;
+    }
+    
+    public static ITuple removePayload(ITuple tuple) {
+        Integer payloadIndex = tuple.getSchema().getIndex(SchemaConstants.PAYLOAD);
+        if (payloadIndex == null) {
+            return tuple;
+        } else {
+            Attribute[] attrWithoutPayload = tuple.getSchema().getAttributes().stream()
+                    .filter(x -> (! x.getFieldName().equals(SchemaConstants.PAYLOAD)))
+                    .toArray(Attribute[]::new);
+            Schema schemaWithoutPayload = new Schema(attrWithoutPayload);
+            List<IField> fieldsWithoutPayload = new ArrayList<IField>(tuple.getFields());
+            fieldsWithoutPayload.remove(payloadIndex.intValue());
+            ITuple tupleWithoutPayload = new DataTuple(schemaWithoutPayload, fieldsWithoutPayload.stream().toArray(IField[]::new));
+            return tupleWithoutPayload;
+        }
     }
     
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -117,7 +117,7 @@ public class KeywordMatcher implements IOperator {
     
     
     private ITuple processConjunction(ITuple currentTuple) throws DataFlowException {    	
-        List<Span> payload = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
+        List<Span> payload = (List<Span>) currentTuple.getField(SchemaConstants.PAYLOAD).getValue(); 
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();
     	
@@ -156,9 +156,6 @@ public class KeywordMatcher implements IOperator {
     		return null;
     	}
     	
-        // temporarily delete all spans in payload to pass all test cases
-        payload.clear();  // TODO: delete this line after DataReader's changes
-    	
         List<Span> spanList = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue();
         spanList.addAll(matchResults);
         
@@ -167,7 +164,7 @@ public class KeywordMatcher implements IOperator {
     
     
     private ITuple processPhrase(ITuple currentTuple) throws DataFlowException {
-        List<Span> payload = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue(); 
+        List<Span> payload = (List<Span>) currentTuple.getField(SchemaConstants.PAYLOAD).getValue(); 
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();
         
@@ -251,10 +248,7 @@ public class KeywordMatcher implements IOperator {
     	if (matchResults.isEmpty()) {
     		return null;
     	}
-    	
-        // temporarily delete all spans in payload to pass all test cases
-        payload.clear();  // TODO: delete this line after DataReader's changes
-    	
+
         List<Span> spanList = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue();
         spanList.addAll(matchResults);
     	
@@ -301,11 +295,7 @@ public class KeywordMatcher implements IOperator {
     	if (matchResults.isEmpty()) {
     		return null;
     	}
-    	
-        List<Span> payload = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue();
-        // temporarily delete all spans in payload to pass all test cases
-    	payload.clear();  // TODO: delete this line after DataReader's changes
-    	
+	
         List<Span> spanList = (List<Span>) currentTuple.getField(SchemaConstants.SPAN_LIST).getValue();
         spanList.addAll(matchResults);
     	

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/utils/TestUtils.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/utils/TestUtils.java
@@ -15,6 +15,7 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.common.utils.Utils;
 
 
 /**
@@ -42,10 +43,13 @@ public class TestUtils {
     }
     
     public static boolean containsAllResults(List<ITuple> expectedResults, List<ITuple> exactResults) {
+        expectedResults = Utils.removePayload(expectedResults);
+        exactResults = Utils.removePayload(exactResults);
+        
         if(expectedResults.size() != exactResults.size())
-        	return false;
+            return false;
         if(!(expectedResults.containsAll(exactResults)) || !(exactResults.containsAll(expectedResults)))
-        	return false;
+            return false;
         
         return true;
     }


### PR DESCRIPTION
For each tuple coming out of Lucene, we obtain a structure called "[term vector](http://makble.com/what-is-term-vector-in-lucene)", which keeps positional information for the keywords as a small inverted index for the tuple.  It contains the starts, ends, and token offsets of all the keywords in this tuple. 


In this PR, we introduce a new attribute called "payload" to include this information, which corresponds to the original "spanList".