### PR TITLE
[Issue #238]Modify OperatorGraph to make it only throw PlanGenException

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/OperatorGraph.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/OperatorGraph.java
@@ -43,9 +43,9 @@ public class OperatorGraph {
      * @param operatorID, a unique ID of the operator
      * @param operatorType, the type of the operator
      * @param operatorProperties, a key-value pair map of the properties of the operator
-     * @throws Exception 
+     * @throws PlanGenException 
      */
-    public void addOperator(String operatorID, String operatorType, Map<String, String> operatorProperties) throws Exception {
+    public void addOperator(String operatorID, String operatorType, Map<String, String> operatorProperties) throws PlanGenException {
         PlanGenUtils.planGenAssert(operatorID != null, "operatorID is null");
         PlanGenUtils.planGenAssert(operatorType != null, "operatorType is null");
         PlanGenUtils.planGenAssert(operatorProperties != null, "operatorProperties is null");
@@ -100,9 +100,9 @@ public class OperatorGraph {
      * Builds and returns the query plan from the operator graph.
      * 
      * @return the plan generated from the operator graph
-     * @throws Exception, if the operator graph is invalid.
+     * @throws PlanGenException, if the operator graph is invalid.
      */
-    public Plan buildQueryPlan() throws Exception {
+    public Plan buildQueryPlan() throws PlanGenException {
         validateOperatorGraph();
         connectOperators();
         ISink sink = findSinkOperator();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/PlanGenUtils.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/PlanGenUtils.java
@@ -26,7 +26,7 @@ public class PlanGenUtils {
     
     @FunctionalInterface
     public interface OperatorBuilder {
-        public IOperator buildOperator(Map<String, String> operatorProperties) throws Exception;
+        public IOperator buildOperator(Map<String, String> operatorProperties) throws PlanGenException;
     }
     
     public static Map<String, OperatorBuilder> operatorBuilderMap = new HashMap<>();
@@ -42,7 +42,7 @@ public class PlanGenUtils {
         operatorBuilderMap.put("Join".toLowerCase(), JoinBuilder::buildOperator);
     }
     
-    public static IOperator buildOperator(String operatorType, Map<String, String> operatorProperties) throws Exception {
+    public static IOperator buildOperator(String operatorType, Map<String, String> operatorProperties) throws PlanGenException {
         OperatorBuilder operatorBuilder = operatorBuilderMap.get(operatorType.toLowerCase());
         planGenAssert(operatorBuilder != null, 
                 String.format("operatorType %s is invalid. It must be one of %s.", operatorType, operatorBuilderMap.keySet()));

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionaryMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionaryMatcherBuilder.java
@@ -33,7 +33,7 @@ public class DictionaryMatcherBuilder {
     /**
      * Builds a DictionaryMatcher according to operatorProperties.
      */
-    public static DictionaryMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException {
+    public static DictionaryMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException {
         String dictionaryStr = OperatorBuilderUtils.getRequiredProperty(DICTIONARY, operatorProperties);
         String matchingTypeStr = OperatorBuilderUtils.getRequiredProperty(MATCHING_TYPE, operatorProperties);
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
@@ -31,7 +31,7 @@ public class FuzzyTokenMatcherBuilder {
     /**
      * Builds a FuzzyTokenMatcher according to operatorProperties.
      */
-    public static FuzzyTokenMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
+    public static FuzzyTokenMatcher buildOperator(Map<String, String> operatorProperties) throws PlanGenException {
         String query = OperatorBuilderUtils.getRequiredProperty(FUZZY_STRING, operatorProperties);
         String thresholdStr = OperatorBuilderUtils.getRequiredProperty(THRESHOLD_RATIO, operatorProperties);
 
@@ -45,8 +45,13 @@ public class FuzzyTokenMatcherBuilder {
         Double thresholdRatioDouble = generateThresholdDouble(thresholdStr);
 
         // build FuzzyTokenMatcher
-        FuzzyTokenPredicate fuzzyTokenPredicate = new FuzzyTokenPredicate(query, attributeList,
-                DataConstants.getStandardAnalyzer(), thresholdRatioDouble);
+        FuzzyTokenPredicate fuzzyTokenPredicate;
+        try {
+            fuzzyTokenPredicate = new FuzzyTokenPredicate(query, attributeList,
+                    DataConstants.getStandardAnalyzer(), thresholdRatioDouble);
+        } catch (DataFlowException e) {
+            throw new PlanGenException(e.getMessage(), e);
+        }
         FuzzyTokenMatcher fuzzyTokenMatcher = new FuzzyTokenMatcher(fuzzyTokenPredicate);
 
         // set limit and offset

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
@@ -35,7 +35,7 @@ public class KeywordMatcherBuilder {
     /**
      * Builds a KeywordMatcher according to operatorProperties.
      */
-    public static KeywordMatcher buildKeywordMatcher(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException {
+    public static KeywordMatcher buildKeywordMatcher(Map<String, String> operatorProperties) throws PlanGenException {
         String keyword = OperatorBuilderUtils.getRequiredProperty(KEYWORD, operatorProperties);
         String matchingTypeStr = OperatorBuilderUtils.getRequiredProperty(MATCHING_TYPE, operatorProperties);
 
@@ -52,8 +52,13 @@ public class KeywordMatcherBuilder {
                 + "must be one of " + KeywordMatcherBuilder.keywordMatchingTypeMap.keySet());
 
         // build KeywordMatcher
-        KeywordPredicate keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                DataConstants.getStandardAnalyzer(), matchingType);
+        KeywordPredicate keywordPredicate;
+        try {
+            keywordPredicate = new KeywordPredicate(keyword, attributeList,
+                    DataConstants.getStandardAnalyzer(), matchingType);
+        } catch (DataFlowException e) {
+            throw new PlanGenException(e.getMessage(), e);
+        }
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
 
         // set limit and offset

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -31,7 +31,7 @@ import edu.uci.ics.textdb.storage.DataStore;
 public class KeywordSourceBuilder {
     
     public static KeywordMatcherSourceOperator buildSourceOperator(Map<String, String> operatorProperties) 
-            throws PlanGenException, DataFlowException {
+            throws PlanGenException {
         String keyword = OperatorBuilderUtils.getRequiredProperty(
                 KeywordMatcherBuilder.KEYWORD, operatorProperties);
         String matchingTypeStr = OperatorBuilderUtils.getRequiredProperty(
@@ -49,8 +49,13 @@ public class KeywordSourceBuilder {
                 "the matching type: "+ matchingTypeStr +" is not valid. "
                 + "It must be one of " + KeywordMatcherBuilder.keywordMatchingTypeMap.keySet());
         
-        KeywordPredicate keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                DataConstants.getStandardAnalyzer(), matchingType);
+        KeywordPredicate keywordPredicate;
+        try {
+            keywordPredicate = new KeywordPredicate(keyword, attributeList,
+                    DataConstants.getStandardAnalyzer(), matchingType);     
+        } catch (DataFlowException e) {
+            throw new PlanGenException(e.getMessage(), e);
+        }
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/NlpExtractorBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/NlpExtractorBuilder.java
@@ -30,7 +30,7 @@ public class NlpExtractorBuilder {
     /**
      * Builds a NlpExtractor according to operatorProperties.
      */
-    public static NlpExtractor buildOperator(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
+    public static NlpExtractor buildOperator(Map<String, String> operatorProperties) throws PlanGenException {
         String nlpTypeStr = OperatorBuilderUtils.getRequiredProperty(NLP_TYPE, operatorProperties);
 
         // check if nlpType is valid

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
@@ -30,7 +30,7 @@ public class RegexMatcherBuilder {
     /**
      * Builds a RegexMatcher according to operatorProperties.
      */
-    public static RegexMatcher buildRegexMatcher(Map<String, String> operatorProperties) throws PlanGenException, DataFlowException, IOException {
+    public static RegexMatcher buildRegexMatcher(Map<String, String> operatorProperties) throws PlanGenException {
         String regex = OperatorBuilderUtils.getRequiredProperty(REGEX, operatorProperties);
 
         // check if regex is empty
@@ -40,8 +40,13 @@ public class RegexMatcherBuilder {
         List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);
 
         // build RegexMatcher
-        RegexPredicate regexPredicate = new RegexPredicate(regex, attributeList,
-                DataConstants.getTrigramAnalyzer());
+        RegexPredicate regexPredicate;
+        try {
+            regexPredicate = new RegexPredicate(regex, attributeList,
+                    DataConstants.getTrigramAnalyzer());
+        } catch (DataFlowException | IOException e) {
+            throw new PlanGenException(e.getMessage(), e);
+        }
         RegexMatcher regexMatcher = new RegexMatcher(regexPredicate);
 
         // set limit and offset


### PR DESCRIPTION
This PR modifies the OperatorGraph and some Operator Builders, to catch other types of exceptions and re-throw PlanGenException.