### PR TITLE
Introduce TextDBException

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/IOperator.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/IOperator.java
@@ -2,6 +2,7 @@ package edu.uci.ics.textdb.api.dataflow;
 
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * Created by chenli on 3/25/16.
@@ -11,11 +12,11 @@ public interface IOperator {
     static final int CLOSED = -1;
     static final int OPENED = 0;
 
-    void open() throws Exception;
+    void open() throws TextDBException;
 
-    ITuple getNextTuple() throws Exception;
+    ITuple getNextTuple() throws TextDBException;
 
-    void close() throws Exception;
+    void close() throws TextDBException;
 
     Schema getOutputSchema();
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/ISink.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/dataflow/ISink.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.textdb.api.dataflow;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * Created by chenli on 5/11/16.
@@ -10,14 +11,14 @@ import edu.uci.ics.textdb.api.common.ITuple;
  *
  */
 public interface ISink extends IOperator {
-    void open() throws Exception;
+    void open() throws TextDBException;
 
-    void processTuples() throws Exception;
+    void processTuples() throws TextDBException;
 
-    void close() throws Exception;
+    void close() throws TextDBException;
     
-    default ITuple getNextTuple() throws Exception {
-        throw new UnsupportedOperationException();
+    default ITuple getNextTuple() throws TextDBException {
+        throw new TextDBException("temp", new UnsupportedOperationException());
     }
     
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/exception/TextDBException.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/exception/TextDBException.java
@@ -1,0 +1,22 @@
+package edu.uci.ics.textdb.api.exception;
+
+/**
+ * Superclass of all exceptions inside TextDB Engine.
+ */
+public class TextDBException extends Exception {
+
+    private static final long serialVersionUID = 4359106470500687632L;
+
+    public TextDBException(String errorMessage) {
+        super(errorMessage);
+    }
+    
+    public TextDBException(String errorMessage, Throwable throwable) {
+        super(errorMessage, throwable);
+    }
+    
+    public TextDBException(Throwable throwable) {
+        super(throwable);
+    }
+    
+}

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/storage/IDataWriter.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/storage/IDataWriter.java
@@ -1,10 +1,11 @@
 package edu.uci.ics.textdb.api.storage;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 public interface IDataWriter {
     
-    public void insertTuple(ITuple tuple) throws Exception;
+    public void insertTuple(ITuple tuple) throws TextDBException;
 
-    public void clearData() throws Exception;
+    public void clearData() throws TextDBException;
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/plan/PlanTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/plan/PlanTest.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.api.plan;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -28,19 +29,19 @@ public class PlanTest {
         return new ISink() {
 
             @Override
-            public void processTuples() throws Exception {
+            public void processTuples() throws TextDBException {
                 // TODO Auto-generated method stub
 
             }
 
             @Override
-            public void open() throws Exception {
+            public void open() throws TextDBException {
                 // TODO Auto-generated method stub
 
             }
 
             @Override
-            public void close() throws Exception {
+            public void close() throws TextDBException {
                 // TODO Auto-generated method stub
 
             }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/DataFlowException.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/DataFlowException.java
@@ -3,11 +3,12 @@
  */
 package edu.uci.ics.textdb.common.exception;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
+
 /**
- * @author sandeepreddy602
- *
+ *  Thrown to indicate that an exception occurs when a TextDB operator processes data.  
  */
-public class DataFlowException extends Exception {
+public class DataFlowException extends TextDBException {
 
     private static final long serialVersionUID = -4779329768850579335L;
 
@@ -18,4 +19,9 @@ public class DataFlowException extends Exception {
     public DataFlowException(String errorMessage) {
         super(errorMessage);
     }
+    
+    public DataFlowException(Throwable throwable) {
+        super(throwable);
+    }
+    
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/DataFlowException.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/DataFlowException.java
@@ -6,7 +6,7 @@ package edu.uci.ics.textdb.common.exception;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
- *  Thrown to indicate that an exception occurs when a TextDB operator processes data.  
+ *  Thrown to indicate that an exception occurs when a TextDB operator processes data.
  */
 public class DataFlowException extends TextDBException {
 

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/PlanGenException.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/PlanGenException.java
@@ -1,8 +1,12 @@
 package edu.uci.ics.textdb.common.exception;
 
-public class PlanGenException extends Exception {
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
-    // auto generated serial version UID
+/*
+ * Thrown to indicate that an exception occurs when constructing a query plan.
+ */
+public class PlanGenException extends TextDBException {
+
     private static final long serialVersionUID = -9145104915599667725L;
 
     public PlanGenException(String errorMessage, Throwable throwable) {
@@ -11,6 +15,10 @@ public class PlanGenException extends Exception {
     
     public PlanGenException(String errorMessage) {
         super(errorMessage);
+    }
+    
+    public PlanGenException(Throwable throwable) {
+        super(throwable);
     }
 
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/StorageException.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/exception/StorageException.java
@@ -1,10 +1,24 @@
 package edu.uci.ics.textdb.common.exception;
 
-public class StorageException extends Exception {
+import edu.uci.ics.textdb.api.exception.TextDBException;
+
+/*
+ * Thrown to indicate that an exception occurs when writing/reading data.
+ */
+public class StorageException extends TextDBException {
 
     private static final long serialVersionUID = -7393624288798221759L;
+    
+    public StorageException(String errorMessage) {
+        super(errorMessage);
+    }
 
     public StorageException(String errorMessage, Throwable throwable) {
         super(errorMessage, throwable);
     }
+    
+    public StorageException(Throwable throwable) {
+        super(throwable);
+    }
+    
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
@@ -5,6 +5,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * AbstractSingleInputOperator is an abstract class that can be used by many operators.
@@ -33,7 +34,7 @@ public abstract class AbstractSingleInputOperator implements IOperator {
     protected int offset = 0;
     
     @Override
-    public void open() throws DataFlowException {
+    public void open() throws TextDBException {
         if (cursor != CLOSED) {
             return;
         }
@@ -53,12 +54,12 @@ public abstract class AbstractSingleInputOperator implements IOperator {
     /**
      * setUp necessary resources, variables in this function.
      * outputSchema MUST be initialized in setUP().
-     * @throws DataFlowException
+     * @throws TextDBException
      */
-    protected abstract void setUp() throws DataFlowException;
+    protected abstract void setUp() throws TextDBException;
 
     @Override
-    public ITuple getNextTuple() throws DataFlowException {
+    public ITuple getNextTuple() throws TextDBException {
         if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
@@ -87,12 +88,12 @@ public abstract class AbstractSingleInputOperator implements IOperator {
      * Give the input tuples, compute the next matching tuple. Return null if there's no more matching tuple.
      * 
      * @return next matching tuple, null if there's no more matching tuple.
-     * @throws Exception
+     * @throws TextDBException
      */
-    protected abstract ITuple computeNextMatchingTuple() throws Exception;
+    protected abstract ITuple computeNextMatchingTuple() throws TextDBException;
 
     @Override
-    public void close() throws DataFlowException {
+    public void close() throws TextDBException {
         if (cursor == CLOSED) {
             return;
         }
@@ -107,7 +108,7 @@ public abstract class AbstractSingleInputOperator implements IOperator {
         cursor = CLOSED;
     }
     
-    protected abstract void cleanUp() throws DataFlowException;
+    protected abstract void cleanUp() throws TextDBException;
 
     @Override
     public Schema getOutputSchema() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.dataflow.comparablematcher;
 import edu.uci.ics.textdb.api.common.*;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 
 /**
@@ -26,7 +27,7 @@ public class ComparableMatcher<T extends Comparable> extends AbstractSingleInput
     }
 
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnector.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnector.java
@@ -6,6 +6,7 @@ import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IConnector;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * OneToNBroadcastConnector connects one input operator with multiple output operators.
@@ -88,7 +89,7 @@ public class OneToNBroadcastConnector implements IConnector {
      * Tuples from input operators are cached in an in-memory list.
      * A new tuple will be fetched from input operator whenever a cursor exceeds the list size.
      */
-    private ITuple getNextTuple(int outputOperatorIndex) throws Exception {
+    private ITuple getNextTuple(int outputOperatorIndex) throws TextDBException {
         int nextPosition = outputCursorList.get(outputOperatorIndex) + 1;
         outputCursorList.set(outputOperatorIndex, nextPosition);
         
@@ -105,7 +106,7 @@ public class OneToNBroadcastConnector implements IConnector {
         }
     }
     
-    private void openInputOperator(int outputOperatorIndex) throws Exception {
+    private void openInputOperator(int outputOperatorIndex) throws TextDBException {
         outputStatusList.set(outputOperatorIndex, OPENED);
         if (! inputOperatorOpened) {
             inputOperator.open();
@@ -113,7 +114,7 @@ public class OneToNBroadcastConnector implements IConnector {
         }
     }
     
-    private void closeInputOperator(int outputOperatorIndex) throws Exception {
+    private void closeInputOperator(int outputOperatorIndex) throws TextDBException {
         outputStatusList.set(outputOperatorIndex, CLOSED);
         boolean isAllClosed = isAllOutputOperatorClosed();
         if (isAllClosed) {
@@ -149,17 +150,17 @@ public class OneToNBroadcastConnector implements IConnector {
         }
 
         @Override
-        public void open() throws Exception {
+        public void open() throws TextDBException {
             ownerConnector.openInputOperator(outputIndex);
         }
 
         @Override
-        public ITuple getNextTuple() throws Exception {
+        public ITuple getNextTuple() throws TextDBException {
             return ownerConnector.getNextTuple(outputIndex);
         }
 
         @Override
-        public void close() throws Exception {      
+        public void close() throws TextDBException {
             ownerConnector.closeInputOperator(outputIndex);
         }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -5,6 +5,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
@@ -66,7 +67,7 @@ public class DictionaryMatcher implements IOperator {
     }
 
     @Override
-    public ITuple getNextTuple() throws Exception {
+    public ITuple getNextTuple() throws TextDBException {
         if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -16,6 +16,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
@@ -137,7 +138,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * 
      */
     @Override
-    public ITuple getNextTuple() throws Exception {
+    public ITuple getNextTuple() throws TextDBException {
         if (resultCursor >= limit + offset - 1) {
             return null;
         }
@@ -223,7 +224,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * Advance the cursor of dictionary. if reach the end of the dictionary,
      * advance the cursor of tuples and reset dictionary
      */
-    private void advanceDictionaryCursor() throws Exception {
+    private void advanceDictionaryCursor() throws TextDBException {
         if ((currentDictionaryEntry = predicate.getNextDictionaryEntry()) != null) {
             return;
         }
@@ -236,7 +237,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * original dataTuple object, if there's a match, return a new dataTuple
      * with span list added
      */
-    private ITuple computeMatchingResult(String key, ITuple sourceTuple) throws Exception {
+    private ITuple computeMatchingResult(String key, ITuple sourceTuple) throws TextDBException {
 
         List<Attribute> attributeList = predicate.getAttributeList();
         List<Span> matchingResults = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -11,6 +11,7 @@ import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -38,7 +39,7 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected void setUp() throws DataFlowException {
+    protected void setUp() throws TextDBException {
         inputSchema = inputOperator.getOutputSchema();
         outputSchema = inputSchema;
         if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
@@ -50,7 +51,7 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
         
@@ -75,7 +76,7 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
         return resultTuple;
     }
     
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+    private ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
         List<Span> payload = (List<Span>) inputTuple.getField(SchemaConstants.PAYLOAD).getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -12,6 +12,7 @@ import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.IJoinPredicate;
 
 
@@ -84,10 +85,10 @@ public class Join implements IOperator {
     }
 
     @Override
-    public void open() throws Exception, DataFlowException {
+    public void open() throws TextDBException {
         if (!(joinPredicate.getJoinAttribute().getFieldType().equals(FieldType.STRING)
                 || joinPredicate.getJoinAttribute().getFieldType().equals(FieldType.TEXT))) {
-            throw new Exception("Fields other than \"STRING\" and \"TEXT\" are not supported by Join yet.");
+            throw new TextDBException("Fields other than \"STRING\" and \"TEXT\" are not supported by Join yet.");
         }
 
         if (cursor != CLOSED) {
@@ -131,7 +132,7 @@ public class Join implements IOperator {
      * @return nextTuple
      */
     @Override
-    public ITuple getNextTuple() throws Exception {
+    public ITuple getNextTuple() throws TextDBException {
     	if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
@@ -194,7 +195,7 @@ public class Join implements IOperator {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws TextDBException {
     	if (cursor == CLOSED) {
             return;
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -16,6 +16,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -34,7 +35,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected void setUp() {
+    protected void setUp() throws TextDBException {
         inputSchema = inputOperator.getOutputSchema();
         outputSchema = inputSchema;
         if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
@@ -46,7 +47,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
         

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -6,6 +6,7 @@ import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.storage.reader.DataReader;
@@ -47,7 +48,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     }
 
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         return this.keywordMatcher.getNextTuple();
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -14,7 +14,7 @@ import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -53,7 +53,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected void setUp() throws DataFlowException {
+    protected void setUp() throws TextDBException {
         inputSchema = inputOperator.getOutputSchema();
         outputSchema = inputSchema;
         if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
@@ -62,7 +62,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
     }
     
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
         
@@ -79,7 +79,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
         return resultTuple;
     }
 
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+    private ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
         List<Span> matchingResults = new ArrayList<>();
         for (Attribute attribute : predicate.getAttributeList()) {
             String fieldName = attribute.getFieldName();
@@ -291,7 +291,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected void cleanUp() throws DataFlowException {
+    protected void cleanUp() throws TextDBException {
     }
 
     public NlpPredicate getPredicate() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
@@ -8,6 +8,7 @@ import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 
@@ -22,7 +23,7 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected void setUp() throws DataFlowException {
+    protected void setUp() throws TextDBException {
         inputSchema = inputOperator.getOutputSchema();
         List<Attribute> outputAttributes = 
                 inputSchema.getAttributes()
@@ -37,7 +38,7 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
     }
 
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = inputOperator.getNextTuple();
         if (inputTuple == null) {
             return null;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
@@ -8,6 +8,7 @@ import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.ListField;
 
@@ -66,7 +67,7 @@ public class QueryRewriter implements IOperator {
      * @throws Exception
      */
     @Override
-    public void open() throws Exception {
+    public void open() throws TextDBException {
         this.isOpen = true;
         this.sourceTuple = null;
     }
@@ -83,7 +84,7 @@ public class QueryRewriter implements IOperator {
      * @throws Exception
      */
     @Override
-    public ITuple getNextTuple() throws Exception {
+    public ITuple getNextTuple() throws TextDBException {
 
         boolean endOfResult = (sourceTuple != null); // Ensures you can call
                                                      // QueryRewriter.getNextTuple
@@ -109,7 +110,7 @@ public class QueryRewriter implements IOperator {
      * @throws Exception
      */
     @Override
-    public void close() throws Exception {
+    public void close() throws TextDBException {
         this.isOpen = false;
         this.searchQuery = null;
         this.sourceTuple = null;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -9,6 +9,7 @@ import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -84,7 +85,7 @@ public class RegexMatcher extends AbstractSingleInputOperator {
     }
     
     @Override
-    protected ITuple computeNextMatchingTuple() throws Exception {
+    protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
         

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/AbstractSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/AbstractSink.java
@@ -4,6 +4,7 @@ import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISink;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * Created by chenli on 5/11/16.
@@ -21,7 +22,7 @@ public abstract class AbstractSink implements ISink {
      * @about Opens the child operator.
      */
     @Override
-    public void open() throws Exception {
+    public void open() throws TextDBException {
         inputOperator.open();
     }
 
@@ -34,7 +35,7 @@ public abstract class AbstractSink implements ISink {
     }
 
     @Override
-    public void processTuples() throws Exception {
+    public void processTuples() throws TextDBException {
         ITuple nextTuple;
 
         while ((nextTuple = inputOperator.getNextTuple()) != null) {
@@ -47,10 +48,10 @@ public abstract class AbstractSink implements ISink {
      * @param nextTuple
      *            A tuple that needs to be processed during each iteration
      */
-    protected abstract void processOneTuple(ITuple nextTuple) throws Exception;
+    protected abstract void processOneTuple(ITuple nextTuple) throws TextDBException;
 
     @Override
-    public void close() throws Exception {
+    public void close() throws TextDBException {
         inputOperator.close();
     }
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/FileSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/FileSink.java
@@ -1,9 +1,11 @@
 package edu.uci.ics.textdb.dataflow.sink;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 
 import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * Created by chenli on 5/11/16.
@@ -30,13 +32,17 @@ public class FileSink extends AbstractSink {
     }
 
     @Override
-    public void open() throws Exception {
+    public void open() throws TextDBException {
         super.open();
-        this.printWriter = new PrintWriter(file);
+        try {
+            this.printWriter = new PrintWriter(file);
+        } catch (FileNotFoundException e) {
+            throw new TextDBException("Failed to open file sink", e);
+        }
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws TextDBException {
         if (this.printWriter != null) {
             this.printWriter.close();
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/IndexSink.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/sink/IndexSink.java
@@ -1,10 +1,10 @@
 package edu.uci.ics.textdb.dataflow.sink;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -24,7 +24,7 @@ public class IndexSink extends AbstractSink {
         this.isAppend = isAppend;
     }
 
-    public void open() throws Exception {
+    public void open() throws TextDBException {
         super.open();
         if (! this.isAppend) {
             this.dataWriter.clearData();
@@ -32,11 +32,11 @@ public class IndexSink extends AbstractSink {
         this.dataWriter.open();
     }
 
-    protected void processOneTuple(ITuple nextTuple) throws StorageException {
+    protected void processOneTuple(ITuple nextTuple) throws TextDBException {
         dataWriter.insertTuple(nextTuple);
     }
 
-    public void close() throws Exception {
+    public void close() throws TextDBException {
         if (this.dataWriter != null) {
             this.dataWriter.close();
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/FileSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/FileSourceOperator.java
@@ -1,11 +1,13 @@
 package edu.uci.ics.textdb.dataflow.source;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Scanner;
 
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 
 /**
  * FileSourceOperator treats files on disk as a source. FileSourceOperator reads
@@ -33,12 +35,16 @@ public class FileSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void open() throws Exception {
-        this.scanner = new Scanner(file);
+    public void open() throws TextDBException {
+        try {
+            this.scanner = new Scanner(file);
+        } catch (FileNotFoundException e) {
+            throw new TextDBException("Failed to open FileSourceOperator", e);
+        }
     }
 
     @Override
-    public ITuple getNextTuple() throws Exception {
+    public ITuple getNextTuple() throws TextDBException {
         if (scanner.hasNextLine()) {
             try {
                 return this.toTupleFunc.convertToTuple(scanner.nextLine());
@@ -51,7 +57,7 @@ public class FileSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws TextDBException {
         if (this.scanner != null) {
             this.scanner.close();
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperator.java
@@ -7,6 +7,7 @@ import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.reader.DataReader;
 
@@ -24,7 +25,7 @@ public class IndexBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void open() throws DataFlowException {
+    public void open() throws TextDBException {
         try {
             dataReader = new DataReader(predicate);
             dataReader.open();
@@ -36,7 +37,7 @@ public class IndexBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public ITuple getNextTuple() throws DataFlowException {
+    public ITuple getNextTuple() throws TextDBException {
         if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
@@ -49,7 +50,7 @@ public class IndexBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void close() throws DataFlowException {
+    public void close() throws TextDBException {
         try {
             dataReader.close();
             cursor = CLOSED;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.dataflow.source;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.MatchAllDocsQuery;
 
@@ -29,7 +30,7 @@ public class ScanBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void open() throws DataFlowException {
+    public void open() throws TextDBException {
         try {
             DataReaderPredicate predicate = new DataReaderPredicate(
                     new MatchAllDocsQuery(), DataConstants.SCAN_QUERY, dataStore,
@@ -43,7 +44,7 @@ public class ScanBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public ITuple getNextTuple() throws DataFlowException {
+    public ITuple getNextTuple() throws TextDBException {
         try {
             return dataReader.getNextTuple();
         } catch (Exception e) {
@@ -53,7 +54,7 @@ public class ScanBasedSourceOperator implements ISourceOperator {
     }
 
     @Override
-    public void close() throws DataFlowException {
+    public void close() throws TextDBException {
         try {
             dataReader.close();
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
@@ -9,16 +9,14 @@ import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.NumberMatchingType;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.common.field.*;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.reader.DataReader;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,7 +58,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getDoubleQueryResults(double threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws TextDBException {
         // Perform the query
         ComparablePredicate<Double> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Double> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -69,7 +67,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getIntegerQueryResults(int threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws TextDBException {
         // Perform the query
         ComparablePredicate<Integer> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Integer> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -78,7 +76,7 @@ public class ComparableMatcherTest {
     }
 
     public List<ITuple> getDateQueryResults(Date threshold, Attribute attribute, NumberMatchingType matchingType)
-            throws DataFlowException {
+            throws TextDBException {
         // Perform the query
         ComparablePredicate<Date> comparablePredicate = new ComparablePredicate<>(threshold, attribute, matchingType);
         ComparableMatcher<Date> comparableMatcher = new ComparableMatcher<>(comparablePredicate);
@@ -86,7 +84,7 @@ public class ComparableMatcherTest {
         return getQueryResults(comparableMatcher);
     }
 
-    public void setDefaultMatcherConfig(ComparableMatcher comparableMatcher) throws DataFlowException {
+    public void setDefaultMatcherConfig(ComparableMatcher comparableMatcher) throws TextDBException {
         // Perform the query
         ScanBasedSourceOperator sourceOperator = getScanSourceOperator(dataStore);
         comparableMatcher.setInputOperator(sourceOperator);
@@ -95,7 +93,7 @@ public class ComparableMatcherTest {
         comparableMatcher.setOffset(0);
     }
 
-    public List<ITuple> getQueryResults(ComparableMatcher comparableMatcher) throws DataFlowException {
+    public List<ITuple> getQueryResults(ComparableMatcher comparableMatcher) throws TextDBException {
         List<ITuple> returnedResults = new ArrayList<>();
         ITuple nextTuple = null;
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -66,7 +67,7 @@ public class OneToNBroadcastConnectorTest {
      * This test connects Connector with Projection
      */
     @Test
-    public void testTwoOutputsWithProjection() throws DataFlowException {
+    public void testTwoOutputsWithProjection() throws TextDBException {
         IOperator sourceOperator = getScanSourceOperator(dataStore);
         
         List<String> projectionFields = Arrays.asList(

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcherTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -21,7 +22,6 @@ import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -66,17 +66,17 @@ public class FuzzyTokenMatcherTest {
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
         return getQueryResults(query, threshold, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList,
-            int limit) throws DataFlowException, ParseException {
+            int limit) throws TextDBException, ParseException {
         return getQueryResults(query, threshold, attributeList, limit, 0);
     }
 
     public List<ITuple> getQueryResults(String query, double threshold, ArrayList<Attribute> attributeList,
-            int limit, int offset) throws DataFlowException, ParseException {
+            int limit, int offset) throws TextDBException, ParseException {
 
         FuzzyTokenPredicate predicate = new FuzzyTokenPredicate(query, attributeList, analyzer, threshold);
         fuzzyTokenMatcher = new FuzzyTokenMatcher(predicate);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -75,19 +76,19 @@ public class KeywordMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
 
         return getPeopleQueryResults(query, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
 
         return getPeopleQueryResults(query, attributeList, limit, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
@@ -348,7 +349,7 @@ public class KeywordMatcherTest {
     }
 
     @Test
-    public void testMatchingWithLimit() throws DataFlowException, ParseException, java.text.ParseException {
+    public void testMatchingWithLimit() throws TextDBException, ParseException, java.text.ParseException {
         String query = "angry";
         ArrayList<Attribute> attributeList = new ArrayList<>();
         attributeList.add(TestConstants.FIRST_NAME_ATTR);
@@ -410,7 +411,7 @@ public class KeywordMatcherTest {
     }
 
     @Test
-    public void testMatchingWithLimitOffset() throws DataFlowException, ParseException, java.text.ParseException {
+    public void testMatchingWithLimitOffset() throws TextDBException, ParseException, java.text.ParseException {
         String query = "angry";
         ArrayList<Attribute> attributeList = new ArrayList<>();
         attributeList.add(TestConstants.FIRST_NAME_ATTR);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -74,17 +75,17 @@ public class PhraseMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
         return getPeopleQueryResults(query, attributeList, Integer.MAX_VALUE, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
         return getPeopleQueryResults(query, attributeList, limit, 0);
     }
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -30,7 +31,6 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
-import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
@@ -75,7 +75,7 @@ public class SubstringMatcherTest {
      */
 
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
-            throws DataFlowException, ParseException {
+            throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
                 DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,15 +20,12 @@ import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.reader.DataReader;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 public class ProjectionOperatorTest {
@@ -53,7 +50,7 @@ public class ProjectionOperatorTest {
         dataWriter.clearData();
     }
     
-    public List<ITuple> getProjectionResults(IOperator inputOperator, List<String> projectionFields) throws DataFlowException {
+    public List<ITuple> getProjectionResults(IOperator inputOperator, List<String> projectionFields) throws TextDBException {
         ProjectionPredicate projectionPredicate = new ProjectionPredicate(projectionFields);
         ProjectionOperator projection = new ProjectionOperator(projectionPredicate);
         projection.setInputOperator(inputOperator);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -17,7 +18,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
@@ -67,7 +67,7 @@ public class IndexBasedSourceOperatorTest {
         indexBasedSourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }
 
-    public List<ITuple> getQueryResults(String query) throws DataFlowException, ParseException {
+    public List<ITuple> getQueryResults(String query) throws TextDBException, ParseException {
         constructIndexBasedSourceOperator(query);
         indexBasedSourceOperator.open();
 
@@ -87,7 +87,7 @@ public class IndexBasedSourceOperatorTest {
      * @throws ParseException
      */
     @Test
-    public void testTextSearchWithMultipleTokens() throws DataFlowException, ParseException {
+    public void testTextSearchWithMultipleTokens() throws TextDBException, ParseException {
         List<ITuple> results = getQueryResults(TestConstants.DESCRIPTION + ":Tall,Brown");
         int numTuples = results.size();
         Assert.assertEquals(3, numTuples);
@@ -103,7 +103,7 @@ public class IndexBasedSourceOperatorTest {
      * @throws ParseException
      */
     @Test
-    public void testTextSearchWithSingleToken() throws DataFlowException, ParseException {
+    public void testTextSearchWithSingleToken() throws TextDBException, ParseException {
         List<ITuple> results = getQueryResults(TestConstants.DESCRIPTION + ":angry");
         int numTuples = results.size();
         boolean check = TestUtils.checkResults(results, "angry", this.luceneAnalyzer, TestConstants.DESCRIPTION);
@@ -119,7 +119,7 @@ public class IndexBasedSourceOperatorTest {
      * @throws ParseException
      */
     @Test
-    public void testStringSearchWithSubstring() throws DataFlowException, ParseException {
+    public void testStringSearchWithSubstring() throws TextDBException, ParseException {
         List<ITuple> results = getQueryResults("lin");
         int numTuples = results.size();
         Assert.assertEquals(0, numTuples);
@@ -133,7 +133,7 @@ public class IndexBasedSourceOperatorTest {
      * @throws ParseException
      */
     @Test
-    public void testMultipleFields() throws DataFlowException, ParseException {
+    public void testMultipleFields() throws TextDBException, ParseException {
         List<ITuple> results = getQueryResults(
                 TestConstants.DESCRIPTION + ":(Tall,Brown)" + " AND " + TestConstants.LAST_NAME + ":cruise");
         int numTuples = results.size();
@@ -156,7 +156,7 @@ public class IndexBasedSourceOperatorTest {
      * @throws DataFlowException
      */
     @Test(expected = DataFlowException.class)
-    public void testResetPredicate() throws ParseException, DataFlowException {
+    public void testResetPredicate() throws ParseException, TextDBException {
         constructIndexBasedSourceOperator(TestConstants.DESCRIPTION + ":angry");
         indexBasedSourceOperator.open();
         indexBasedSourceOperator.getNextTuple();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
@@ -5,30 +5,23 @@ package edu.uci.ics.textdb.dataflow.source;
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.Query;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
-import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.reader.DataReader;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
@@ -62,7 +55,7 @@ public class ScanBasedSourceOperatorTest {
     }
 
     @Test
-    public void testFlow() throws DataFlowException, ParseException {
+    public void testFlow() throws TextDBException, ParseException {
         List<ITuple> actualTuples = TestConstants.getSamplePeopleTuples();
         scanBasedSourceOperator.open();
         ITuple nextTuple = null;

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
@@ -68,7 +69,7 @@ public class FuzzyTokenMatcherPerformanceTest {
      * 
      */
     public static void runTest(String queryFileName, List<Double> thresholds)
-            throws StorageException, DataFlowException, IOException {
+            throws TextDBException, IOException {
 
         // Reads queries from query file into a list
         ArrayList<String> queries = PerfTestUtils.readQueries(PerfTestUtils.getQueryPath(queryFileName));
@@ -118,7 +119,7 @@ public class FuzzyTokenMatcherPerformanceTest {
      * This function does match for a list of queries
      */
     public static void match(ArrayList<String> queryList, double threshold, Analyzer luceneAnalyzer,
-            DataStore dataStore, boolean bool) throws DataFlowException, IOException {
+            DataStore dataStore, boolean bool) throws TextDBException, IOException {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
@@ -136,7 +137,7 @@ public class KeywordMatcherPerformanceTest {
      * This function does match for a list of queries
      */
     public static void match(ArrayList<String> queryList, KeywordMatchingType opType, Analyzer luceneAnalyzer,
-            DataStore dataStore) throws DataFlowException, IOException {
+            DataStore dataStore) throws TextDBException, IOException {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.ITuple;
@@ -57,7 +58,7 @@ public class RegexMatcherPerformanceTest {
      * 
      */
     public static void runTest(List<String> regexQueries)
-            throws StorageException, DataFlowException, IOException {
+            throws TextDBException, IOException {
 
         FileWriter fileWriter = null;
          
@@ -92,7 +93,7 @@ public class RegexMatcherPerformanceTest {
     /*
      *         This function does match for a list of regex queries
      */
-    public static void matchRegex(List<String> regexes, DataStore dataStore) throws DataFlowException, IOException {
+    public static void matchRegex(List<String> regexes, DataStore dataStore) throws TextDBException, IOException {
 
         Attribute[] attributeList = new Attribute[] { MedlineIndexWriter.ABSTRACT_ATTR };
         


### PR DESCRIPTION
This PR introduces `TextDBException`, which is the superclass of all exceptions within TextDB.

Catching and throwing the `Exception` class is a bad practice because it's too generic. We want the callers to handle one specific kind of Exception, which indicates that some error happens in TextDB. 

So this PR introduces `TextDBException`, which becomes the superclass of all Exceptions defined in TextDB. So callers can distinguish between other Exceptions and TextDBExceptions.
