### PR TITLE
Refactor abstract sink, index sink, and file sink

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/AbstractSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/AbstractSink.java
@@ -16,10 +16,6 @@ public abstract class AbstractSink implements ISink {
 
     private IOperator inputOperator;
 
-    public AbstractSink(IOperator inputOperator) {
-        this.inputOperator = inputOperator;
-    }
-
     /**
      * @about Opens the child operator.
      */
@@ -38,13 +34,11 @@ public abstract class AbstractSink implements ISink {
 
     @Override
     public void processTuples() throws Exception {
-
         ITuple nextTuple;
 
         while ((nextTuple = inputOperator.getNextTuple()) != null) {
             processOneTuple(nextTuple);
         }
-
     }
 
     /**

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/FileSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/FileSink.java
@@ -5,7 +5,6 @@ import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 
 import edu.uci.ics.textdb.api.common.ITuple;
-import edu.uci.ics.textdb.api.dataflow.IOperator;
 
 /**
  * Created by chenli on 5/11/16.
@@ -13,13 +12,22 @@ import edu.uci.ics.textdb.api.dataflow.IOperator;
  * This class serializes each tuple from the subtree to a given file.
  */
 public class FileSink extends AbstractSink {
+    
+    @FunctionalInterface
+    public static interface TupleToString {
+        String convertToString(ITuple tuple);
+    }
 
     private PrintWriter printWriter;
-    private final File file;
-
-    public FileSink(IOperator childOperator, File file) throws FileNotFoundException {
-        super(childOperator);
+    private final File file;   
+    private TupleToString toStringFunction = (tuple -> tuple.toString());
+    
+    public FileSink(File file) throws FileNotFoundException {
         this.file = file;
+    }
+    
+    public void setToStringFunction(TupleToString toStringFunction) {
+        this.toStringFunction = toStringFunction;
     }
 
     @Override
@@ -38,6 +46,6 @@ public class FileSink extends AbstractSink {
 
     @Override
     protected void processOneTuple(ITuple nextTuple) {
-        printWriter.write(nextTuple.toString());
+        printWriter.write(toStringFunction.convertToString(nextTuple));
     }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/IndexSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/IndexSink.java
@@ -4,7 +4,6 @@ import org.apache.lucene.analysis.Analyzer;
 
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
@@ -18,14 +17,7 @@ public class IndexSink extends AbstractSink {
 
     private DataWriter dataWriter;
 
-    public IndexSink(IOperator inputOperator, String indexDirectory, Schema schema, Analyzer luceneAnalyzer) {
-        super(inputOperator);
-        DataStore dataStore = new DataStore(indexDirectory, schema);
-        this.dataWriter = new DataWriter(dataStore, luceneAnalyzer);
-    }
-
     public IndexSink(String indexDirectory, Schema schema, Analyzer luceneAnalyzer) {
-        super(null);
         DataStore dataStore = new DataStore(indexDirectory, schema);
         this.dataWriter = new DataWriter(dataStore, luceneAnalyzer);
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/AbstractSinkTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/AbstractSinkTest.java
@@ -15,12 +15,13 @@ public class AbstractSinkTest {
     @Before
     public void setUp() {
         childOperator = Mockito.mock(IOperator.class);
-        sink = new AbstractSink(childOperator) {
+        sink = new AbstractSink() {
             @Override
             protected void processOneTuple(ITuple nextTuple) {
 
             }
         };
+        sink.setInputOperator(childOperator);
     }
 
     @Test

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/FileSinkTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/FileSinkTest.java
@@ -21,7 +21,8 @@ public class FileSinkTest {
     public void setUp() throws FileNotFoundException {
         childOperator = Mockito.mock(IOperator.class);
         file = new File("sample.txt");
-        fileSink = new FileSink(childOperator, file);
+        fileSink = new FileSink(file);
+        fileSink.setInputOperator(childOperator);
     }
 
     @After


### PR DESCRIPTION
This PR refactors abstract sink, index sink, and file sink in order to make them consistent with other operators by using `setInputOperator` instead of passing inputOperator in constructor.