### PR TITLE
Revert fieldName in schema back to case insensitve

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -22,7 +22,7 @@ public class Schema {
         fieldNameVsIndex = new HashMap<String, Integer>();
         for (int count = 0; count < attributes.size(); count++) {
             String fieldName = attributes.get(count).getFieldName();
-            fieldNameVsIndex.put(fieldName, count);
+            fieldNameVsIndex.put(fieldName.toLowerCase(), count);
         }
     }
 
@@ -31,11 +31,11 @@ public class Schema {
     }
     
     public Integer getIndex(String fieldName){
-        return fieldNameVsIndex.get(fieldName);
+        return fieldNameVsIndex.get(fieldName.toLowerCase());
     }
     
     public boolean containsField(String fieldName) {
-        return fieldNameVsIndex.keySet().contains(fieldName);
+        return fieldNameVsIndex.keySet().contains(fieldName.toLowerCase());
     }
     
     

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -37,7 +37,7 @@ public class SchemaTest {
          int expectedIndex1 = 0;		
          int expectedIndex2 = 1;		
          int retrievedIndex1 = schema.getIndex(fieldName1);		
-         int retrievedIndex2 = schema.getIndex(fieldName2);		
+         int retrievedIndex2 = schema.getIndex(fieldName2.toUpperCase());		
          Assert.assertEquals(expectedIndex1, retrievedIndex1);		
          Assert.assertEquals(expectedIndex2, retrievedIndex2);		
          		


### PR DESCRIPTION
Previously, I changed fieldName in schema to be case sensitive. Now I'm changing it back to case insensitive.