### PR TITLE
Rename OperatorGraph to LogicalPlan

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/LogicalPlan.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/LogicalPlan.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.plangen;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,10 +18,9 @@ import edu.uci.ics.textdb.dataflow.join.Join;
  * 
  * @author Zuozhi Wang
  */
-public class OperatorGraph {
+public class LogicalPlan implements Serializable {
     
-    // a map of an operator ID to the operator object
-    HashMap<String, IOperator> operatorObjectMap;
+    private static final long serialVersionUID = -4473743060478893198L;
     
     // a map of an operator ID to the operator's type
     HashMap<String, String> operatorTypeMap;
@@ -30,11 +30,11 @@ public class OperatorGraph {
     HashMap<String, HashSet<String>> adjacencyList;
 
     
-    public OperatorGraph() {
-        operatorObjectMap = new HashMap<>();
+    public LogicalPlan(LogicalPlan logicalPlan) {
         operatorTypeMap = new HashMap<>();
         operatorPropertyMap = new HashMap<>();
         adjacencyList = new HashMap<>();
+        
     }
     
     /**
@@ -62,8 +62,6 @@ public class OperatorGraph {
         operatorPropertyMap.put(operatorID, operatorProperties);
         adjacencyList.put(operatorID, new HashSet<>());
         
-        IOperator operator = PlanGenUtils.buildOperator(operatorType, operatorProperties);
-        operatorObjectMap.put(operatorID, operator);
     }
     
     /**
@@ -103,12 +101,26 @@ public class OperatorGraph {
      * @throws PlanGenException, if the operator graph is invalid.
      */
     public Plan buildQueryPlan() throws PlanGenException {
+        HashMap<String, IOperator> operatorObjectMap = buildOperators();
         validateOperatorGraph();
-        connectOperators();
-        ISink sink = findSinkOperator();
+        connectOperators(operatorObjectMap);
+        ISink sink = findSinkOperator(operatorObjectMap);
         
         Plan queryPlan = new Plan(sink);
         return queryPlan;
+    }
+    
+    /*
+     * Build the operator objects from operator properties.
+     */
+    private HashMap<String, IOperator> buildOperators() throws PlanGenException {
+        HashMap<String, IOperator> operatorObjectMap = new HashMap<>();
+        for (String operatorID : operatorTypeMap.keySet()) {
+            IOperator operator = PlanGenUtils.buildOperator(
+                    operatorTypeMap.get(operatorID), operatorPropertyMap.get(operatorID));
+            operatorObjectMap.put(operatorID, operator);
+        }
+        return operatorObjectMap;
     }
 
 
@@ -300,7 +312,7 @@ public class OperatorGraph {
      * It goes through every link, and invokes
      * the corresponding "setInputOperator" function to connect operators.
      */
-    private void connectOperators() throws PlanGenException { 
+    private void connectOperators(HashMap<String, IOperator> operatorObjectMap) throws PlanGenException { 
         for (String vertex : adjacencyList.keySet()) {
             IOperator currentOperator = operatorObjectMap.get(vertex);
             int outputArity = adjacencyList.get(vertex).size();
@@ -352,7 +364,7 @@ public class OperatorGraph {
      * 
      * This function assumes that the graph is valid and there is only one sink in the graph.
      */
-    private ISink findSinkOperator() throws PlanGenException {
+    private ISink findSinkOperator(HashMap<String, IOperator> operatorObjectMap) throws PlanGenException {
         IOperator sinkOperator = adjacencyList.keySet().stream()
                 .filter(operator -> operatorTypeMap.get(operator).toLowerCase().contains("sink"))
                 .map(operator -> operatorObjectMap.get(operator))

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/LogicalPlan.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/LogicalPlan.java
@@ -30,11 +30,10 @@ public class LogicalPlan implements Serializable {
     HashMap<String, HashSet<String>> adjacencyList;
 
     
-    public LogicalPlan(LogicalPlan logicalPlan) {
+    public LogicalPlan() {
         operatorTypeMap = new HashMap<>();
         operatorPropertyMap = new HashMap<>();
         adjacencyList = new HashMap<>();
-        
     }
     
     /**

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
@@ -27,7 +27,7 @@ import edu.uci.ics.textdb.plangen.operatorbuilder.OperatorBuilderUtils;
 import edu.uci.ics.textdb.plangen.operatorbuilder.RegexMatcherBuilder;
 import junit.framework.Assert;
 
-public class OperatorGraphTest {
+public class LogicalPlanTest {
 
     public static HashMap<String, String> keywordSourceProperties = new HashMap<String, String>() {
         {
@@ -93,16 +93,16 @@ public class OperatorGraphTest {
      * 
      */
     @Test
-    public void testOperatorGraph1() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testLogicalPlan1() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("sink", "FileSink", fileSinkProperties);
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("regex", "sink");
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("regex", "sink");
 
-        Plan queryPlan = operatorGraph.buildQueryPlan();
+        Plan queryPlan = LogicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -123,26 +123,26 @@ public class OperatorGraphTest {
      * 
      */
     @Test
-    public void testOperatorGraph2() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testLogicalPlan2() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
         JSONObject schemaJsonJSONObject = new JSONObject();
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        operatorGraph.addOperator("join", "Join", joinProperties);
-        operatorGraph.addOperator("sink", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        LogicalPlan.addOperator("join", "Join", joinProperties);
+        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("source", "nlp");
-        operatorGraph.addLink("regex", "join");
-        operatorGraph.addLink("nlp", "join");
-        operatorGraph.addLink("join", "sink");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("source", "nlp");
+        LogicalPlan.addLink("regex", "join");
+        LogicalPlan.addLink("nlp", "join");
+        LogicalPlan.addLink("join", "sink");
 
-        Plan queryPlan = operatorGraph.buildQueryPlan();
+        Plan queryPlan = LogicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -187,31 +187,31 @@ public class OperatorGraphTest {
      * 
      */
     @Test
-    public void testOperatorGraph3() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testLogicalPlan3() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
         JSONObject schemaJsonJSONObject = new JSONObject();
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        operatorGraph.addOperator("fuzzytoken", "FuzzyTokenMatcher", fuzzyTokenMatcherProperties);
-        operatorGraph.addOperator("join", "Join", joinProperties);
-        operatorGraph.addOperator("join2", "Join", joinProperties);
-        operatorGraph.addOperator("sink", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        LogicalPlan.addOperator("fuzzytoken", "FuzzyTokenMatcher", fuzzyTokenMatcherProperties);
+        LogicalPlan.addOperator("join", "Join", joinProperties);
+        LogicalPlan.addOperator("join2", "Join", joinProperties);
+        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("source", "nlp");
-        operatorGraph.addLink("source", "fuzzytoken");
-        operatorGraph.addLink("regex", "join");
-        operatorGraph.addLink("nlp", "join");
-        operatorGraph.addLink("join", "join2");
-        operatorGraph.addLink("fuzzytoken", "join2");
-        operatorGraph.addLink("join2", "sink");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("source", "nlp");
+        LogicalPlan.addLink("source", "fuzzytoken");
+        LogicalPlan.addLink("regex", "join");
+        LogicalPlan.addLink("nlp", "join");
+        LogicalPlan.addLink("join", "join2");
+        LogicalPlan.addLink("fuzzytoken", "join2");
+        LogicalPlan.addLink("join2", "sink");
 
-        Plan queryPlan = operatorGraph.buildQueryPlan();
+        Plan queryPlan = LogicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -266,14 +266,14 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph1() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan1() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("sink", "FileSink", fileSinkProperties);
-        operatorGraph.addLink("regex", "sink");
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        LogicalPlan.addLink("regex", "sink");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
 
     /*
@@ -283,14 +283,14 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph2() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan2() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addLink("source", "regex");
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addLink("source", "regex");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
 
     /*
@@ -300,19 +300,19 @@ public class OperatorGraphTest {
      *                                   -> FileSink2
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph3() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan3() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
-        operatorGraph.addOperator("sink2", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("sink2", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("regex", "sink1");
-        operatorGraph.addLink("regex", "sink2");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("regex", "sink1");
+        LogicalPlan.addLink("regex", "sink2");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
 
     /*
@@ -324,21 +324,21 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph4() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan4() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        operatorGraph.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("regex", "sink1");
-        operatorGraph.addLink("regex2", "nlp");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("regex", "sink1");
+        LogicalPlan.addLink("regex2", "nlp");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
 
     /*
@@ -351,26 +351,26 @@ public class OperatorGraphTest {
      *                                 --> (back to the same) RegexMatcher2
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph5() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan5() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("regex1", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("regex1", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        operatorGraph.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        operatorGraph.addOperator("join", "Join", joinProperties);
+        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        LogicalPlan.addOperator("join", "Join", joinProperties);
 
 
-        operatorGraph.addLink("source", "regex1");
-        operatorGraph.addLink("regex1", "join");
-        operatorGraph.addLink("regex2", "nlp");
-        operatorGraph.addLink("nlp", "regex2");
-        operatorGraph.addLink("nlp", "join");
-        operatorGraph.addLink("join", "sink1");
+        LogicalPlan.addLink("source", "regex1");
+        LogicalPlan.addLink("regex1", "join");
+        LogicalPlan.addLink("regex2", "nlp");
+        LogicalPlan.addLink("nlp", "regex2");
+        LogicalPlan.addLink("nlp", "join");
+        LogicalPlan.addLink("join", "sink1");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
     
     /*
@@ -383,23 +383,23 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph6() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan6() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("source2", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("source2", "KeywordSource", keywordSourceProperties);
 
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
 
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("source2", "regex2");
-        operatorGraph.addLink("regex", "sink1");
-        operatorGraph.addLink("regex2", "sink1");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("source2", "regex2");
+        LogicalPlan.addLink("regex", "sink1");
+        LogicalPlan.addLink("regex2", "sink1");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
     
     /*
@@ -413,21 +413,21 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph7() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan7() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
 
-        operatorGraph.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        operatorGraph.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
 
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "regex");
-        operatorGraph.addLink("source", "regex2");
-        operatorGraph.addLink("regex", "sink1");
+        LogicalPlan.addLink("source", "regex");
+        LogicalPlan.addLink("source", "regex2");
+        LogicalPlan.addLink("regex", "sink1");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
     
     /*
@@ -437,16 +437,16 @@ public class OperatorGraphTest {
      * 
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidOperatorGraph8() throws Exception {
-        OperatorGraph operatorGraph = new OperatorGraph();
+    public void testInvalidLogicalPlan8() throws Exception {
+        LogicalPlan LogicalPlan = new LogicalPlan();
 
-        operatorGraph.addOperator("source", "KeywordSource", keywordSourceProperties);
-        operatorGraph.addOperator("sink1", "FileSink", fileSinkProperties);
+        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        operatorGraph.addLink("source", "sink1");
-        operatorGraph.addLink("sink1", "source");
+        LogicalPlan.addLink("source", "sink1");
+        LogicalPlan.addLink("sink1", "source");
 
-        operatorGraph.buildQueryPlan();
+        LogicalPlan.buildQueryPlan();
     }
 
 }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
@@ -94,15 +94,15 @@ public class LogicalPlanTest {
      */
     @Test
     public void testLogicalPlan1() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("regex", "sink");
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("regex", "sink");
 
-        Plan queryPlan = LogicalPlan.buildQueryPlan();
+        Plan queryPlan = logicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -124,25 +124,25 @@ public class LogicalPlanTest {
      */
     @Test
     public void testLogicalPlan2() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
         JSONObject schemaJsonJSONObject = new JSONObject();
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        LogicalPlan.addOperator("join", "Join", joinProperties);
-        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        logicalPlan.addOperator("join", "Join", joinProperties);
+        logicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("source", "nlp");
-        LogicalPlan.addLink("regex", "join");
-        LogicalPlan.addLink("nlp", "join");
-        LogicalPlan.addLink("join", "sink");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("source", "nlp");
+        logicalPlan.addLink("regex", "join");
+        logicalPlan.addLink("nlp", "join");
+        logicalPlan.addLink("join", "sink");
 
-        Plan queryPlan = LogicalPlan.buildQueryPlan();
+        Plan queryPlan = logicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -188,30 +188,30 @@ public class LogicalPlanTest {
      */
     @Test
     public void testLogicalPlan3() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
         JSONObject schemaJsonJSONObject = new JSONObject();
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
         schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        LogicalPlan.addOperator("fuzzytoken", "FuzzyTokenMatcher", fuzzyTokenMatcherProperties);
-        LogicalPlan.addOperator("join", "Join", joinProperties);
-        LogicalPlan.addOperator("join2", "Join", joinProperties);
-        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        logicalPlan.addOperator("fuzzytoken", "FuzzyTokenMatcher", fuzzyTokenMatcherProperties);
+        logicalPlan.addOperator("join", "Join", joinProperties);
+        logicalPlan.addOperator("join2", "Join", joinProperties);
+        logicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("source", "nlp");
-        LogicalPlan.addLink("source", "fuzzytoken");
-        LogicalPlan.addLink("regex", "join");
-        LogicalPlan.addLink("nlp", "join");
-        LogicalPlan.addLink("join", "join2");
-        LogicalPlan.addLink("fuzzytoken", "join2");
-        LogicalPlan.addLink("join2", "sink");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("source", "nlp");
+        logicalPlan.addLink("source", "fuzzytoken");
+        logicalPlan.addLink("regex", "join");
+        logicalPlan.addLink("nlp", "join");
+        logicalPlan.addLink("join", "join2");
+        logicalPlan.addLink("fuzzytoken", "join2");
+        logicalPlan.addLink("join2", "sink");
 
-        Plan queryPlan = LogicalPlan.buildQueryPlan();
+        Plan queryPlan = logicalPlan.buildQueryPlan();
 
         ISink fileSink = queryPlan.getRoot();
         Assert.assertTrue(fileSink instanceof FileSink);
@@ -267,13 +267,13 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan1() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
-        LogicalPlan.addLink("regex", "sink");
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("sink", "FileSink", fileSinkProperties);
+        logicalPlan.addLink("regex", "sink");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
 
     /*
@@ -284,13 +284,13 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan2() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addLink("source", "regex");
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addLink("source", "regex");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
 
     /*
@@ -301,18 +301,18 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan3() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
-        LogicalPlan.addOperator("sink2", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("sink2", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("regex", "sink1");
-        LogicalPlan.addLink("regex", "sink2");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("regex", "sink1");
+        logicalPlan.addLink("regex", "sink2");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
 
     /*
@@ -325,20 +325,20 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan4() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        logicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("regex", "sink1");
-        LogicalPlan.addLink("regex2", "nlp");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("regex", "sink1");
+        logicalPlan.addLink("regex2", "nlp");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
 
     /*
@@ -352,25 +352,25 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan5() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("regex1", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("regex1", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
-        LogicalPlan.addOperator("join", "Join", joinProperties);
+        logicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("nlp", "NlpExtractor", nlpExtractorProperties);
+        logicalPlan.addOperator("join", "Join", joinProperties);
 
 
-        LogicalPlan.addLink("source", "regex1");
-        LogicalPlan.addLink("regex1", "join");
-        LogicalPlan.addLink("regex2", "nlp");
-        LogicalPlan.addLink("nlp", "regex2");
-        LogicalPlan.addLink("nlp", "join");
-        LogicalPlan.addLink("join", "sink1");
+        logicalPlan.addLink("source", "regex1");
+        logicalPlan.addLink("regex1", "join");
+        logicalPlan.addLink("regex2", "nlp");
+        logicalPlan.addLink("nlp", "regex2");
+        logicalPlan.addLink("nlp", "join");
+        logicalPlan.addLink("join", "sink1");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
     
     /*
@@ -384,22 +384,22 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan6() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("source2", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("source2", "KeywordSource", keywordSourceProperties);
 
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
 
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("source2", "regex2");
-        LogicalPlan.addLink("regex", "sink1");
-        LogicalPlan.addLink("regex2", "sink1");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("source2", "regex2");
+        logicalPlan.addLink("regex", "sink1");
+        logicalPlan.addLink("regex2", "sink1");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
     
     /*
@@ -414,20 +414,20 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan7() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
 
-        LogicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
-        LogicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("regex", "RegexMatcher", regexMatcherProperties);
+        logicalPlan.addOperator("regex2", "RegexMatcher", regexMatcherProperties);
 
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "regex");
-        LogicalPlan.addLink("source", "regex2");
-        LogicalPlan.addLink("regex", "sink1");
+        logicalPlan.addLink("source", "regex");
+        logicalPlan.addLink("source", "regex2");
+        logicalPlan.addLink("regex", "sink1");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
     
     /*
@@ -438,15 +438,15 @@ public class LogicalPlanTest {
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidLogicalPlan8() throws Exception {
-        LogicalPlan LogicalPlan = new LogicalPlan();
+        LogicalPlan logicalPlan = new LogicalPlan();
 
-        LogicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
-        LogicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
+        logicalPlan.addOperator("source", "KeywordSource", keywordSourceProperties);
+        logicalPlan.addOperator("sink1", "FileSink", fileSinkProperties);
 
-        LogicalPlan.addLink("source", "sink1");
-        LogicalPlan.addLink("sink1", "source");
+        logicalPlan.addLink("source", "sink1");
+        logicalPlan.addLink("sink1", "source");
 
-        LogicalPlan.buildQueryPlan();
+        logicalPlan.buildQueryPlan();
     }
 
 }


### PR DESCRIPTION
This PR renames OperatorGraph to Logical Plan, and make OperatorGraph implements the Serializable interface, so the Logical Plan class can be written to a file and be retrieved later.