### PR TITLE
Add a FuzzyTokenMatcher Builder

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -113,4 +113,12 @@ public class FuzzyTokenPredicate implements IPredicate {
         return dataReaderPredicate;
     }
 
+    public String getQuery() {
+        return this.query;
+    }
+
+    public double getThresholdRatio() {
+        return this.thresholdRatio;
+    }
+
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -15,6 +15,7 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
+import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
 
 /**
  *  @author Zuozhi Wang (zuozhiw)
@@ -130,6 +131,10 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
 
     @Override
     protected void cleanUp() throws DataFlowException {        
+    }
+
+    public FuzzyTokenPredicate getPredicate() {
+        return this.predicate;
     }
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -15,7 +15,6 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
-import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
 
 /**
  *  @author Zuozhi Wang (zuozhiw)

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
@@ -1,0 +1,72 @@
+package edu.uci.ics.textdb.plangen.operatorbuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
+import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;
+import edu.uci.ics.textdb.plangen.PlanGenUtils;
+
+/**
+ * FuzzyTokenMatcherBuilder provides a static function that builds a FuzzyTokenMatcher.
+ * 
+ * Besides some commonly used properties (properties for attribute list, limit, offset), 
+ * FuzzyTokenMatcherBuilder currently needs the following properties:
+ * 
+ *   query (required)
+ *   threshold (required)
+ * 
+ * @author Zuozhi Wang
+ *
+ */
+public class FuzzyTokenMatcherBuilder {
+    public static final String QUERY = "query";
+    public static final String THRESHOLD_RATIO = "thresholdRatio";
+    
+    /**
+     * Builds a FuzzyTokenMatcher according to operatorProperties.
+     */
+    public static FuzzyTokenMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
+        String query = OperatorBuilderUtils.getRequiredProperty(QUERY, operatorProperties);
+        String thresholdStr = OperatorBuilderUtils.getRequiredProperty(THRESHOLD_RATIO, operatorProperties);
+
+        // check if query is empty
+        PlanGenUtils.planGenAssert(!query.trim().isEmpty(), "query is empty");
+
+        // generate attribute list
+        List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);
+        
+        // generate threshold ratio double
+        Double thresholdRatioDouble = generateThresholdDouble(thresholdStr);
+
+        // build FuzzyTokenMatcher
+        FuzzyTokenPredicate fuzzyTokenPredicate = new FuzzyTokenPredicate(query, attributeList,
+                DataConstants.getStandardAnalyzer(), thresholdRatioDouble);
+        FuzzyTokenMatcher fuzzyTokenMatcher = new FuzzyTokenMatcher(fuzzyTokenPredicate);
+
+        // set limit and offset
+        Integer limitInt = OperatorBuilderUtils.findLimit(operatorProperties);
+        if (limitInt != null) {
+            fuzzyTokenMatcher.setLimit(limitInt);
+        }
+        Integer offsetInt = OperatorBuilderUtils.findOffset(operatorProperties);
+        if (offsetInt != null) {
+            fuzzyTokenMatcher.setOffset(offsetInt);
+        }
+
+        return fuzzyTokenMatcher;
+    }
+    
+    private static Double generateThresholdDouble(String thresholdStr) throws PlanGenException {
+        Double thresholdDouble = Double.parseDouble(thresholdStr);
+        if (thresholdDouble < 0.0 || thresholdDouble > 1.0) {
+            throw new PlanGenException("fuzzy token threshold ratio must be between 0.0 and 1.0 (inclusive)");
+        }
+        return thresholdDouble;
+    }
+}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
@@ -25,14 +25,14 @@ import edu.uci.ics.textdb.plangen.PlanGenUtils;
  *
  */
 public class FuzzyTokenMatcherBuilder {
-    public static final String QUERY = "query";
+    public static final String FUZZY_STRING = "fuzzyString";
     public static final String THRESHOLD_RATIO = "thresholdRatio";
     
     /**
      * Builds a FuzzyTokenMatcher according to operatorProperties.
      */
     public static FuzzyTokenMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
-        String query = OperatorBuilderUtils.getRequiredProperty(QUERY, operatorProperties);
+        String query = OperatorBuilderUtils.getRequiredProperty(FUZZY_STRING, operatorProperties);
         String thresholdStr = OperatorBuilderUtils.getRequiredProperty(THRESHOLD_RATIO, operatorProperties);
 
         // check if query is empty

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
@@ -1,0 +1,204 @@
+package edu.uci.ics.textdb.plangen.operatorbuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;
+import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
+import junit.framework.Assert;
+
+/**
+ * Tests cases for FuzzyTokenMatcherBuilder
+ * @author Zuozhi Wang
+ *
+ */
+public class FuzzyTokenMatcherBuilderTest {
+    
+    /*
+     * test FuzzyTokenMatcherBuilder with the following properties:
+     *   query: "test with fuzzy token matcher builder"
+     *   thresholdRatio: 0.5
+     *   attribute list: {content, TEXT}
+     *   limit: 100
+     *   offset: 11
+     * 
+     */
+    @Test
+    public void testFuzzyTokenMatcherBuilder1() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0.5");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+     
+        FuzzyTokenMatcher fuzzyTokenMatcher = FuzzyTokenMatcherBuilder.buildOperator(operatorProperties);
+        
+        Assert.assertEquals(query, fuzzyTokenMatcher.getPredicate().getQuery());
+        Assert.assertEquals(0.5, fuzzyTokenMatcher.getPredicate().getThresholdRatio());
+        List<Attribute> attrList = Arrays.asList(
+                new Attribute("content", FieldType.TEXT));
+        Assert.assertEquals(attrList.toString(), fuzzyTokenMatcher.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(100, fuzzyTokenMatcher.getLimit());
+        Assert.assertEquals(11, fuzzyTokenMatcher.getOffset());   
+    }
+    
+    /*
+     * test FuzzyTokenMatcherBuilder a corner case thresholdRatio: 1
+     * 
+     */
+    @Test
+    public void testFuzzyTokenMatcherBuilder2() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "1");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+     
+        FuzzyTokenMatcher fuzzyTokenMatcher = FuzzyTokenMatcherBuilder.buildOperator(operatorProperties);
+        
+        Assert.assertEquals(query, fuzzyTokenMatcher.getPredicate().getQuery());
+        Assert.assertEquals(1.0, fuzzyTokenMatcher.getPredicate().getThresholdRatio());
+        List<Attribute> attrList = Arrays.asList(
+                new Attribute("content", FieldType.TEXT));
+        Assert.assertEquals(attrList.toString(), fuzzyTokenMatcher.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(100, fuzzyTokenMatcher.getLimit());
+        Assert.assertEquals(11, fuzzyTokenMatcher.getOffset());   
+    }
+    
+    /*
+     * test FuzzyTokenMatcherBuilder a corner case thresholdRatio: 0
+     * 
+     */
+    @Test
+    public void testFuzzyTokenMatcherBuilder3() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+     
+        FuzzyTokenMatcher fuzzyTokenMatcher = FuzzyTokenMatcherBuilder.buildOperator(operatorProperties);
+        
+        Assert.assertEquals(query, fuzzyTokenMatcher.getPredicate().getQuery());
+        Assert.assertEquals(0.0, fuzzyTokenMatcher.getPredicate().getThresholdRatio());
+        List<Attribute> attrList = Arrays.asList(
+                new Attribute("content", FieldType.TEXT));
+        Assert.assertEquals(attrList.toString(), fuzzyTokenMatcher.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(100, fuzzyTokenMatcher.getLimit());
+        Assert.assertEquals(11, fuzzyTokenMatcher.getOffset());   
+    }
+    
+    /*
+     * test invalid FuzzyTokenMatcherBuilder with missing query property
+     * 
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidFuzzyTokenMatcherBuilder1() throws PlanGenException, DataFlowException, IOException {
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0.5");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+       
+        FuzzyTokenMatcherBuilder.buildOperator(operatorProperties); 
+    }
+    
+    /*
+     * test invalid FuzzyTokenMatcherBuilder with empty query
+     * 
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidFuzzyTokenMatcherBuilder2() throws PlanGenException, DataFlowException, IOException {
+        String query = "";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0.5");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+       
+        FuzzyTokenMatcherBuilder.buildOperator(operatorProperties); 
+    }
+    
+    /*
+     * test invalid FuzzyTokenMatcherBuilder with missing thresholdRatio property
+     * 
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidFuzzyTokenMatcherBuilder3() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+       
+        FuzzyTokenMatcherBuilder.buildOperator(operatorProperties); 
+    }
+
+    /*
+     * test invalid FuzzyTokenMatcherBuilder with invalid thresholdRatio property
+     * 
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidFuzzyTokenMatcherBuilder4() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "100");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+       
+        FuzzyTokenMatcherBuilder.buildOperator(operatorProperties); 
+    }
+    
+    /*
+     * test invalid FuzzyTokenMatcherBuilder with invalid thresholdRatio property
+     * 
+     */
+    @Test(expected = PlanGenException.class)
+    public void testInvalidFuzzyTokenMatcherBuilder5() throws PlanGenException, DataFlowException, IOException {
+        String query = "test with fuzzy token matcher builder";
+        
+        HashMap<String, String> operatorProperties = new HashMap<>();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "-1.2");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
+        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
+        operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
+        operatorProperties.put(OperatorBuilderUtils.OFFSET, "11");
+       
+        FuzzyTokenMatcherBuilder.buildOperator(operatorProperties); 
+    }
+    
+
+}

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
@@ -12,7 +12,6 @@ import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;
-import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
 import junit.framework.Assert;
 
 /**
@@ -36,7 +35,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0.5");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
@@ -63,7 +62,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "1");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
@@ -90,7 +89,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
@@ -109,7 +108,7 @@ public class FuzzyTokenMatcherBuilderTest {
     }
     
     /*
-     * test invalid FuzzyTokenMatcherBuilder with missing query property
+     * test invalid FuzzyTokenMatcherBuilder by missing a query property
      * 
      */
     @Test(expected = PlanGenException.class)
@@ -126,7 +125,7 @@ public class FuzzyTokenMatcherBuilderTest {
     }
     
     /*
-     * test invalid FuzzyTokenMatcherBuilder with empty query
+     * test invalid FuzzyTokenMatcherBuilder by an empty query
      * 
      */
     @Test(expected = PlanGenException.class)
@@ -134,7 +133,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "0.5");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
@@ -145,7 +144,7 @@ public class FuzzyTokenMatcherBuilderTest {
     }
     
     /*
-     * test invalid FuzzyTokenMatcherBuilder with missing thresholdRatio property
+     * test invalid FuzzyTokenMatcherBuilder by missing a thresholdRatio property
      * 
      */
     @Test(expected = PlanGenException.class)
@@ -153,7 +152,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
         operatorProperties.put(OperatorBuilderUtils.LIMIT, "100");
@@ -163,7 +162,7 @@ public class FuzzyTokenMatcherBuilderTest {
     }
 
     /*
-     * test invalid FuzzyTokenMatcherBuilder with invalid thresholdRatio property
+     * test invalid FuzzyTokenMatcherBuilder by an invalid thresholdRatio property
      * 
      */
     @Test(expected = PlanGenException.class)
@@ -171,7 +170,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "100");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
@@ -182,7 +181,7 @@ public class FuzzyTokenMatcherBuilderTest {
     }
     
     /*
-     * test invalid FuzzyTokenMatcherBuilder with invalid thresholdRatio property
+     * test invalid FuzzyTokenMatcherBuilder with an invalid thresholdRatio property
      * 
      */
     @Test(expected = PlanGenException.class)
@@ -190,7 +189,7 @@ public class FuzzyTokenMatcherBuilderTest {
         String query = "test with fuzzy token matcher builder";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(FuzzyTokenMatcherBuilder.QUERY, query);
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, query);
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, "-1.2");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");


### PR DESCRIPTION
Similar to #220 and #221 , this PR adds a FuzzyTokenMatcher Builder to build a FuzzyTokenMatcher operator from a given set of properties (a map of <String, String> representing properties).