### PR TITLE
Add a separate, connectable DictionaryMatcher.

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -1,0 +1,162 @@
+package edu.uci.ics.textdb.dataflow.dictionarymatcher;
+
+import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
+import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
+import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
+
+public class DictionaryMatcher implements IOperator {
+    
+    private DictionaryPredicate predicate;
+    
+    private IOperator inputOperator;
+    private KeywordMatcher keywordMatcher;
+    
+    private Schema outputSchema;
+    
+    String currentDictionaryEntry;
+    
+    private int resultCursor;
+    private int limit;
+    private int offset;
+    
+    private int cursor = CLOSED;
+    
+    public DictionaryMatcher(DictionaryPredicate predicate) {
+        this.predicate = predicate;
+        
+        this.resultCursor = -1;
+        this.limit = Integer.MAX_VALUE;
+        this.offset = 0;
+    }
+
+    @Override
+    public void open() throws DataFlowException {
+        if (cursor != CLOSED) {
+            return;
+        }
+        try {
+            if (inputOperator == null) {
+                throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+            }
+            
+            predicate.resetDictCursor();
+            currentDictionaryEntry = predicate.getNextDictionaryEntry();
+            if (currentDictionaryEntry == null) {
+                throw new DataFlowException("Dictionary is empty");
+            }
+            
+            KeywordPredicate keywordPredicate = new KeywordPredicate(
+                    currentDictionaryEntry,
+                    predicate.getAttributeList(),
+                    predicate.getAnalyzer(),
+                    predicate.getKeywordMatchingType());
+            
+            keywordMatcher = new KeywordMatcher(keywordPredicate);
+            keywordMatcher.setInputOperator(inputOperator);
+            
+            keywordMatcher.open();
+            outputSchema = keywordMatcher.getOutputSchema();           
+            
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+        cursor = OPENED;
+    }
+
+    @Override
+    public ITuple getNextTuple() throws Exception {
+        if (cursor == CLOSED) {
+            throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
+        }
+        if (resultCursor >= limit + offset - 1){
+            return null;
+        }
+        
+        ITuple sourceTuple;
+        while (true) {
+            // If there's result from current keywordMatcher, return it.
+            if ((sourceTuple = keywordMatcher.getNextTuple()) != null) {
+                resultCursor++;
+                if (resultCursor >= offset){
+                    return sourceTuple;
+                }
+                continue;
+            }
+            // If all results from current keywordMatcher are consumed, 
+            // advance to next dictionary entry, and
+            // return null if reach the end of dictionary.
+            if ((currentDictionaryEntry = predicate.getNextDictionaryEntry()) == null) {
+                return null;
+            }
+            
+            // Construct a new KeywordMatcher with the new dictionary entry.
+            keywordMatcher.close();
+            inputOperator.close();
+            
+            KeywordPredicate keywordPredicate = new KeywordPredicate(
+                    currentDictionaryEntry,
+                    predicate.getAttributeList(),
+                    predicate.getAnalyzer(),
+                    predicate.getKeywordMatchingType());
+            
+            
+            keywordMatcher = new KeywordMatcher(keywordPredicate);
+            keywordMatcher.setInputOperator(inputOperator);
+            
+            keywordMatcher.open();
+        }       
+    }
+
+    @Override
+    public void close() throws DataFlowException {
+        if (cursor == CLOSED) {
+            return;
+        }
+        try {
+            if (keywordMatcher != null) {
+                keywordMatcher.close();
+            }
+            if (inputOperator != null) {
+                inputOperator.close();
+            }
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+        cursor = CLOSED;
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
+    
+    public void setLimit(int limit){
+        this.limit = limit;
+    }
+    
+    public int getLimit(){
+        return this.limit;
+    }
+    
+    public void setOffset(int offset){
+        this.offset = offset;
+    }
+    
+    public int getOffset(){
+        return this.offset;
+    }
+    
+    public void setInputOperator(IOperator inputOperator) {
+        this.inputOperator = inputOperator;
+    }
+    
+    public IOperator getInputOperator() {
+        return inputOperator;
+    }
+
+}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -102,7 +102,7 @@ public class FuzzyTokenMatcher implements IOperator{
                 if (resultTuple != null) {
                     cursor++;
                 }
-                if (cursor >= offset) {
+                if (resultTuple!= null && cursor >= offset){
                     break;
                 }
             }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -121,7 +121,7 @@ public class KeywordMatcher implements IOperator {
 	            if (resultTuple != null) {
             		cursor++;
             	}
-            	if (cursor >= offset) {
+            	if (resultTuple != null && cursor >= offset) {
             		break;
             	}
         	}
@@ -357,7 +357,7 @@ public class KeywordMatcher implements IOperator {
 		return inputOperator;
 	}
 
-	public void setInputOperator(ISourceOperator inputOperator) {
+	public void setInputOperator(IOperator inputOperator) {
 		this.inputOperator = inputOperator;
 	}
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -122,7 +122,7 @@ public class RegexMatcher implements IOperator {
 	            if (resultTuple != null) {
 		            cursor++;
 	            }
-	            if (cursor >= offset){
+	            if (resultTuple!= null && cursor >= offset){
 	            	break;
 	            }
 			}

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -35,6 +35,7 @@ import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.Dictionary;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
+import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
@@ -45,7 +46,6 @@ import edu.uci.ics.textdb.storage.writer.DataWriter;
  */
 public class DictionaryMatcherTest {
 
-    private DictionaryMatcherSourceOperator dictionaryMatcher;
     private DataStore dataStore;
     private IDataWriter dataWriter;
     private Analyzer luceneAnalyzer;
@@ -71,7 +71,12 @@ public class DictionaryMatcherTest {
             List<Attribute> attributes) throws Exception {
 
     	DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, srcOpType);
-    	dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);
+//    	DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);	
+    	
+    	DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
+    	ScanBasedSourceOperator indexSource = dictionaryPredicate.getScanSourceOperator(dataStore);
+    	dictionaryMatcher.setInputOperator(indexSource);
+    	
     	dictionaryMatcher.open();
         ITuple nextTuple = null;
         List<ITuple> results = new ArrayList<ITuple>();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -24,6 +24,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -69,15 +70,40 @@ public class DictionaryMatcherTest {
 
     public List<ITuple> getQueryResults(IDictionary dictionary, KeywordMatchingType srcOpType,
             List<Attribute> attributes) throws Exception {
+        List<ITuple> dictionaryMatcherSourceOperatorResults = 
+                getDictionaryMatcherSourceOperatorResults(dictionary, srcOpType, attributes);
+        List<ITuple> dictionaryMatcherResults = 
+                getDictionaryMatcherResults(dictionary, srcOpType, attributes);
+        
+        Assert.assertTrue(TestUtils.containsAllResults(dictionaryMatcherSourceOperatorResults, dictionaryMatcherResults));
 
-    	DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, srcOpType);
-//    	DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);	
-    	
-    	DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
-    	ScanBasedSourceOperator indexSource = dictionaryPredicate.getScanSourceOperator(dataStore);
-    	dictionaryMatcher.setInputOperator(indexSource);
-    	
-    	dictionaryMatcher.open();
+        return dictionaryMatcherResults;
+    }
+    
+    private List<ITuple> getDictionaryMatcherSourceOperatorResults(IDictionary dictionary, KeywordMatchingType srcOpType,
+            List<Attribute> attributes) throws Exception {
+        DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, srcOpType);
+        DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate, dataStore);    
+
+        dictionaryMatcher.open();
+        ITuple nextTuple = null;
+        List<ITuple> results = new ArrayList<ITuple>();
+        while ((nextTuple = dictionaryMatcher.getNextTuple()) != null) {
+            results.add(nextTuple);
+        }
+        dictionaryMatcher.close();
+        return results;
+    }
+    
+    private List<ITuple> getDictionaryMatcherResults(IDictionary dictionary, KeywordMatchingType srcOpType,
+            List<Attribute> attributes) throws Exception {
+        DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributes, luceneAnalyzer, srcOpType);
+        
+        DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
+        ScanBasedSourceOperator indexSource = dictionaryPredicate.getScanSourceOperator(dataStore);
+        dictionaryMatcher.setInputOperator(indexSource);
+        
+        dictionaryMatcher.open();
         ITuple nextTuple = null;
         List<ITuple> results = new ArrayList<ITuple>();
         while ((nextTuple = dictionaryMatcher.getNextTuple()) != null) {


### PR DESCRIPTION
In PR #204 , we renamed the old DictionaryMatcher to DictionaryMatcherSourceOperator.

This PR adds a new DictionaryMatcher, which is completely separate from IndexSource. It can be connected with any operator.

This PR also fixes a bug across all operators that may cause getNextTuple to return null.