### PR TITLE
Change IPredicate in operators' constructor to specific predicates

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
@@ -79,7 +79,7 @@ public class DictionaryPredicate implements IPredicate {
     public IOperator getScanSourceOperator() throws ParseException, DataFlowException {
         QueryParser luceneQueryParser = new QueryParser(attributeList.get(0).getFieldName(), luceneAnalyzer);
         Query luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
-        IPredicate dataReaderPredicate = new DataReaderPredicate(luceneQuery,DataConstants.SCAN_QUERY, dataStore, attributeList, luceneAnalyzer);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(luceneQuery,DataConstants.SCAN_QUERY, dataStore, attributeList, luceneAnalyzer);
         IDataReader dataReader = new DataReader(dataReaderPredicate);
 
         IOperator operator = new ScanBasedSourceOperator(dataReader);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -50,7 +50,7 @@ public class DictionaryMatcher implements IOperator {
      * @param predicate
      * 
      */
-    public DictionaryMatcher(IPredicate predicate) {
+    public DictionaryMatcher(DictionaryPredicate predicate) {
         this.resultCursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -40,11 +40,11 @@ public class FuzzyTokenMatcher implements IOperator{
     private int cursor;
     private int offset;
 
-    public FuzzyTokenMatcher(IPredicate predicate) {
+    public FuzzyTokenMatcher(FuzzyTokenPredicate predicate) {
         this.cursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;
-        this.predicate = (FuzzyTokenPredicate)predicate;
+        this.predicate = predicate;
         DataReaderPredicate dataReaderPredicate = this.predicate.getDataReaderPredicate();
         this.inputOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -62,10 +62,10 @@ public class Join implements IOperator {
 	 * @param joinPredicate
 	 *            is the predicate over which the join is made
 	 */
-	public Join(IOperator outerOperator, IOperator innerOperator, IPredicate joinPredicate) {
+	public Join(IOperator outerOperator, IOperator innerOperator, JoinPredicate joinPredicate) {
 		this.outerOperator = outerOperator;
 		this.innerOperator = innerOperator;
-		this.joinPredicate = (JoinPredicate) joinPredicate;
+		this.joinPredicate = joinPredicate;
 	}
 
 	@Override

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -45,11 +45,11 @@ public class KeywordMatcher implements IOperator {
     private int limit;
     private int offset;
 
-    public KeywordMatcher(IPredicate predicate) {
+    public KeywordMatcher(KeywordPredicate predicate) {
         this.cursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;
-        this.predicate = (KeywordPredicate)predicate;
+        this.predicate = predicate;
         this.query = this.predicate.getQuery();
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -58,11 +58,11 @@ public class RegexMatcher implements IOperator {
 	private java.util.regex.Pattern javaPattern;
 	
 	
-    public RegexMatcher(IPredicate predicate) throws DataFlowException{
+    public RegexMatcher(RegexPredicate predicate) throws DataFlowException{
     	this.cursor = -1;
     	this.offset = 0;
     	this.limit = Integer.MAX_VALUE;
-    	this.regexPredicate = (RegexPredicate) predicate;
+    	this.regexPredicate = predicate;
     	this.regex = regexPredicate.getRegex();
     	this.attributeList = regexPredicate.getAttributeList();  	
     			

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -19,8 +19,8 @@ public class IndexBasedSourceOperator implements ISourceOperator {
 	private DataReaderPredicate predicate;
 	private int cursor = CLOSED;
 	
-	public IndexBasedSourceOperator(IPredicate predicate){
-	    this.predicate = (DataReaderPredicate)predicate;
+	public IndexBasedSourceOperator(DataReaderPredicate predicate){
+	    this.predicate = predicate;
 	}
 
 	@Override

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -70,7 +70,7 @@ public class DictionaryMatcherTest {
     public List<ITuple> getQueryResults(IDictionary dictionary, KeywordMatchingType srcOpType,
             List<Attribute> attributes) throws Exception {
 
-    	IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, srcOpType);
+    	DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, srcOpType);
     	dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
     	dictionaryMatcher.open();
         ITuple nextTuple = null;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
@@ -63,7 +63,7 @@ public class FuzzyTokenMatcherTest {
     
     public List<ITuple> getQueryResults(String query,double threshold, ArrayList<Attribute> attributeList, boolean isSpanInformationAdded) throws DataFlowException, ParseException {
 
-        IPredicate predicate = new FuzzyTokenPredicate(query, dataStore, attributeList, analyzer, threshold, isSpanInformationAdded);
+        FuzzyTokenPredicate predicate = new FuzzyTokenPredicate(query, dataStore, attributeList, analyzer, threshold, isSpanInformationAdded);
         fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);
         fuzzyTokenMatcher.open();
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -119,7 +119,7 @@ public class JoinTest {
 	public List<ITuple> getJoinResults(IOperator outer, IOperator inner,
 			Attribute idAttribute, Attribute joinAttribute, Integer threshold)
 					throws Exception {
-		IPredicate joinPredicate = new JoinPredicate(idAttribute, joinAttribute,
+		JoinPredicate joinPredicate = new JoinPredicate(idAttribute, joinAttribute,
 				threshold);
 		join = new Join(outer, inner, joinPredicate);
 		join.open();
@@ -533,7 +533,7 @@ public class JoinTest {
 		query = "this writer writes well";
 		double thresholdRatio = 0.25;
 		boolean isSpanInformationAdded = false;
-		IPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(query, dataStoreForInner, attributeList, analyzer,
+		FuzzyTokenPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(query, dataStoreForInner, attributeList, analyzer,
 				thresholdRatio, isSpanInformationAdded);
 		FuzzyTokenMatcher fuzzyMatcherInner = new FuzzyTokenMatcher(fuzzyPredicateInner);
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
@@ -42,7 +42,7 @@ public class NlpExtractorTest {
     private Query query;
     private Analyzer analyzer;
 
-    private IPredicate dataReaderPredicate;
+    private DataReaderPredicate dataReaderPredicate;
 
 
     @After

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -39,7 +39,7 @@ public class IndexBasedSourceOperatorTest {
 	private IndexBasedSourceOperator indexBasedSourceOperator;
 	private IDataStore dataStore;
 	private Analyzer luceneAnalyzer;
-    private IPredicate dataReaderPredicate;
+    private DataReaderPredicate dataReaderPredicate;
 
 
 	@Before

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
@@ -43,7 +43,7 @@ public class ScanBasedSourceOperatorTest {
     private IDataStore dataStore;
     private Analyzer lucneAnalyzer;
     private Query query;
-    private IPredicate dataReaderPredicate;
+    private DataReaderPredicate dataReaderPredicate;
     
     @Before
     public void setUp() throws Exception{

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -136,7 +136,7 @@ public class DictionaryMatcherPerformanceTest {
 		List<Attribute> attributes = Arrays.asList(MedlineIndexWriter.ABSTRACT_ATTR);
 
 		IDictionary dictionary = new Dictionary(queryList);
-		IPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, opType);
+		DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, opType);
 		DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
 
 		long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -141,7 +141,7 @@ public class FuzzyTokenMatcherPerformanceTest {
 		Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 
 		for (String query : queryList) {
-			IPredicate predicate = new FuzzyTokenPredicate(query, dataStore, Arrays.asList(attributeList),
+			FuzzyTokenPredicate predicate = new FuzzyTokenPredicate(query, dataStore, Arrays.asList(attributeList),
 					luceneAnalyzer, threshold, true);
 			FuzzyTokenMatcher fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);
 

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -57,8 +57,8 @@ public class DataReader implements IDataReader {
 	private int offset;
 	private boolean payloadAdded = true;
 	
-	public DataReader(IPredicate dataReaderPredicate) {
-		predicate = (DataReaderPredicate)dataReaderPredicate;
+	public DataReader(DataReaderPredicate dataReaderPredicate) {
+		predicate = dataReaderPredicate;
 	}
 	
 	

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -29,7 +29,7 @@ public class DataWriterReaderTest {
     private IDataWriter dataWriter;
     private IDataReader dataReader;
     private IDataStore dataStore;
-    private IPredicate dataReaderPredicate;
+    private DataReaderPredicate dataReaderPredicate;
     private Analyzer luceneAnalyzer;
     private Query query;
     


### PR DESCRIPTION
Previously, in almost all operators' constructor, predicate is passed with type IPredicate, which is the interface of all predicates. Then IPredicate will be cased to specific predicates.
For example:
```
public KeywordMatcher(IPredicate predicate) {
    this.predicate = (KeywordPredicate) predicate;
}
```

Following the principle that compile time check is safer than run time casting, all operators now require their own predicate.
For example:
```
public KeywordMatcher(KeywordPredicate predicate) {
    this.predicate = predicate;
}
```
