### PR TITLE
Modify RegexMatcher's logic to be consistent with other operators

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -29,7 +29,6 @@ import edu.uci.ics.textdb.storage.DataReaderPredicate;
 public class RegexPredicate implements IPredicate {
 
 	private String regex;
-	private List<String> fieldNameList;
 	private List<Attribute> attributeList;
 	
 	private Analyzer luceneAnalyzer;	
@@ -40,7 +39,7 @@ public class RegexPredicate implements IPredicate {
     	this.regex = regex;
     	this.luceneAnalyzer = analyzer;
     	this.attributeList = attributeList;
-    	this.fieldNameList = attributeList.stream()
+    	List<String> fieldNameList = attributeList.stream()
     			.filter(attr -> (attr.getFieldType() == FieldType.TEXT || attr.getFieldType() == FieldType.STRING))
     			.map(attr -> attr.getFieldName()).collect(Collectors.toList());
     	
@@ -81,10 +80,6 @@ public class RegexPredicate implements IPredicate {
 
 	public Analyzer getLuceneAnalyzer() {
 		return this.luceneAnalyzer;
-	}
-
-	public List<String> getFieldNameList() {
-		return this.fieldNameList;
 	}
 
 	public List<Attribute> getAttributeList() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -9,6 +9,8 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
@@ -16,6 +18,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.field.DataTuple;
@@ -34,10 +37,10 @@ public class RegexMatcher implements IOperator {
     private RegexPredicate regexPredicate;
     
     private String regex;
-    private List<String> fieldNameList;
+    private List<Attribute> attributeList;
     
-    private Schema sourceTupleSchema;
-    private Schema spanSchema;
+    private Schema inputSchema;
+    private Schema outputSchema;
     
 	private IOperator inputOperator;
     
@@ -61,9 +64,7 @@ public class RegexMatcher implements IOperator {
     	this.limit = Integer.MAX_VALUE;
     	this.regexPredicate = (RegexPredicate) predicate;
     	this.regex = regexPredicate.getRegex();
-    	this.fieldNameList = regexPredicate.getFieldNameList();
-    	
-    	
+    	this.attributeList = regexPredicate.getAttributeList();  	
     			
 		// try Java Regex first
 		try {
@@ -80,6 +81,28 @@ public class RegexMatcher implements IOperator {
 	    	}
 		}		
     }
+    
+    
+    @Override
+    public void open() throws DataFlowException {
+        if (this.inputOperator == null) {
+            throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+        }
+
+        try {
+            inputOperator.open();
+            
+            this.inputSchema = inputOperator.getOutputSchema();
+            if (! this.inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+                outputSchema = Utils.createSpanSchema(inputSchema);
+            } else {
+                outputSchema = inputSchema;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
 	
 	
     @Override
@@ -90,7 +113,10 @@ public class RegexMatcher implements IOperator {
 			}
 			ITuple sourceTuple;
 			ITuple resultTuple = null;
-			while ((sourceTuple = inputOperator.getNextTuple()) != null) {     
+			while ((sourceTuple = inputOperator.getNextTuple()) != null) {
+			    if (! inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+			        sourceTuple = Utils.getSpanTuple(sourceTuple.getFields(), new ArrayList<Span>(), outputSchema);
+			    }	    
 	            resultTuple = computeMatchingResult(sourceTuple);
 	            
 	            if (resultTuple != null) {
@@ -107,31 +133,7 @@ public class RegexMatcher implements IOperator {
         }        
     }
     
-    public void setLimit(int limit){
-    	this.limit = limit;
-    }
-    
-    public int getLimit(){
-    	return this.limit;
-    }
-    
-    public void setOffset(int offset){
-    	this.offset = offset;
-    }
-    
-    public int getOffset(){
-    	return this.offset;
-    }
-    
-    private ITuple constructSpanTuple(List<IField> fields, List<Span> spans) {
-    	List<IField> fieldListDuplicate = new ArrayList<>(fields);
-    	IField spanListField = new ListField<Span>(spans);
-    	fieldListDuplicate.add(spanListField);
-    	IField[]  fieldsDuplicate = fieldListDuplicate.toArray(new IField[fieldListDuplicate.size()]);
-    	return new DataTuple(spanSchema, fieldsDuplicate);
-    }
-	
-    
+
 	/**
 	 * This function returns a list of spans in the given tuple that match the
 	 * regex For example, given tuple ("george watson", "graduate student", 23,
@@ -143,55 +145,68 @@ public class RegexMatcher implements IOperator {
 	 *            document in which search is performed
 	 * @return a list of spans describing the occurrence of a matching sequence
 	 *         in the document
+	 * @throws DataFlowException 
 	 */
-	public ITuple computeMatchingResult(ITuple sourceTuple) {
-		List<Span> spanList = new ArrayList<>();
-		if (sourceTuple == null) {
+	public ITuple computeMatchingResult(ITuple sourceTuple) throws DataFlowException {
+	    if (sourceTuple == null) {
+	        return null;
+	    }
+	    
+        List<Span> matchingResults = new ArrayList<>();
+        
+        for (Attribute attribute : attributeList) {
+            String fieldName = attribute.getFieldName();
+            FieldType fieldType = attribute.getFieldType();
+            String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
+            
+            // types other than TEXT and STRING: throw Exception for now
+            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+                        
+            switch (regexEngine) {
+            case JavaRegex:
+                matchingResults.addAll(javaRegexMatch(fieldValue, fieldName));
+                break;
+            case RE2J:
+                matchingResults.addAll(re2jRegexMatch(fieldValue, fieldName));
+                break;
+            }     
+        }
+
+		if (matchingResults.isEmpty()) {
 			return null;
 		}
-		for (String fieldName : fieldNameList) {
-			IField field = sourceTuple.getField(fieldName);
-			String fieldValue = field.getValue().toString();
-			if (fieldValue == null) {
-				return null;
-			} else {
-				switch (regexEngine) {
-				case JavaRegex:
-					spanList = javaRegexMatch(fieldValue, fieldName, spanList);
-					break;
-				case RE2J:
-					spanList = re2jRegexMatch(fieldValue, fieldName, spanList);
-					break;
-				}
-			}
-		}
-		if (spanList.isEmpty()) {
-			return null;
-		}
-		return constructSpanTuple(sourceTuple.getFields(),spanList);
+			
+        List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        spanList.addAll(matchingResults);
+        
+		return sourceTuple;
 	}
 	
 	
-	private List<Span> javaRegexMatch(String fieldValue, String fieldName, List<Span> spanList) {
+	private List<Span> javaRegexMatch(String fieldValue, String fieldName) {
+	    List<Span> matchingResults = new ArrayList<>();
 		java.util.regex.Matcher javaMatcher = this.javaPattern.matcher(fieldValue);
 		while (javaMatcher.find()) {
 			int start = javaMatcher.start();
 			int end = javaMatcher.end();
-			spanList.add(new Span(fieldName, start, end, 
+			matchingResults.add(new Span(fieldName, start, end, 
 					this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
 		}
-		return spanList;
+		return matchingResults;
 	}
 	
-	private List<Span> re2jRegexMatch(String fieldValue, String fieldName, List<Span> spanList) {
+	private List<Span> re2jRegexMatch(String fieldValue, String fieldName) {
+        List<Span> matchingResults = new ArrayList<>();	    
 		com.google.re2j.Matcher re2jMatcher = this.re2jPattern.matcher(fieldValue);
 		while (re2jMatcher.find()) {
 			int start = re2jMatcher.start();
 			int end = re2jMatcher.end();
-			spanList.add(new Span(fieldName, start, end, 
+			matchingResults.add(new Span(fieldName, start, end, 
 					this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
 		}
-		return spanList;
+		return matchingResults;
 	}
 	
 	/**
@@ -231,22 +246,6 @@ public class RegexMatcher implements IOperator {
 		return this.regexEngine.toString();
 	}
     
-    
-    @Override
-    public void open() throws DataFlowException {
-        if (this.inputOperator == null) {
-            throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
-        }
-        
-        
-        try {
-            inputOperator.open();
-            this.spanSchema = Utils.createSpanSchema(this.inputOperator.getOutputSchema());
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
-        }
-    }
 
     @Override
     public void close() throws DataFlowException {
@@ -260,10 +259,6 @@ public class RegexMatcher implements IOperator {
         }
     }
     
-
-    public Schema getSpanSchema() {
-    	return spanSchema;
-    }
     
     public String getRegex() {
     	return this.regex;
@@ -277,9 +272,24 @@ public class RegexMatcher implements IOperator {
 		this.inputOperator = inputOperator;
 	}
 
-
     @Override
     public Schema getOutputSchema() {
-        return spanSchema;
+        return outputSchema;
+    }
+    
+    public void setLimit(int limit){
+        this.limit = limit;
+    }
+    
+    public int getLimit(){
+        return this.limit;
+    }
+    
+    public void setOffset(int offset){
+        this.offset = offset;
+    }
+    
+    public int getOffset(){
+        return this.offset;
     }
 }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
@@ -50,7 +50,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "brad lie angelina"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(TestConstants.FIRST_NAME, 11, 17, "g[^\\s]*", "gelina"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -83,7 +83,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 
 		//expected to match "http://weibo.com"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsCorp.URL, 0, 16, query, "http://weibo.com"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -116,7 +116,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "66.220.144.0"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsCorp.IP_ADDRESS, 0, 12, query, "66.220.144.0"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -157,7 +157,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "k.bocanegra@uci.edu"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantStaff.EMAIL, 0, 19, query, "m.bocanegra@164.com"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -192,7 +192,7 @@ public class RegexMatcherTest {
 		
 		
 		//expected to match "test" & testing"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 5, 9, regex, "test"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 21, 28, regex, "testing"));
@@ -235,7 +235,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "followup"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 28, 36, regex, "followup"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 54, 62, regex, "followup"));
@@ -281,7 +281,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "Tomato" & "tomato"
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 0, 6, regex, "Tomato"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 94, 100, regex, "tomato"));
@@ -323,7 +323,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match [a] & [!]
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 110, 113, regex, "[a]"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 120, 123, regex, "[!]"));
@@ -349,7 +349,7 @@ public class RegexMatcherTest {
 		List<ITuple> exactResultsWithLimit = testHelper.getResults();
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 4, 11, regex, "patient"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -391,7 +391,7 @@ public class RegexMatcherTest {
 		List<ITuple> exactResultsWithLimitOffset = testHelper.getResults();
 		List<ITuple> expectedResults = new ArrayList<ITuple> ();
 		
-		Schema spanSchema = testHelper.getOutputSchema();
+		Schema spanSchema = testHelper.getSpanSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 4, 11, regex, "patient"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -432,7 +432,7 @@ public class RegexMatcherTest {
 //		List<ITuple> exactResults = testHelper.getResults();
 //		List<ITuple> expectedResults = new ArrayList<ITuple>();
 //		
-//		Schema spanSchema = testHelper.getOutputSchema();
+//		Schema spanSchema = testHelper.getSpanSchema();
 //		List<Span> spans = new ArrayList<Span>();
 //		spans.add(new Span(RegexTestConstantsText.CONTENT, 61, 64, regex, "the"));
 //		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
@@ -50,7 +50,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "brad lie angelina"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(TestConstants.FIRST_NAME, 11, 17, "g[^\\s]*", "gelina"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -83,7 +83,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 
 		//expected to match "http://weibo.com"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsCorp.URL, 0, 16, query, "http://weibo.com"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -116,7 +116,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "66.220.144.0"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsCorp.IP_ADDRESS, 0, 12, query, "66.220.144.0"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -157,7 +157,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "k.bocanegra@uci.edu"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantStaff.EMAIL, 0, 19, query, "m.bocanegra@164.com"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -192,7 +192,7 @@ public class RegexMatcherTest {
 		
 		
 		//expected to match "test" & testing"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 5, 9, regex, "test"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 21, 28, regex, "testing"));
@@ -235,7 +235,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "followup"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 28, 36, regex, "followup"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 54, 62, regex, "followup"));
@@ -281,7 +281,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match "Tomato" & "tomato"
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 0, 6, regex, "Tomato"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 94, 100, regex, "tomato"));
@@ -323,7 +323,7 @@ public class RegexMatcherTest {
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
 		//expected to match [a] & [!]
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 110, 113, regex, "[a]"));
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 120, 123, regex, "[!]"));
@@ -349,7 +349,7 @@ public class RegexMatcherTest {
 		List<ITuple> exactResultsWithLimit = testHelper.getResults();
 		List<ITuple> expectedResults = new ArrayList<ITuple>();
 		
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 4, 11, regex, "patient"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -391,7 +391,7 @@ public class RegexMatcherTest {
 		List<ITuple> exactResultsWithLimitOffset = testHelper.getResults();
 		List<ITuple> expectedResults = new ArrayList<ITuple> ();
 		
-		Schema spanSchema = testHelper.getSpanSchema();
+		Schema spanSchema = testHelper.getOutputSchema();
 		List<Span> spans = new ArrayList<Span>();
 		spans.add(new Span(RegexTestConstantsText.CONTENT, 4, 11, regex, "patient"));
 		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));
@@ -432,7 +432,7 @@ public class RegexMatcherTest {
 //		List<ITuple> exactResults = testHelper.getResults();
 //		List<ITuple> expectedResults = new ArrayList<ITuple>();
 //		
-//		Schema spanSchema = testHelper.getSpanSchema();
+//		Schema spanSchema = testHelper.getOutputSchema();
 //		List<Span> spans = new ArrayList<Span>();
 //		spans.add(new Span(RegexTestConstantsText.CONTENT, 61, 64, regex, "the"));
 //		IField spanField = new ListField<Span>(new ArrayList<Span>(spans));

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTest.java
@@ -374,6 +374,7 @@ public class RegexMatcherTest {
 		fields.add(spanField);
 		expectedResults.add(new DataTuple(spanSchema, fields.toArray(new IField[fields.size()])));
 		
+		exactResultsWithLimit = Utils.removePayload(exactResultsWithLimit);
 		Assert.assertTrue(expectedResults.containsAll(exactResultsWithLimit));
 		Assert.assertEquals(expectedResults.size(), 3);
 		Assert.assertEquals(exactResultsWithLimit.size(), 2);
@@ -416,6 +417,7 @@ public class RegexMatcherTest {
 		fields.add(spanField);
 		expectedResults.add(new DataTuple(spanSchema, fields.toArray(new IField[fields.size()])));
 		
+		exactResultsWithLimitOffset = Utils.removePayload(exactResultsWithLimitOffset);
 		Assert.assertTrue(expectedResults.containsAll(exactResultsWithLimitOffset));
 		Assert.assertEquals(expectedResults.size(), 3);
 		Assert.assertEquals(exactResultsWithLimitOffset.size(), 2);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -49,8 +49,8 @@ public class RegexMatcherTestHelper {
 		return results;
 	}
 	
-	public Schema getSpanSchema() {
-		return regexMatcher.getSpanSchema();
+	public Schema getOutputSchema() {
+		return regexMatcher.getOutputSchema();
 	}
 	
 	public void runTest(String regex, Attribute attribute) throws Exception {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcherTestHelper.java
@@ -14,6 +14,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
 import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -33,8 +34,11 @@ public class RegexMatcherTestHelper {
 	
 	List<ITuple> results;
     Analyzer luceneAnalyzer;
+    
+    Schema inputSchema;
 	
 	public RegexMatcherTestHelper(Schema schema, List<ITuple> data) throws Exception {
+	    inputSchema = schema;
 		dataStore = new DataStore(DataConstants.INDEX_DIR, schema);
 		luceneAnalyzer = CustomAnalyzer.builder()
 				.withTokenizer(NGramTokenizerFactory.class, new String[]{"minGramSize", "3", "maxGramSize", "3"})
@@ -49,8 +53,8 @@ public class RegexMatcherTestHelper {
 		return results;
 	}
 	
-	public Schema getOutputSchema() {
-		return regexMatcher.getOutputSchema();
+	public Schema getSpanSchema() {
+		return Utils.createSpanSchema(inputSchema);
 	}
 	
 	public void runTest(String regex, Attribute attribute) throws Exception {


### PR DESCRIPTION
To prepare for incoming changes in DataReader, all operators need to change how they handle schema. 
KeywordMatcher is changed in #193 , FuzzyTokenMatcher is changed in #194 .

This PR change RegexMatcher to be consistent in those PRs.