### PR TITLE
[Issue #259] Add processOneInputTuple to AbstractSingleSourceOperator

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
@@ -33,7 +33,7 @@ public abstract class AbstractSingleInputOperator implements IOperator {
     protected int offset = 0;
     
     @Override
-    public void open() throws DataFlowException {
+    public void open() throws Exception {
         if (cursor != CLOSED) {
             return;
         }
@@ -58,7 +58,7 @@ public abstract class AbstractSingleInputOperator implements IOperator {
     protected abstract void setUp() throws DataFlowException;
 
     @Override
-    public ITuple getNextTuple() throws DataFlowException {
+    public ITuple getNextTuple() throws Exception {
         if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
@@ -90,6 +90,8 @@ public abstract class AbstractSingleInputOperator implements IOperator {
      * @throws Exception
      */
     protected abstract ITuple computeNextMatchingTuple() throws Exception;
+
+    public abstract ITuple processOneInputTuple(ITuple tuple) throws DataFlowException;
 
     @Override
     public void close() throws DataFlowException {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -31,30 +31,36 @@ public class ComparableMatcher<T extends Comparable> extends AbstractSingleInput
         ITuple resultTuple = null;
 
         while ((inputTuple = inputOperator.getNextTuple()) != null) {
-            Attribute attribute = predicate.getAttribute();
-            DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
-
-            FieldType fieldType = attribute.getFieldType();
-            String fieldName = attribute.getFieldName();
-
-            T value;
-            T threshold;
-            try {
-                value = (T) inputTuple.getField(fieldName).getValue();
-                threshold = (T) predicate.getThreshold();
-            } catch (ClassCastException e) {
-                continue;
-            }
-
-            if (compareValues(value, threshold, operatorType)) {
-                resultTuple = inputTuple;
-            }
+            resultTuple = processOneInputTuple(inputTuple);
 
             if (resultTuple != null) {
                 break;
             }
         }
         return resultTuple;
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple tuple) throws DataFlowException {
+        Attribute attribute = predicate.getAttribute();
+        DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
+
+        FieldType fieldType = attribute.getFieldType();
+        String fieldName = attribute.getFieldName();
+
+        T value;
+        T threshold;
+        try {
+            value = (T) tuple.getField(fieldName).getValue();
+            threshold = (T) predicate.getThreshold();
+        } catch (ClassCastException e) {
+            return null;
+        }
+
+        if (compareValues(value, threshold, operatorType)) {
+            return tuple;
+        }
+        return null;
     }
 
     private boolean compareValues(T value, T threshold, DataConstants.NumberMatchingType operatorType) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -74,8 +74,9 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
         }
         return resultTuple;
     }
-    
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
         List<Span> payload = (List<Span>) inputTuple.getField(SchemaConstants.PAYLOAD).getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -51,32 +51,39 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         ITuple resultTuple = null;
         
         while ((inputTuple = inputOperator.getNextTuple()) != null) {
-            
-            // There's an implicit assumption that, in open() method, PAYLOAD is
-            // checked before SPAN_LIST.
-            // Therefore, PAYLOAD needs to be checked and added first
-            if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
-                inputTuple = Utils.getSpanTuple(inputTuple.getFields(),
-                        Utils.generatePayloadFromTuple(inputTuple, predicate.getLuceneAnalyzer()), outputSchema);
-            }
-            if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
-                inputTuple = Utils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
-            }
+            resultTuple = processOneInputTuple(inputTuple);
 
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-                resultTuple = computeConjunctionMatchingResult(inputTuple);
-            }
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
-                resultTuple = computePhraseMatchingResult(inputTuple);
-            }
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
-                resultTuple = computeSubstringMatchingResult(inputTuple);
-            }
-            
             if (resultTuple != null) {
                 break;
             }
         }
+        return resultTuple;
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple tuple) throws DataFlowException {
+        ITuple resultTuple = null;
+        // There's an implicit assumption that, in open() method, PAYLOAD is
+        // checked before SPAN_LIST.
+        // Therefore, PAYLOAD needs to be checked and added first
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            tuple = Utils.getSpanTuple(tuple.getFields(),
+                    Utils.generatePayloadFromTuple(tuple, predicate.getLuceneAnalyzer()), outputSchema);
+        }
+        if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+            tuple = Utils.getSpanTuple(tuple.getFields(), new ArrayList<Span>(), outputSchema);
+        }
+
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+            resultTuple = computeConjunctionMatchingResult(tuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+            resultTuple = computePhraseMatchingResult(tuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
+            resultTuple = computeSubstringMatchingResult(tuple);
+        }
+
         return resultTuple;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -52,6 +52,11 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     }
 
     @Override
+    public ITuple processOneInputTuple(ITuple tuple) throws DataFlowException {
+        return this.keywordMatcher.processOneInputTuple(tuple);
+    }
+
+    @Override
     protected void cleanUp() throws DataFlowException {        
     }
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -79,7 +79,8 @@ public class NlpExtractor extends AbstractSingleInputOperator {
         return resultTuple;
     }
 
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
         List<Span> matchingResults = new ArrayList<>();
         for (Attribute attribute : predicate.getAttributeList()) {
             String fieldName = attribute.getFieldName();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
@@ -42,15 +42,19 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
         if (inputTuple == null) {
             return null;
         }
-        
-        IField[] outputFields = 
-                outputSchema.getAttributes()
-                .stream()
-                .map(attr -> inputTuple.getField(attr.getFieldName()))
-                .toArray(IField[]::new);
-        
-        return new DataTuple(outputSchema, outputFields); 
 
+        return processOneInputTuple(inputTuple);
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple tuple) throws DataFlowException {
+        IField[] outputFields =
+                outputSchema.getAttributes()
+                        .stream()
+                        .map(attr -> tuple.getField(attr.getFieldName()))
+                        .toArray(IField[]::new);
+
+        return new DataTuple(outputSchema, outputFields);
     }
 
     @Override

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -114,7 +114,8 @@ public class RegexMatcher extends AbstractSingleInputOperator {
      *         in the document
      * @throws DataFlowException
      */
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
         if (inputTuple == null) {
             return null;
         }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
@@ -62,7 +62,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getDoubleQueryResults(double threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws Exception {
         // Perform the query
         ComparablePredicate<Double> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Double> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -71,7 +71,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getIntegerQueryResults(int threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws Exception {
         // Perform the query
         ComparablePredicate<Integer> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Integer> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -80,7 +80,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getDateQueryResults(Date threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws Exception {
         // Perform the query
         ComparablePredicate<Date> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Date> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -88,7 +88,7 @@ public class ComparableMatcherTest {
         return getQueryResults(comparableMatcher);
     }
 
-    public void setDefaultMatcherConfig(ComparableMatcher comparableMatcher) throws DataFlowException {
+    public void setDefaultMatcherConfig(ComparableMatcher comparableMatcher) throws Exception {
         // Perform the query
         ScanBasedSourceOperator sourceOperator = getScanSourceOperator(dataStore);
         comparableMatcher.setInputOperator(sourceOperator);
@@ -97,7 +97,7 @@ public class ComparableMatcherTest {
         comparableMatcher.setOffset(0);
     }
 
-    public List<ITuple> getQueryResults(ComparableMatcher comparableMatcher) throws DataFlowException {
+    public List<ITuple> getQueryResults(ComparableMatcher comparableMatcher) throws Exception {
         List<ITuple> returnedResults = new ArrayList<>();
         ITuple nextTuple = null;
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
@@ -64,7 +64,7 @@ public class OneToNBroadcastConnectorTest {
      * This test connects Connector with Projection
      */
     @Test
-    public void testTwoOutputsWithProjection() throws DataFlowException {
+    public void testTwoOutputsWithProjection() throws Exception {
         IOperator sourceOperator = getScanSourceOperator(dataStore);
         
         List<String> projectionFields = Arrays.asList(

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
@@ -64,17 +64,17 @@ public class FuzzyTokenMatcherTest {
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws Exception {
         return getQueryResults(query, threshold, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList,
-            int limit) throws DataFlowException, ParseException {
+            int limit) throws Exception {
         return getQueryResults(query, threshold, attributeList, limit, 0);
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList,
-            int limit, int offset) throws DataFlowException, ParseException {
+            int limit, int offset) throws Exception {
 
         FuzzyTokenPredicate predicate = new FuzzyTokenPredicate(query, attributeList, analyzer, threshold);
         fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -73,19 +73,19 @@ public class KeywordMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws Exception {
 
         return getPeopleQueryResults(query, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit)
-            throws DataFlowException, ParseException {
+            throws Exception {
 
         return getPeopleQueryResults(query, attributeList, limit, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
-            throws DataFlowException, ParseException {
+            throws Exception {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
@@ -346,7 +346,7 @@ public class KeywordMatcherTest {
     }
 
     @Test
-    public void testMatchingWithLimit() throws DataFlowException, ParseException, java.text.ParseException {
+    public void testMatchingWithLimit() throws Exception {
         String query = "angry";
         ArrayList<Attribute> attributeList = new ArrayList<>();
         attributeList.add(TestConstants.FIRST_NAME_ATTR);
@@ -408,7 +408,7 @@ public class KeywordMatcherTest {
     }
 
     @Test
-    public void testMatchingWithLimitOffset() throws DataFlowException, ParseException, java.text.ParseException {
+    public void testMatchingWithLimitOffset() throws Exception {
         String query = "angry";
         ArrayList<Attribute> attributeList = new ArrayList<>();
         attributeList.add(TestConstants.FIRST_NAME_ATTR);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -72,17 +72,17 @@ public class PhraseMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws Exception {
         return getPeopleQueryResults(query, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit)
-            throws DataFlowException, ParseException {
+            throws Exception {
         return getPeopleQueryResults(query, attributeList, limit, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
-            throws DataFlowException, ParseException {
+            throws Exception {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -73,7 +73,7 @@ public class SubstringMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws Exception {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
                 DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
@@ -51,7 +51,7 @@ public class ProjectionOperatorTest {
         dataWriter.clearData();
     }
     
-    public List<ITuple> getProjectionResults(IOperator inputOperator, List<String> projectionFields) throws DataFlowException {
+    public List<ITuple> getProjectionResults(IOperator inputOperator, List<String> projectionFields) throws Exception {
         ProjectionPredicate projectionPredicate = new ProjectionPredicate(projectionFields);
         ProjectionOperator projection = new ProjectionOperator(projectionPredicate);
         projection.setInputOperator(inputOperator);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -68,7 +68,7 @@ public class FuzzyTokenMatcherPerformanceTest {
      * 
      */
     public static void runTest(String queryFileName, List<Double> thresholds)
-            throws StorageException, DataFlowException, IOException {
+            throws Exception {
 
         // Reads queries from query file into a list
         ArrayList<String> queries = PerfTestUtils.readQueries(PerfTestUtils.getQueryPath(queryFileName));
@@ -118,7 +118,7 @@ public class FuzzyTokenMatcherPerformanceTest {
      * This function does match for a list of queries
      */
     public static void match(ArrayList<String> queryList, double threshold, Analyzer luceneAnalyzer,
-            DataStore dataStore, boolean bool) throws DataFlowException, IOException {
+            DataStore dataStore, boolean bool) throws Exception {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -136,7 +136,7 @@ public class KeywordMatcherPerformanceTest {
      * This function does match for a list of queries
      */
     public static void match(ArrayList<String> queryList, KeywordMatchingType opType, Analyzer luceneAnalyzer,
-            DataStore dataStore) throws DataFlowException, IOException {
+            DataStore dataStore) throws Exception {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -57,7 +57,7 @@ public class RegexMatcherPerformanceTest {
      * 
      */
     public static void runTest(List<String> regexQueries)
-            throws StorageException, DataFlowException, IOException {
+            throws Exception {
 
         FileWriter fileWriter = null;
          
@@ -92,7 +92,7 @@ public class RegexMatcherPerformanceTest {
     /*
      *         This function does match for a list of regex queries
      */
-    public static void matchRegex(List<String> regexes, DataStore dataStore) throws DataFlowException, IOException {
+    public static void matchRegex(List<String> regexes, DataStore dataStore) throws Exception {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
         


### PR DESCRIPTION
Copied from Issue #259 

This issue is related to Efficient Text Widget Recommendations to Users, which is, for the given document with highlighted substring, we would like to recommend which plans we have match that, so that user can reuse pre-defined plans.

This can be done by executing plans we have on that given single document(or on just substring), and since some of extended class of AbstractSingleSourceOperator already have such method, I think it's good idea to make it abstract method. We need to come up with a converter which evaluates JSON query to actual query plan object, and a slightly different conversion can be applied to a plan so that it can efficiently run on a single document.
