### PR TITLE
Modify DictionaryMatcher's logic with incoming dataReader chagnes

### DIFF
--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -133,7 +133,7 @@ public class DictionaryMatcherTest {
                 TestConstants.DESCRIPTION_ATTR);
 
         List<ITuple> returnedResults = getQueryResults(dictionary, KeywordMatchingType.SUBSTRING_SCANBASED, attributes);
-        boolean contains = TestUtils.containsAllResults(expectedResults, returnedResults);
+        boolean contains = TestUtils.containsAllResults(expectedResults, returnedResults);        
         Assert.assertTrue(contains);
     }
     


### PR DESCRIPTION
Modify dictionaryMatcher's logic to be consistent with the new dataReader design. Similar changes are made to Regex( #197 ), Keyword( #193 ), and Fuzzy( #194 ).