### PR TITLE
Add a RegexMatcher Builder 

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -229,5 +229,9 @@ public class RegexMatcher extends AbstractSingleInputOperator {
     @Override
     protected void cleanUp() throws DataFlowException {        
     }
+
+    public RegexPredicate getPredicate() {
+        return this.regexPredicate;
+    }
     
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
@@ -1,0 +1,20 @@
+package edu.uci.ics.textdb.plangen.operatorbuilder;
+
+/**
+ * RegexMatcherBuilder provides a static function that builds a RegexMatcher.
+ * 
+ * Besides some commonly used properties (properties for attribute list, limit, offset), 
+ * KeywordMatcherBuilder currently needs the following properties:
+ * 
+ *   regex (required)
+ * 
+ * @author Zuozhi Wang
+ *
+ */
+public class RegexMatcherBuilder {
+    
+    public static final String REGEX = "regex";
+    
+    
+
+}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
@@ -1,10 +1,22 @@
 package edu.uci.ics.textdb.plangen.operatorbuilder;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
+import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
+import edu.uci.ics.textdb.plangen.PlanGenUtils;
+
 /**
  * RegexMatcherBuilder provides a static function that builds a RegexMatcher.
  * 
  * Besides some commonly used properties (properties for attribute list, limit, offset), 
- * KeywordMatcherBuilder currently needs the following properties:
+ * RegexMatcherBuilder currently needs the following properties:
  * 
  *   regex (required)
  * 
@@ -15,6 +27,34 @@ public class RegexMatcherBuilder {
     
     public static final String REGEX = "regex";
     
-    
+    /**
+     * Builds a RegexMatcher according to operatorProperties.
+     */
+    public static RegexMatcher buildRegexMatcher(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
+        String regex = OperatorBuilderUtils.getRequiredProperty(REGEX, operatorProperties);
+
+        // check if regex is empty
+        PlanGenUtils.planGenAssert(!regex.trim().isEmpty(), "regex is empty");
+
+        // generate attribute list
+        List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);
+
+        // build RegexMatcher
+        RegexPredicate regexPredicate = new RegexPredicate(regex, attributeList,
+                DataConstants.getTrigramAnalyzer());
+        RegexMatcher regexMatcher = new RegexMatcher(regexPredicate);
+
+        // set limit and offset
+        Integer limitInt = OperatorBuilderUtils.findLimit(operatorProperties);
+        if (limitInt != null) {
+            regexMatcher.setLimit(limitInt);
+        }
+        Integer offsetInt = OperatorBuilderUtils.findOffset(operatorProperties);
+        if (offsetInt != null) {
+            regexMatcher.setOffset(offsetInt);
+        }
+
+        return regexMatcher;
+    }
 
 }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilderTest.java
@@ -1,0 +1,110 @@
+package edu.uci.ics.textdb.plangen.operatorbuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
+import junit.framework.Assert;
+
+/**
+ * Tests cases for RegexMatcherBuilder
+ * @author Zuozhi Wang
+ *
+ */
+public class RegexMatcherBuilderTest {
+
+    /*
+     * test RegexMatcherBuilder with the following properties:
+     *   regex: \b(woman)|(man)|(patient)\b
+     *   attribute list: {content, TEXT}
+     *   limit: default (Integer.MAX_VALUE)
+     *   offset: default (0)
+     * 
+     */
+    @Test
+    public void testRegexMatcherBuilder1() throws PlanGenException, DataFlowException, IOException {
+        String regex = "\\b(woman)|(man)|(patient)\\b";
+        
+        HashMap<String, String> regexProperties = new HashMap<>();
+        regexProperties.put(RegexMatcherBuilder.REGEX, regex);
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        
+        RegexMatcher regexMatcher = RegexMatcherBuilder.buildRegexMatcher(regexProperties);
+        
+        Assert.assertEquals(regex, regexMatcher.getPredicate().getRegex());
+        List<Attribute> regexAttrList = Arrays.asList(
+                new Attribute("content", FieldType.TEXT));
+        Assert.assertEquals(regexAttrList.toString(), regexMatcher.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(Integer.MAX_VALUE, regexMatcher.getLimit());
+        Assert.assertEquals(0, regexMatcher.getOffset());    
+    }
+    
+    /*
+     * test RegexMatcherBuilder with the following properties:
+     *   regex: (19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])
+     *   attribute list: {date, DATE}, {amount, INTEGER}, {description, TEXT}
+     *   limit: 100
+     *   offset: 11
+     * 
+     */
+    @Test
+    public void testRegexMatcherBuilder2() throws PlanGenException, DataFlowException, IOException {
+        String regex = "(19|20)\\d\\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])";
+        
+        HashMap<String, String> regexProperties = new HashMap<>();
+        regexProperties.put(RegexMatcherBuilder.REGEX, regex);
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "date, amount, description");
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "DATE, INTEGER, TEXT");
+        regexProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        regexProperties.put(OperatorBuilderUtils.OFFSET, "11");
+        
+        RegexMatcher regexMatcher = RegexMatcherBuilder.buildRegexMatcher(regexProperties);
+        
+        Assert.assertEquals(regex, regexMatcher.getPredicate().getRegex());
+        List<Attribute> regexAttrList = Arrays.asList(
+                new Attribute("date", FieldType.DATE), 
+                new Attribute("amount", FieldType.INTEGER), 
+                new Attribute("description", FieldType.TEXT));
+        Assert.assertEquals(regexAttrList.toString(), regexMatcher.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(100, regexMatcher.getLimit());
+        Assert.assertEquals(11, regexMatcher.getOffset());    
+    }
+    
+    /*
+     * test invalid RegexMatcherBuilder with missing regex properties
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidRegexMatcherBuilder1() throws PlanGenException, DataFlowException, IOException {
+        HashMap<String, String> regexProperties = new HashMap<>();
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "date, amount, description");
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "DATE, INTEGER, TEXT");
+        regexProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        regexProperties.put(OperatorBuilderUtils.OFFSET, "11");
+        
+        RegexMatcherBuilder.buildRegexMatcher(regexProperties); 
+    }
+    
+    /*
+     * test invalid RegexMatcherBuilder with empty regex
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidRegexMatcherBuilder2() throws PlanGenException, DataFlowException, IOException {
+        HashMap<String, String> regexProperties = new HashMap<>();
+        regexProperties.put(RegexMatcherBuilder.REGEX, "");
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "date, amount, description");
+        regexProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "DATE, INTEGER, TEXT");
+        regexProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        regexProperties.put(OperatorBuilderUtils.OFFSET, "11");
+        
+        RegexMatcherBuilder.buildRegexMatcher(regexProperties); 
+    }
+}


### PR DESCRIPTION
Similar to #220 , this PR adds a RegexMatcher Builder to build a RegexMatcher operator from a given set of properties (a map of <String, String> representing properties).