### PR TITLE
Build Payload if it doesn't exist

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -66,6 +66,11 @@ public class FuzzyTokenPredicate implements IPredicate {
     public ArrayList<String> getQueryTokens(){
     	return this.tokens;
     }
+    
+    public Analyzer getLuceneAnalyzer() {
+        return luceneAnalyzer;
+    }
+    
     private void extractSearchFields() {
     	this.fields = new String[this.attributeList.size()];
     	int i = 0;


### PR DESCRIPTION
Currently, KeywordMatcher and FuzzyTokenMatcher assume that payload always exists for input tuples.
However, this might not always be the case. For example, if the first step of the plan is a regex matcher, the tuple comes from a trigram index, and it doesn't contain payload. 
In this case, keywordMatcher and FuzzyTokenMatcher need to generate payload on their own.