### PR TITLE
Rename original DictionaryMatcher to DictionaryMatcherSourceOperator

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/DictionaryPredicate.java
@@ -10,7 +10,6 @@ import org.apache.lucene.search.Query;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IDictionary;
 import edu.uci.ics.textdb.api.common.IPredicate;
-import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants;
@@ -25,8 +24,7 @@ public class DictionaryPredicate implements IPredicate {
     private IDictionary dictionary;
     private Analyzer luceneAnalyzer;
     private List<Attribute> attributeList;
-    private IDataStore dataStore;
-    private KeywordMatchingType srcOpType;
+    private KeywordMatchingType keywordMatchingType;
     
     /*
     dictionary refers to list of phrases to search for.
@@ -34,18 +32,17 @@ public class DictionaryPredicate implements IPredicate {
     New and York; if searched in String field we search for Exact string.
      */
 
-    public DictionaryPredicate(IDictionary dictionary, IDataStore dataStore, List<Attribute> attributeList,
-    		Analyzer luceneAnalyzer, KeywordMatchingType srcOpType) {
+    public DictionaryPredicate(IDictionary dictionary, List<Attribute> attributeList,
+    		Analyzer luceneAnalyzer, KeywordMatchingType keywordMatchingType) {
 
         this.dictionary = dictionary;
         this.luceneAnalyzer = luceneAnalyzer;
         this.attributeList = attributeList;
-        this.srcOpType = srcOpType;
-        this.dataStore = dataStore;
+        this.keywordMatchingType = keywordMatchingType;
     }
 
-    public KeywordMatchingType getSourceOperatorType() {
-        return srcOpType;
+    public KeywordMatchingType getKeywordMatchingType() {
+        return keywordMatchingType;
     }
     
     /**
@@ -63,10 +60,6 @@ public class DictionaryPredicate implements IPredicate {
         return attributeList;
     }
 
-    public IDataStore getDataStore() {
-        return dataStore;
-    }
-
     public Analyzer getAnalyzer() {
         return luceneAnalyzer;
     }
@@ -76,13 +69,13 @@ public class DictionaryPredicate implements IPredicate {
     and generate SCAN based source operator
      */
 
-    public IOperator getScanSourceOperator() throws ParseException, DataFlowException {
+    public ScanBasedSourceOperator getScanSourceOperator(IDataStore dataStore) throws ParseException, DataFlowException {
         QueryParser luceneQueryParser = new QueryParser(attributeList.get(0).getFieldName(), luceneAnalyzer);
         Query luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(luceneQuery,DataConstants.SCAN_QUERY, dataStore, attributeList, luceneAnalyzer);
         IDataReader dataReader = new DataReader(dataReaderPredicate);
 
-        IOperator operator = new ScanBasedSourceOperator(dataReader);
+        ScanBasedSourceOperator operator = new ScanBasedSourceOperator(dataReader);
         return operator;
     }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -38,7 +38,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     private KeywordMatcher keywordMatcher;
 
     private Schema inputSchema;
-	private Schema outputSchema;
+    private Schema outputSchema;
     
     private ITuple sourceTuple;
     private String currentDictionaryEntry;
@@ -288,10 +288,10 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     @Override
     public void close() throws DataFlowException {
         try {
-        	if (keywordMatcher != null) {
-        	    keywordMatcher.close();
-        	}
-            if (indexSource != null) {
+            if (keywordMatcher != null) {
+                keywordMatcher.close();
+            }
+        	if (indexSource != null) {
                 indexSource.close();
             }
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -12,6 +12,8 @@ import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -30,16 +32,19 @@ import edu.uci.ics.textdb.storage.DataReaderPredicate;
  * @author Zuozhi Wang (zuozhi)
  * 
  */
-public class DictionaryMatcher implements IOperator {
+public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
-    private IOperator inputOperator;
+    private ISourceOperator indexSource;
+    private KeywordMatcher keywordMatcher;
 
-	private Schema spanSchema;
+    private Schema inputSchema;
+	private Schema outputSchema;
     
     private ITuple sourceTuple;
     private String currentDictionaryEntry;
 
     private final DictionaryPredicate predicate;
+    private IDataStore dataStore;
     
     private int resultCursor;
     private int limit;
@@ -50,12 +55,12 @@ public class DictionaryMatcher implements IOperator {
      * @param predicate
      * 
      */
-    public DictionaryMatcher(DictionaryPredicate predicate) {
+    public DictionaryMatcherSourceOperator(DictionaryPredicate predicate, IDataStore dataStore) {
         this.resultCursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;
-        this.predicate = (DictionaryPredicate) predicate;
-        this.spanSchema = Utils.createSpanSchema(this.predicate.getDataStore().getSchema());
+        this.predicate = predicate;
+        this.dataStore = dataStore;
     }
     
 
@@ -70,35 +75,35 @@ public class DictionaryMatcher implements IOperator {
             	throw new DataFlowException("Dictionary is empty");
             }
             
-            if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
-                inputOperator = predicate.getScanSourceOperator();
-                inputOperator.open();
-            } else {
-                KeywordPredicate keywordPredicate = null;
-                if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
-                    keywordPredicate = new KeywordPredicate(
-                            currentDictionaryEntry,
-                            predicate.getAttributeList(), predicate.getAnalyzer(),
-                            KeywordMatchingType.PHRASE_INDEXBASED);
-                    
-
-                } else if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-                    keywordPredicate = new KeywordPredicate(
-                            currentDictionaryEntry,
-                            predicate.getAttributeList(), predicate.getAnalyzer(),
-                            KeywordMatchingType.CONJUNCTION_INDEXBASED);
+            if (predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
+                // For Substring matching, create a scan source operator.
+                indexSource = predicate.getScanSourceOperator(dataStore);
+                indexSource.open();
+                
+                // Substring matching's output schema needs to contains span list.
+                inputSchema = indexSource.getOutputSchema();
+                outputSchema = inputSchema;
+                if (! inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+                    outputSchema = Utils.addAttributeToSchema(outputSchema, SchemaConstants.SPAN_LIST_ATTRIBUTE);
                 }
                 
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
-                KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
-                keywordMatcher.setInputOperator(indexInputOperator);
-                inputOperator = keywordMatcher;
-                
-                inputOperator.open();
-            }
-            
+            } else {
+                // For other keyword matching types (conjunction and phrase), create keyword matcher based on index.
+                KeywordPredicate keywordPredicate = new KeywordPredicate(
+                        currentDictionaryEntry,
+                        predicate.getAttributeList(), predicate.getAnalyzer(),
+                        predicate.getKeywordMatchingType());
 
-            
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
+                keywordMatcher = new KeywordMatcher(keywordPredicate);
+                keywordMatcher.setInputOperator(indexInputOperator);
+                keywordMatcher.open();
+                
+                // Other keyword matching types uses a KeywordMatcher, so the output schema is the same as keywordMatcher's schema
+                inputSchema = indexInputOperator.getOutputSchema();
+                outputSchema = keywordMatcher.getOutputSchema();
+            }
+        
         } catch (Exception e) {
             throw new DataFlowException(e.getMessage(), e);
         }
@@ -137,14 +142,14 @@ public class DictionaryMatcher implements IOperator {
     	if (resultCursor >= limit + offset - 1){
     		return null;
     	}
-    	if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED
-    	||  predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+    	if (predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED
+    	||  predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
     		// For each dictionary entry, 
     		// get all result from KeywordMatcher.
     		
     		while (true) {
     			// If there's result from current keywordMatcher, return it.
-    			if ((sourceTuple = inputOperator.getNextTuple()) != null) {
+    			if ((sourceTuple = keywordMatcher.getNextTuple()) != null) {
     				resultCursor++;
     				if (resultCursor >= offset){
     					return sourceTuple;
@@ -160,46 +165,42 @@ public class DictionaryMatcher implements IOperator {
     			
     			// Construct a new KeywordMatcher with the new dictionary entry.
     			KeywordMatchingType keywordMatchingType;
-    			if (predicate.getSourceOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+    			if (predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
     				keywordMatchingType = KeywordMatchingType.PHRASE_INDEXBASED;
     			} else {
     				keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
     			}
     			
-                inputOperator.close();
+    			keywordMatcher.close();
     			
 				KeywordPredicate keywordPredicate = new KeywordPredicate(
 						currentDictionaryEntry,
 						predicate.getAttributeList(), predicate.getAnalyzer(),
 						keywordMatchingType);
     			
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(predicate.getDataStore()));
-    	        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(keywordPredicate.generateDataReaderPredicate(dataStore));
+    	        keywordMatcher = new KeywordMatcher(keywordPredicate);
     	        keywordMatcher.setInputOperator(indexInputOperator);
-                inputOperator = keywordMatcher;
                 
-    			inputOperator.open();
+    	        keywordMatcher.open();
     		}
         }
+    	// Substring matching (based on scan)
     	else {
-    		if (sourceTuple == null) {
-    			if ((sourceTuple = inputOperator.getNextTuple()) == null) {
-    				return null;
-    			}
-    		}
-    		ITuple resultTuple = null;
-	    	while (sourceTuple != null) {
-	    	    if (! predicate.getDataStore().getSchema().containsField(SchemaConstants.SPAN_LIST)) {
-	    	        sourceTuple = Utils.getSpanTuple(sourceTuple.getFields(), new ArrayList<Span>(), Utils.createSpanSchema(sourceTuple.getSchema()));
-	    	    }
-	    		resultTuple = computeMatchingResult(currentDictionaryEntry, sourceTuple);
-	    		if (resultTuple != null) {
-	    			resultCursor++;
-	    		}
-	    		if (resultTuple != null && resultCursor >= offset){
-	    			break;
-	    		}
-	    	}
+            ITuple sourceTuple;
+            ITuple resultTuple = null;
+            while ((sourceTuple = indexSource.getNextTuple()) != null) {
+                if (! inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+                    sourceTuple = Utils.getSpanTuple(sourceTuple.getFields(), new ArrayList<Span>(), outputSchema);
+                }
+                resultTuple = computeMatchingResult(currentDictionaryEntry, sourceTuple);
+                if (resultTuple != null) {
+                    resultCursor++;
+                }
+                if (resultTuple != null && resultCursor >= offset){
+                    break;
+                }              
+            }
     		return resultTuple;
     	}
     }
@@ -231,7 +232,6 @@ public class DictionaryMatcher implements IOperator {
     	}
     	predicate.resetDictCursor();
     	currentDictionaryEntry = predicate.getNextDictionaryEntry();
-    	sourceTuple = inputOperator.getNextTuple();
     }
     
     /*
@@ -288,28 +288,22 @@ public class DictionaryMatcher implements IOperator {
     @Override
     public void close() throws DataFlowException {
         try {
-        	if (inputOperator != null) {
-                inputOperator.close();
+        	if (keywordMatcher != null) {
+        	    keywordMatcher.close();
         	}
+            if (indexSource != null) {
+                indexSource.close();
+            }
         } catch (Exception e) {
             e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
         }
     }
-    
-    
-    public IOperator getInputOperator() {
-		return inputOperator;
-	}
-
-	public void setInputOperator(IOperator inputOperator) {
-		this.inputOperator = inputOperator;
-	}
 
 
 	@Override
 	public Schema getOutputSchema() {
-		return spanSchema;
+		return outputSchema;
 	}
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -8,24 +8,20 @@ import java.util.regex.Pattern;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
-import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
 import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 
 /**
  * @author Sudeep (inkudo)
@@ -291,7 +287,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
             if (keywordMatcher != null) {
                 keywordMatcher.close();
             }
-        	if (indexSource != null) {
+            if (indexSource != null) {
                 indexSource.close();
             }
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -45,7 +45,7 @@ import edu.uci.ics.textdb.storage.writer.DataWriter;
  */
 public class DictionaryMatcherTest {
 
-    private DictionaryMatcher dictionaryMatcher;
+    private DictionaryMatcherSourceOperator dictionaryMatcher;
     private DataStore dataStore;
     private IDataWriter dataWriter;
     private Analyzer luceneAnalyzer;
@@ -70,8 +70,8 @@ public class DictionaryMatcherTest {
     public List<ITuple> getQueryResults(IDictionary dictionary, KeywordMatchingType srcOpType,
             List<Attribute> attributes) throws Exception {
 
-    	DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, srcOpType);
-    	dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
+    	DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, srcOpType);
+    	dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);
     	dictionaryMatcher.open();
         ITuple nextTuple = null;
         List<ITuple> results = new ArrayList<ITuple>();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -21,7 +21,7 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.dataflow.common.Dictionary;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
-import edu.uci.ics.textdb.dataflow.dictionarymatcher.DictionaryMatcher;
+import edu.uci.ics.textdb.dataflow.dictionarymatcher.DictionaryMatcherSourceOperator;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -136,8 +136,8 @@ public class DictionaryMatcherPerformanceTest {
 		List<Attribute> attributes = Arrays.asList(MedlineIndexWriter.ABSTRACT_ATTR);
 
 		IDictionary dictionary = new Dictionary(queryList);
-		DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, dataStore, attributes, luceneAnalyzer, opType);
-		DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
+		DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, opType);
+		DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);
 
 		long startMatchTime = System.currentTimeMillis();
 		dictionaryMatcher.open();


### PR DESCRIPTION
We want to make DictionaryMatcher a separate, connectable operator. However, the original DictionaryMatcher is tightly coupled with IndexSource because DictionaryMatcher's logic requires it to interact with IndexSource.

To avoid this limitation, this PR introduces DicitonaryMatcherSourceOperator. This operator is a data source itself, which means it can only generate outputs. 
The original DictionaryMatcher is renamed to DicitonaryMatcherSourceOperator with some minor modifications.

In the future, we will create a new DictionaryMatcher, which is not related to index, and can be connected to any operator.