### PR TITLE
Modify Join operator to create the output schema during open()

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -144,6 +144,15 @@ public class Utils {
         Schema newSchema = new Schema(attributes.toArray(new Attribute[attributes.size()]));
         return newSchema;
     }
+    
+    /**
+     * Get the field names of a list of attributes
+     * @param attributeList
+     * @return a list of strings, which are names of each attribute
+     */
+    public static List<String> getAttributeNameList(List<Attribute> attributeList) {
+        return attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList());
+    }
 
     /**
      * Tokenizes the query string using the given analyser

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinPredicate.java
@@ -85,7 +85,7 @@ public class JoinPredicate implements IPredicate {
         this.threshold = threshold;
     }
 
-    public Attribute getIdAttribute() {
+    public Attribute getIDAttribute() {
         return this.idAttribute;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinPredicate.java
@@ -85,11 +85,11 @@ public class JoinPredicate implements IPredicate {
         this.threshold = threshold;
     }
 
-    public Attribute getidAttribute() {
+    public Attribute getIdAttribute() {
         return this.idAttribute;
     }
 
-    public Attribute getjoinAttribute() {
+    public Attribute getJoinAttribute() {
         return this.joinAttribute;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -283,11 +283,9 @@ public class Join implements IOperator {
     }
     
     
-    
-    // create a new Schema called 
-    // outputSchema which is an intersection of Attributes from both the 
-    // inner and outer tuples. This new Schema is then used to form tuples 
-    // returned upon subsequent calls of getNextTuple(). 
+    /*
+     * Create outputSchema, which is the intersection of innerOperator's schema and outerOperator's schema.
+     */
     private void generateIntersectionSchema() throws DataFlowException {
         List<Attribute> innerAttributes = innerOperator.getOutputSchema().getAttributes();
         List<Attribute> outerAttributes = outerOperator.getOutputSchema().getAttributes();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -32,7 +32,7 @@ import edu.uci.ics.textdb.dataflow.common.JoinPredicate;
  * the difference of span ends should be for the join to take place.
  * 
  * Join takes two operators: innerOperator and outerOperator.
- * Each operator have a stream of output tuples, Join performs join on 
+ * Each operator has a stream of output tuples, Join performs join on 
  * two tuples' span lists only if two tuples have the same ID.
  * 
  * Two operators usually have the same schema, but they don't necessarily have to.
@@ -40,9 +40,9 @@ import edu.uci.ics.textdb.dataflow.common.JoinPredicate;
  * For other attributes, join will perform an intersection on them.
  * 
  * Join assumes two tuples are the same if their ID are same.
- * If some attribute value of two tuples are different, if the attribute is the 
+ * If some attribute values of two tuples are different, if the attribute is the 
  * join attribute, the tuple is discarded. If the attribute is not join attribute,
- * then one of the value will be chosen to become the output value.
+ * then one of the values will be chosen to become the output value.
  * 
  * @author Sripad Kowshik Subramanyam (sripadks)
  *

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -138,7 +138,6 @@ public class Join implements IOperator {
                     shouldIGetOuterOperatorNextTuple = true;
                 }
             }
-
             
             nextTuple = joinTuples(outerTuple, innerTuple, joinPredicate);
         } while (nextTuple == null);
@@ -160,8 +159,8 @@ public class Join implements IOperator {
         innerTupleList.clear();
     }
 
-    // check if the ID of two tuples are the same
-    // return null if one of them doesn't have ID field
+    // compare if two tuples have the save value over a field
+    // return null if one of them doesn't have this field
     private boolean compareField(ITuple innerTuple, ITuple outerTuple, String fieldName) {  
         IField innerField = innerTuple.getField(fieldName);
         IField outerField = outerTuple.getField(fieldName);
@@ -255,8 +254,8 @@ public class Join implements IOperator {
         if (newJoinSpanList.isEmpty()) {
             return null;
         }
-
-        
+       
+        // create output fields based on innerTuple's value
         List<IField> outputFields = 
                 outputAttrList.stream()
                 .filter(attr -> ! attr.equals(SchemaConstants.SPAN_LIST_ATTRIBUTE))

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -182,7 +182,7 @@ public class Join implements IOperator {
         // For other fields, we use the value from innerTuple.
 
         // check if the ID fields are the same
-        if (! compareField(innerTuple, outerTuple, joinPredicate.getIdAttribute().getFieldName())) {
+        if (! compareField(innerTuple, outerTuple, joinPredicate.getIDAttribute().getFieldName())) {
             return null;
         }
 
@@ -292,7 +292,7 @@ public class Join implements IOperator {
             throw new DataFlowException("inner operator and outer operator don't share any common attributes");
         } else if (! intersectionAttributes.contains(joinPredicate.getJoinAttribute())) {
             throw new DataFlowException("inner operator or outer operator doesn't contain join attribute");
-        } else if (! intersectionAttributes.contains(joinPredicate.getIdAttribute())) {
+        } else if (! intersectionAttributes.contains(joinPredicate.getIDAttribute())) {
             throw new DataFlowException("inner operator or outer operator doesn't contain ID attribute");
         } else if (! intersectionAttributes.contains(SchemaConstants.SPAN_LIST_ATTRIBUTE)) {
             throw new DataFlowException("inner operator or outer operator doesn't contain spanList attribute");

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -18,22 +18,35 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.dataflow.common.JoinPredicate;
 
+
 /**
+ * The Join operator is an operator which intends to perform a "join" over the
+ * the outputs of two other operators based on certain conditions defined
+ * using the JoinPredicate.
  * 
- * @author sripadks
+ * The JoinPredicate currently takes:
+ * ID attribute -> Which serves as the document/tuple ID. Only for the tuples
+ * whose IDs match, we perform the join.
+ * Join Attribute -> The attribute to perform Join on.
+ * and Threshold -> The value within which the difference of span starts and
+ * the difference of span ends should be for the join to take place.
+ * 
+ * Join takes two operators: innerOperator and outerOperator.
+ * Each operator have a stream of output tuples, Join performs join on 
+ * two tuples' span lists only if two tuples have the same ID.
+ * 
+ * Two operators usually have the same schema, but they don't necessarily have to.
+ * Join requires two operators to share ID attribute and attribute to join.
+ * For other attributes, join will perform an intersection on them.
+ * 
+ * Join assumes two tuples are the same if their ID are same.
+ * If some attribute value of two tuples are different, if the attribute is the 
+ * join attribute, the tuple is discarded. If the attribute is not join attribute,
+ * then one of the value will be chosen to become the output value.
+ * 
+ * @author Sripad Kowshik Subramanyam (sripadks)
  *
  */
-
-// The Join operator is an operator which intends to perform a "join" over the
-// the outputs of two other operators based on certain conditions defined
-// using the JoinPredicate.
-// The JoinPredicate currently takes:
-// ID attribute -> Which serves as the document/tuple ID. Only for the tuples
-// whose IDs match, we perform the join.
-// Join Attribute -> The attribute to perform Join on.
-// and Threshold -> The value within which the difference of span starts and
-// the difference of span ends should be for the join to take place.
-
 public class Join implements IOperator {
 
     private IOperator outerOperator;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -921,11 +921,11 @@ public class JoinTest {
                         + "hilariously so), and pop science writer Mary Roach is " + "always up to the task."),
                 new ListField<>(spanList) };
         ITuple expectedTuple = new DataTuple(new Schema(schemaAttributes), book);
-        List<ITuple> expectedResult = new ArrayList<>();
+        List<ITuple> expectedResult = new ArrayList<>(1);
         expectedResult.add(expectedTuple);
-        
+
         boolean contains = TestUtils.containsAllResults(expectedResult, resultList);
-        
+
         Assert.assertEquals(1, resultList.size());
         Assert.assertTrue(contains);
     }


### PR DESCRIPTION
Join used to create output schema the first time getNextTuple() is called.

We added the getOutputSchema() to IOperator interface a while ago in #190 . Now join is modified to create outputSchema during open(), because its inner and outer operators' output schemas are known during open().