### PR TITLE
[Issue #242] Adds beans and tests for the remaining operators

### DIFF
--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/QueryPlanRequest.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/QueryPlanRequest.java
@@ -83,6 +83,10 @@ public class QueryPlanRequest {
             try {
                 Method method = operatorBeanClassName.getMethod(GET_PROPERTIES_FUNCTION_NAME);
                 HashMap<String, String> currentOperatorProperty = (HashMap<String, String>) method.invoke(operatorBean);
+                if(currentOperatorProperty == null) {
+                    this.operatorProperties = null;
+                    return false;
+                }
                 this.operatorProperties.put(operatorBean.getOperatorID(), currentOperatorProperty);
             }
             catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
@@ -101,6 +105,11 @@ public class QueryPlanRequest {
      * @return - A boolean to denote the status of LogicalPlan creation
      */
     public boolean createLogicalPlan() {
+        // Checking if the operatorProperties have been aggregated
+        if(this.operatorProperties == null) {
+            return false;
+        }
+
         logicalPlan = new LogicalPlan();
 
         // Adding operatorBeans to the logical plan

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionaryMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionaryMatcherBean.java
@@ -53,6 +53,8 @@ public class DictionaryMatcherBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getDictionary() == null || this.getMatchingType() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(DictionaryMatcherBuilder.DICTIONARY, this.getDictionary());
         operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, this.getMatchingType().name());
         return operatorProperties;

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionarySourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionarySourceBean.java
@@ -67,6 +67,9 @@ public class DictionarySourceBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getDictionary() == null || this.getMatchingType() == null || this.getDataSource() == null ||
+                operatorProperties == null)
+            return null;
         operatorProperties.put(DictionarySourceBuilder.DICTIONARY, this.getDictionary());
         operatorProperties.put(DictionarySourceBuilder.MATCHING_TYPE, this.getMatchingType().name());
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
@@ -39,6 +39,8 @@ public class FileSinkBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(operatorProperties == null || this.getFilePath() == null)
+            return null;
         operatorProperties.put(FileSinkBuilder.FILE_PATH, this.getFilePath());
         return operatorProperties;
     }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
@@ -1,0 +1,62 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.FileSinkBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the FileSink operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("FileSink")
+public class FileSinkBean extends OperatorBean {
+    @JsonProperty("file_path")
+    private String filePath;
+
+    public FileSinkBean() {
+    }
+
+    public FileSinkBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                        String filePath) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.filePath = filePath;
+    }
+
+    @JsonProperty("file_path")
+    public String getFilePath() {
+        return filePath;
+    }
+
+    @JsonProperty("file_path")
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(FileSinkBuilder.FILE_PATH, this.getFilePath());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        FileSinkBean fileSinkBean = (FileSinkBean) other;
+        return super.equals(other) &&
+                this.getFilePath().equals(fileSinkBean.getFilePath())
+                && super.equals(fileSinkBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(filePath)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FileSinkBean.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.web.request.beans;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.uci.ics.textdb.plangen.operatorbuilder.FileSinkBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.HashMap;
@@ -48,9 +49,10 @@ public class FileSinkBean extends OperatorBean {
         if (other == this) return true;
         if (!(other instanceof OperatorBean)) return false;
         FileSinkBean fileSinkBean = (FileSinkBean) other;
-        return super.equals(other) &&
-                this.getFilePath().equals(fileSinkBean.getFilePath())
-                && super.equals(fileSinkBean);
+        return new EqualsBuilder()
+                .append(filePath, fileSinkBean.getFilePath())
+                .isEquals() &&
+                super.equals(fileSinkBean);
     }
 
     @Override

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBean.java
@@ -1,0 +1,80 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.FuzzyTokenMatcherBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the FuzzyTokenMatcher operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("FuzzyTokenMatcher")
+public class FuzzyTokenMatcherBean extends OperatorBean {
+    @JsonProperty("query")
+    private String query;
+    @JsonProperty("threshold_ratio")
+    private String thresholdRatio;
+
+    public FuzzyTokenMatcherBean() {
+    }
+
+    public FuzzyTokenMatcherBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                                 String query, String thresholdRatio) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.query = query;
+        this.thresholdRatio = thresholdRatio;
+    }
+
+    @JsonProperty("query")
+    public String getQuery() {
+        return query;
+    }
+
+    @JsonProperty("query")
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @JsonProperty("threshold_ratio")
+    public String getThresholdRatio() {
+        return thresholdRatio;
+    }
+
+    @JsonProperty("threshold_ratio")
+    public void setThresholdRatio(String thresholdRatio) {
+        this.thresholdRatio = thresholdRatio;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, this.getQuery());
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, this.getThresholdRatio());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        FuzzyTokenMatcherBean fuzzyTokenMatcherBean = (FuzzyTokenMatcherBean) other;
+        return new EqualsBuilder()
+                .append(query, fuzzyTokenMatcherBean.getQuery())
+                .append(thresholdRatio, fuzzyTokenMatcherBean.getThresholdRatio())
+                .isEquals() &&
+                super.equals(fuzzyTokenMatcherBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(query)
+                .append(thresholdRatio)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBean.java
@@ -52,6 +52,8 @@ public class FuzzyTokenMatcherBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getQuery() == null || this.getThresholdRatio() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, this.getQuery());
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, this.getThresholdRatio());
         return operatorProperties;

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
@@ -1,0 +1,97 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.FuzzyTokenMatcherBuilder;
+import edu.uci.ics.textdb.plangen.operatorbuilder.OperatorBuilderUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the FuzzyTokenSource operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("FuzzyTokenSource")
+public class FuzzyTokenSourceBean extends OperatorBean {
+    @JsonProperty("query")
+    private String query;
+    @JsonProperty("threshold_ratio")
+    private String thresholdRatio;
+    @JsonProperty("data_source")
+    private String dataSource;
+
+    public FuzzyTokenSourceBean() {
+    }
+
+    public FuzzyTokenSourceBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                                String query, String thresholdRatio, String dataSource) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.query = query;
+        this.thresholdRatio = thresholdRatio;
+        this.dataSource = dataSource;
+    }
+
+    @JsonProperty("query")
+    public String getQuery() {
+        return query;
+    }
+
+    @JsonProperty("query")
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @JsonProperty("threshold_ratio")
+    public String getThresholdRatio() {
+        return thresholdRatio;
+    }
+
+    @JsonProperty("threshold_ratio")
+    public void setThresholdRatio(String thresholdRatio) {
+        this.thresholdRatio = thresholdRatio;
+    }
+
+    @JsonProperty("data_source")
+    public String getDataSource() {
+        return dataSource;
+    }
+
+    @JsonProperty("data_source")
+    public void setDataSource(String dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, this.getQuery());
+        operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, this.getThresholdRatio());
+        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        FuzzyTokenSourceBean fuzzyTokenSourceBean = (FuzzyTokenSourceBean) other;
+        return new EqualsBuilder()
+                .append(query, fuzzyTokenSourceBean.getQuery())
+                .append(thresholdRatio, fuzzyTokenSourceBean.getThresholdRatio())
+                .append(dataSource, fuzzyTokenSourceBean.getDataSource())
+                .isEquals() &&
+                super.equals(fuzzyTokenSourceBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(query)
+                .append(thresholdRatio)
+                .append(dataSource)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
@@ -66,6 +66,9 @@ public class FuzzyTokenSourceBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getQuery() == null || this.getThresholdRatio() == null || this.getDataSource() == null ||
+                operatorProperties == null)
+            return null;
         operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, this.getQuery());
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, this.getThresholdRatio());
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBean.java
@@ -1,0 +1,78 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the IndexSink operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("IndexSink")
+public class IndexSinkBean extends OperatorBean {
+    @JsonProperty("index_path")
+    private String indexPath;
+    @JsonProperty("index_name")
+    private String indexName;
+
+    public IndexSinkBean() {
+    }
+
+    public IndexSinkBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                         String indexPath, String indexName) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.indexPath = indexPath;
+        this.indexName = indexName;
+    }
+
+    @JsonProperty("index_path")
+    public String getIndexPath() {
+        return indexPath;
+    }
+
+    @JsonProperty("index_path")
+    public void setIndexPath(String indexPath) {
+        this.indexPath = indexPath;
+    }
+
+    @JsonProperty("index_name")
+    public String getIndexName() {
+        return indexName;
+    }
+
+    @JsonProperty("index_name")
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        //TODO - Check on properties for IndexSink, IndexSinkBuilder seems to be missing
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        IndexSinkBean indexSinkBean = (IndexSinkBean) other;
+        return new EqualsBuilder()
+                .append(indexPath, indexSinkBean.getIndexPath())
+                .append(indexName, indexSinkBean.getIndexName())
+                .isEquals() &&
+                super.equals(indexSinkBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(indexPath)
+                .append(indexName)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBean.java
@@ -51,6 +51,8 @@ public class IndexSinkBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(operatorProperties == null)
+            return null;
         //TODO - Check on properties for IndexSink, IndexSinkBuilder seems to be missing
         return operatorProperties;
     }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
@@ -81,4 +81,3 @@ public class JoinBean extends OperatorBean {
                 .toHashCode();
     }
 }
-}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
@@ -54,6 +54,8 @@ public class JoinBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getIdAttribute() == null || this.getDistance() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(JoinBuilder.JOIN_ID_ATTRIBUTE_NAME, this.getIdAttribute());
         operatorProperties.put(JoinBuilder.JOIN_DISTANCE, this.getDistance());
         // TODO - Check on the other properties required for the Join Operator

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/JoinBean.java
@@ -1,0 +1,84 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.JoinBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the Join operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("Join")
+public class JoinBean extends OperatorBean {
+    @JsonProperty("id_attribute")
+    private String idAttribute;
+    @JsonProperty("distance")
+    private String distance;
+
+    // A bean variable for the predicate type of the join has been omitted for now and will be included in the future
+
+    public JoinBean() {
+    }
+
+    public JoinBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                    String idAttribute, String distance) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.idAttribute = idAttribute;
+        this.distance = distance;
+    }
+
+    @JsonProperty("id_attribute")
+    public String getIdAttribute() {
+        return idAttribute;
+    }
+
+    @JsonProperty("id_attribute")
+    public void setIdAttribute(String idAttribute) {
+        this.idAttribute = idAttribute;
+    }
+
+    @JsonProperty("distance")
+    public String getDistance() {
+        return distance;
+    }
+
+    @JsonProperty("distance")
+    public void setDistance(String distance) {
+        this.distance = distance;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(JoinBuilder.JOIN_ID_ATTRIBUTE_NAME, this.getIdAttribute());
+        operatorProperties.put(JoinBuilder.JOIN_DISTANCE, this.getDistance());
+        // TODO - Check on the other properties required for the Join Operator
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        JoinBean joinBean = (JoinBean) other;
+        return new EqualsBuilder()
+                .append(idAttribute, joinBean.getIdAttribute())
+                .append(distance, joinBean.getDistance())
+                .isEquals() &&
+                super.equals(joinBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(idAttribute)
+                .append(distance)
+                .toHashCode();
+    }
+}
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBean.java
@@ -53,6 +53,8 @@ public class KeywordMatcherBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getKeyword() == null || this.getMatchingType() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, this.getKeyword());
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, this.getMatchingType().name());
         return operatorProperties;

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBean.java
@@ -1,0 +1,81 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.plangen.operatorbuilder.KeywordMatcherBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the KeywordMatcher operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("KeywordMatcher")
+public class KeywordMatcherBean extends OperatorBean {
+    @JsonProperty("keyword")
+    private String keyword;
+    @JsonProperty("matching_type")
+    private KeywordMatchingType matchingType;
+
+    public KeywordMatcherBean() {
+    }
+
+    public KeywordMatcherBean(String operatorID, String operatorType, String attributes, String limit,
+                              String offset, String keyword, KeywordMatchingType matchingType) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.keyword = keyword;
+        this.matchingType = matchingType;
+    }
+
+    @JsonProperty("keyword")
+    public String getKeyword() {
+        return keyword;
+    }
+
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @JsonProperty("matching_type")
+    public KeywordMatchingType getMatchingType() {
+        return matchingType;
+    }
+
+    @JsonProperty("matching_type")
+    public void setMatchingType(KeywordMatchingType matchingType) {
+        this.matchingType = matchingType;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(KeywordMatcherBuilder.KEYWORD, this.getKeyword());
+        operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, this.getMatchingType().name());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        KeywordMatcherBean keywordMatcherBean = (KeywordMatcherBean) other;
+        return new EqualsBuilder()
+                .append(keyword, keywordMatcherBean.getKeyword())
+                .append(matchingType, keywordMatcherBean.getMatchingType())
+                .isEquals() &&
+                super.equals(keywordMatcherBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(keyword)
+                .append(matchingType)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
@@ -67,6 +67,9 @@ public class KeywordSourceBean extends OperatorBean {
 
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getKeyword() == null || this.getMatchingType() == null || this.getDataSource() == null ||
+                operatorProperties == null)
+            return null;
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, this.getKeyword());
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, this.getMatchingType().name());
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
@@ -1,0 +1,98 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.plangen.operatorbuilder.KeywordMatcherBuilder;
+import edu.uci.ics.textdb.plangen.operatorbuilder.OperatorBuilderUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the KeywordSource operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("KeywordSource")
+public class KeywordSourceBean extends OperatorBean {
+    @JsonProperty("keyword")
+    private String keyword;
+    @JsonProperty("matching_type")
+    private DataConstants.KeywordMatchingType matchingType;
+    @JsonProperty("data_source")
+    private String dataSource;
+
+    public KeywordSourceBean() {
+    }
+
+    public KeywordSourceBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                             String keyword, DataConstants.KeywordMatchingType matchingType, String dataSource) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.keyword = keyword;
+        this.matchingType = matchingType;
+        this.dataSource = dataSource;
+    }
+
+    @JsonProperty("keyword")
+    public String getKeyword() {
+        return keyword;
+    }
+
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @JsonProperty("matching_type")
+    public DataConstants.KeywordMatchingType getMatchingType() {
+        return matchingType;
+    }
+
+    @JsonProperty("matching_type")
+    public void setMatchingType(DataConstants.KeywordMatchingType matchingType) {
+        this.matchingType = matchingType;
+    }
+
+    @JsonProperty("data_source")
+    public String getDataSource() {
+        return dataSource;
+    }
+
+    @JsonProperty("data_source")
+    public void setDataSource(String dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(KeywordMatcherBuilder.KEYWORD, this.getKeyword());
+        operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, this.getMatchingType().name());
+        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        KeywordSourceBean keywordSourceBean = (KeywordSourceBean) other;
+        return new EqualsBuilder()
+                .append(keyword, keywordSourceBean.getKeyword())
+                .append(matchingType, keywordSourceBean.getMatchingType())
+                .append(dataSource, keywordSourceBean.getDataSource())
+                .isEquals() &&
+                super.equals(keywordSourceBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(keyword)
+                .append(matchingType)
+                .append(dataSource)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBean.java
@@ -41,6 +41,8 @@ public class NlpExtractorBean extends OperatorBean {
     @Override
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getNlpTokenType() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(NlpExtractorBuilder.NLP_TYPE, this.getNlpTokenType().name());
         return operatorProperties;
     }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBean.java
@@ -1,0 +1,66 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.dataflow.nlpextrator.NlpPredicate.NlpTokenType;
+import edu.uci.ics.textdb.plangen.operatorbuilder.NlpExtractorBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the NlpExtractor operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("NlpExtractor")
+public class NlpExtractorBean extends OperatorBean {
+    @JsonProperty("nlp_type")
+    private NlpTokenType nlpTokenType;
+
+    public NlpExtractorBean() {
+    }
+
+    public NlpExtractorBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                            NlpTokenType nlpTokenType) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.nlpTokenType = nlpTokenType;
+    }
+
+    @JsonProperty("nlp_type")
+    public NlpTokenType getNlpTokenType() {
+        return nlpTokenType;
+    }
+
+    @JsonProperty("nlp_type")
+    public void setNlpTokenType(NlpTokenType nlpTokenType) {
+        this.nlpTokenType = nlpTokenType;
+    }
+
+    @Override
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(NlpExtractorBuilder.NLP_TYPE, this.getNlpTokenType().name());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        NlpExtractorBean nlpExtractorBean = (NlpExtractorBean) other;
+        return new EqualsBuilder()
+                .append(nlpTokenType, nlpExtractorBean.getNlpTokenType())
+                .isEquals() &&
+                super.equals(nlpExtractorBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(nlpTokenType)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/OperatorBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/OperatorBean.java
@@ -101,6 +101,8 @@ public abstract class OperatorBean {
             basicOperatorProperties.put(OperatorBuilderUtils.LIMIT, this.getLimit());
         if(this.getOffset() != null)
             basicOperatorProperties.put(OperatorBuilderUtils.OFFSET, this.getOffset());
+        if(this.getAttributes() == null)
+            return null;
         basicOperatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, this.getAttributes());
         return basicOperatorProperties;
     }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/ProjectionBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/ProjectionBean.java
@@ -15,6 +15,8 @@ public class ProjectionBean extends OperatorBean {
     @Override
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(operatorProperties == null)
+            return null;
         return operatorProperties;
     }
 }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/ProjectionBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/ProjectionBean.java
@@ -1,0 +1,20 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the Projection operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("Projection")
+public class ProjectionBean extends OperatorBean {
+    // Properties regarding the projection operator will go here
+    @Override
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        return operatorProperties;
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBean.java
@@ -1,0 +1,65 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.RegexMatcherBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the RegexMatcher operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 10/17/16.
+ */
+@JsonTypeName("RegexMatcher")
+public class RegexMatcherBean extends OperatorBean {
+    @JsonProperty("regex")
+    private String regex;
+
+    public RegexMatcherBean() {
+    }
+
+    public RegexMatcherBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                            String regex) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.regex = regex;
+    }
+
+    @JsonProperty("regex")
+    public String getRegex() {
+        return regex;
+    }
+
+    @JsonProperty("regex")
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    @Override
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(RegexMatcherBuilder.REGEX, this.getRegex());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        RegexMatcherBean regexMatcherBean = (RegexMatcherBean) other;
+        return new EqualsBuilder()
+                .append(regex, regexMatcherBean.getRegex())
+                .isEquals() &&
+                super.equals(regexMatcherBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(regex)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBean.java
@@ -40,6 +40,8 @@ public class RegexMatcherBean extends OperatorBean {
     @Override
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getRegex() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(RegexMatcherBuilder.REGEX, this.getRegex());
         return operatorProperties;
     }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
@@ -54,6 +54,8 @@ public class RegexSourceBean extends OperatorBean {
     @Override
     public HashMap<String, String> getOperatorProperties() {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        if(this.getRegex() == null || this.getDataSource() == null || operatorProperties == null)
+            return null;
         operatorProperties.put(RegexMatcherBuilder.REGEX, this.getRegex());
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
         return operatorProperties;

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
@@ -1,0 +1,82 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.uci.ics.textdb.plangen.operatorbuilder.OperatorBuilderUtils;
+import edu.uci.ics.textdb.plangen.operatorbuilder.RegexMatcherBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.HashMap;
+
+/**
+ * This class defines the properties/data members specific to the RegexSource operator
+ * and extends the OperatorBean class which defines the data members general to all operators
+ * Created by kishorenarendran on 11/09/16.
+ */
+@JsonTypeName("RegexSource")
+public class RegexSourceBean extends OperatorBean {
+    @JsonProperty("regex")
+    private String regex;
+    @JsonProperty("data_source")
+    private String dataSource;
+
+    public RegexSourceBean() {
+    }
+
+    public RegexSourceBean(String operatorID, String operatorType, String attributes, String limit, String offset,
+                           String regex, String dataSource) {
+        super(operatorID, operatorType, attributes, limit, offset);
+        this.regex = regex;
+        this.dataSource = dataSource;
+    }
+
+    @JsonProperty("regex")
+    public String getRegex() {
+        return regex;
+    }
+
+    @JsonProperty("regex")
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    @JsonProperty("data_source")
+    public String getDataSource() {
+        return dataSource;
+    }
+
+    @JsonProperty("data_source")
+    public void setDataSource(String dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public HashMap<String, String> getOperatorProperties() {
+        HashMap<String, String> operatorProperties = super.getOperatorProperties();
+        operatorProperties.put(RegexMatcherBuilder.REGEX, this.getRegex());
+        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        return operatorProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (other == this) return true;
+        if (!(other instanceof OperatorBean)) return false;
+        RegexSourceBean regexSourceBean = (RegexSourceBean) other;
+        return new EqualsBuilder()
+                .append(regex, regexSourceBean.getRegex())
+                .append(dataSource, regexSourceBean.getDataSource())
+                .isEquals() &&
+                super.equals(regexSourceBean);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31)
+                .append(regex)
+                .append(dataSource)
+                .toHashCode();
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/QueryPlanRequestTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/QueryPlanRequestTest.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.web.request;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import org.junit.Test;
@@ -44,5 +45,41 @@ public class QueryPlanRequestTest {
         QueryPlanRequest queryPlanRequest = MAPPER.readValue(jsonString, QueryPlanRequest.class);
         assertEquals(queryPlanRequest.getOperatorBeans().size(), 2);
         assertEquals(queryPlanRequest.getOperatorLinkBeans().size(), 1);
+    }
+
+    @Test
+    public void testInvalidOperatorTypeDeserialization() throws IOException {
+        String jsonString = "{\n" +
+                "    \"operators\": [{\n" +
+                "        \"operator_id\": \"operator1\",\n" +
+                "        \"operator_type\": \"SomeRandomOperatorType\",\n" +
+                "        \"attributes\": \"attributes\",\n" +
+                "        \"limit\": \"10\",\n" +
+                "        \"offset\": \"100\",\n" +
+                "        \"dictionary\": \"dict1\",\n" +
+                "        \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+                "    }, {\n" +
+                "\n" +
+                "        \"operator_id\": \"operator2\",\n" +
+                "        \"operator_type\": \"DictionaryMatcher\",\n" +
+                "        \"attributes\": \"attributes\",\n" +
+                "        \"limit\": \"10\",\n" +
+                "        \"offset\": \"100\",\n" +
+                "        \"dictionary\": \"dict2\",\n" +
+                "        \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+                "    }],\n" +
+                "    \"links\": [{\n" +
+                "        \"from\": \"operator1\",\n" +
+                "        \"to\": \"operator2\"    \n" +
+                "    }]\n" +
+                "}";
+        boolean exceptionThrownFlag = false;
+        try {
+            QueryPlanRequest queryPlanRequest = MAPPER.readValue(jsonString, QueryPlanRequest.class);
+        }
+        catch(JsonMappingException e) {
+            exceptionThrownFlag = true;
+        }
+        assertEquals(exceptionThrownFlag, true);
     }
 }

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FileSinkBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FileSinkBeanTest.java
@@ -1,0 +1,49 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the FileSink operators' properties
+ * Created by kishorenarendran on 11/9/16.
+ */
+public class FileSinkBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final FileSinkBean fileSinkBean = new FileSinkBean("operator1", "FileSink", "attributes", "10", "100",
+                "filepath");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"FileSink\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"file_path\": \"filepath\"\n" +
+                "}";
+        FileSinkBean deserializedObject = MAPPER.readValue(jsonString, FileSinkBean.class);
+        assertEquals(fileSinkBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final FileSinkBean fileSinkBean = new FileSinkBean("operator1", "FileSink", "attributes", "10", "100",
+                "filepath");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"FileSink\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"file_path\": \"filepath1\"\n" +
+                "}";
+        FileSinkBean deserializedObject = MAPPER.readValue(jsonString, FileSinkBean.class);
+        assertEquals(fileSinkBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenMatcherBeanTest.java
@@ -1,0 +1,53 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.FileSinkBean;
+import edu.uci.ics.textdb.web.request.beans.FuzzyTokenMatcherBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the FuzzyTokenMatcher operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class FuzzyTokenMatcherBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final FuzzyTokenMatcherBean fuzzyTokenMatcherBean = new FuzzyTokenMatcherBean("operator1", "FuzzyTokenMatcher",
+                "attributes", "10", "100", "query",  "0.8");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"FuzzyTokenMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"query\": \"query\",\n" +
+                "    \"threshold_ratio\": \"0.8\"\n" +
+                "}";
+        FuzzyTokenMatcherBean deserializedObject = MAPPER.readValue(jsonString, FuzzyTokenMatcherBean.class);
+        assertEquals(fuzzyTokenMatcherBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final FuzzyTokenMatcherBean fuzzyTokenMatcherBean = new FuzzyTokenMatcherBean("operator1", "FuzzyTokenMatcher",
+                "attributes", "10", "100", "query",  "0.8");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"FuzzyTokenMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"query\": \"query1\",\n" +
+                "    \"threshold_ratio\": \"0.9\"\n" +
+                "}";
+        FuzzyTokenMatcherBean deserializedObject = MAPPER.readValue(jsonString, FuzzyTokenMatcherBean.class);
+        assertEquals(fuzzyTokenMatcherBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBeanTest.java
@@ -1,0 +1,54 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.FuzzyTokenSourceBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the FuzzyTokenSource operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class FuzzyTokenSourceBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final FuzzyTokenSourceBean fuzzyTokenSourceBean = new FuzzyTokenSourceBean("operator1", "FuzzyTokenSource",
+                "attributes", "10", "100", "query", "0.8", "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"FuzzyTokenSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"query\": \"query\",\n" +
+                "    \"threshold_ratio\": \"0.8\",\n" +
+                "    \"data_source\": \"datasource\"\n" +
+                "}";
+        FuzzyTokenSourceBean deserializedObject = MAPPER.readValue(jsonString, FuzzyTokenSourceBean.class);
+        assertEquals(fuzzyTokenSourceBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final FuzzyTokenSourceBean fuzzyTokenSourceBean = new FuzzyTokenSourceBean("operator1", "FuzzyTokenSource",
+                "attributes", "10", "100", "query", "0.8", "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"FuzzyTokenSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"query\": \"query2\",\n" +
+                "    \"threshold_ratio\": \"0.9\",\n" +
+                "    \"data_source\": \"datasource1\"\n" +
+                "}";
+        FuzzyTokenSourceBean deserializedObject = MAPPER.readValue(jsonString, FuzzyTokenSourceBean.class);
+        assertEquals(fuzzyTokenSourceBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/IndexSinkBeanTest.java
@@ -1,0 +1,52 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.IndexSinkBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the IndexSink operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class IndexSinkBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final IndexSinkBean indexSinkBean = new IndexSinkBean("operator1", "IndexSink", "attributes", "10", "100",
+                "indexpath", "indexname");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"IndexSink\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"index_path\": \"indexpath\",\n" +
+                "    \"index_name\": \"indexname\"\n" +
+                "}";
+        IndexSinkBean deserializedObject = MAPPER.readValue(jsonString, IndexSinkBean.class);
+        assertEquals(indexSinkBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final IndexSinkBean indexSinkBean = new IndexSinkBean("operator1", "IndexSink", "attributes", "10", "100",
+                "indexpath", "indexname");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"IndexSink\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"index_path\": \"indexpath1\",\n" +
+                "    \"index_name\": \"indexname1\"\n" +
+                "}";
+        IndexSinkBean deserializedObject = MAPPER.readValue(jsonString, IndexSinkBean.class);
+        assertEquals(indexSinkBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/JoinBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/JoinBeanTest.java
@@ -1,0 +1,50 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.JoinBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the JoinBean operators' properties
+ * Created by kishorenarendran on 10/20/16.
+ */
+public class JoinBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final JoinBean joinBean = new JoinBean("operator1", "Join", "attributes", "10", "100", "attribute", "10");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"Join\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"id_attribute\": \"attribute\",\n" +
+                "    \"distance\": \"10\"\n" +
+                "}";
+        JoinBean deserializedObject = MAPPER.readValue(jsonString, JoinBean.class);
+        assertEquals(joinBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final JoinBean joinBean = new JoinBean("operator1", "Join", "attributes", "10", "100", "attribute", "10");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"Join\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"id_attribute\": \"attribute2\",\n" +
+                "    \"distance\": \"20\"\n" +
+                "}";
+        JoinBean deserializedObject = MAPPER.readValue(jsonString, JoinBean.class);
+        assertEquals(joinBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/KeywordMatcherBeanTest.java
@@ -1,0 +1,54 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.web.request.beans.FileSinkBean;
+import edu.uci.ics.textdb.web.request.beans.KeywordMatcherBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the KeywordMatcher operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class KeywordMatcherBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final KeywordMatcherBean keywordMatcherBean = new KeywordMatcherBean("operator1", "KeywordMatcher",
+                "attributes", "10", "100", "keyword1", DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"KeywordMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"keyword\": \"keyword1\",\n" +
+                "    \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+                "}";
+        KeywordMatcherBean deserializedObject = MAPPER.readValue(jsonString, KeywordMatcherBean.class);
+        assertEquals(keywordMatcherBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final KeywordMatcherBean keywordMatcherBean = new KeywordMatcherBean("operator1", "KeywordMatcher",
+                "attributes", "10", "100", "keyword1", DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"KeywordMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"keyword\": \"keyword2\",\n" +
+                "    \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+                "}";
+        KeywordMatcherBean deserializedObject = MAPPER.readValue(jsonString, KeywordMatcherBean.class);
+        assertEquals(keywordMatcherBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBeanTest.java
@@ -1,0 +1,57 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.web.request.beans.FileSinkBean;
+import edu.uci.ics.textdb.web.request.beans.KeywordMatcherBean;
+import edu.uci.ics.textdb.web.request.beans.KeywordSourceBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the KeywordSource operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class KeywordSourceBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final KeywordSourceBean keywordSourceBean = new KeywordSourceBean("operator1", "KeywordSource", "attributes",
+                "10", "100", "keyword1", DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"KeywordSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"keyword\": \"keyword1\",\n" +
+                "    \"matching_type\": \"PHRASE_INDEXBASED\",\n" +
+                "    \"data_source\": \"datasource\"\n" +
+                "}";
+        KeywordSourceBean deserializedObject = MAPPER.readValue(jsonString, KeywordSourceBean.class);
+        assertEquals(keywordSourceBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final KeywordSourceBean keywordSourceBean = new KeywordSourceBean("operator1", "KeywordSource", "attributes",
+                "10", "100", "keyword1", DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"KeywordSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"keyword\": \"keyword2\",\n" +
+                "    \"matching_type\": \"PHRASE_INDEXBASED\",\n" +
+                "    \"data_source\": \"datasource1\"\n" +
+                "}";
+        KeywordSourceBean deserializedObject = MAPPER.readValue(jsonString, KeywordSourceBean.class);
+        assertEquals(keywordSourceBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/NlpExtractorBeanTest.java
@@ -1,0 +1,51 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.dataflow.nlpextrator.NlpPredicate;
+import edu.uci.ics.textdb.web.request.beans.NlpExtractorBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the NLPExtractor operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class NlpExtractorBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final NlpExtractorBean nlpExtractorBean = new NlpExtractorBean("operator1", "NlpExtractor", "attributes",
+                "10", "100", NlpPredicate.NlpTokenType.Noun);
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"NlpExtractor\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"nlp_type\": \"Noun\"\n" +
+                "}";
+        NlpExtractorBean deserializedObject = MAPPER.readValue(jsonString, NlpExtractorBean.class);
+        assertEquals(nlpExtractorBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final NlpExtractorBean nlpExtractorBean = new NlpExtractorBean("operator1", "NlpExtractor", "attributes",
+                "10", "100", NlpPredicate.NlpTokenType.Noun);
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"NlpExtractor\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"nlp_type\": \"Verb\"\n" +
+                "}";
+        NlpExtractorBean deserializedObject = MAPPER.readValue(jsonString, NlpExtractorBean.class);
+        assertEquals(nlpExtractorBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/RegexMatcherBeanTest.java
@@ -1,0 +1,50 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.RegexMatcherBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the RegexMatcher operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class RegexMatcherBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final RegexMatcherBean regexMatcherBean = new RegexMatcherBean("operator1", "RegexMatcher", "attributes",
+                "10", "100", "regex");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"RegexMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"regex\": \"regex\"\n" +
+                "}";
+        RegexMatcherBean deserializedObject = MAPPER.readValue(jsonString, RegexMatcherBean.class);
+        assertEquals(regexMatcherBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final RegexMatcherBean regexMatcherBean = new RegexMatcherBean("operator1", "RegexMatcher", "attributes",
+                "10", "100", "regex");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"RegexMatcher\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"regex\": \"regex1\"\n" +
+                "}";
+        RegexMatcherBean deserializedObject = MAPPER.readValue(jsonString, RegexMatcherBean.class);
+        assertEquals(regexMatcherBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBeanTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBeanTest.java
@@ -1,0 +1,52 @@
+package edu.uci.ics.textdb.web.request.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.uci.ics.textdb.web.request.beans.RegexSourceBean;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for the deserialization of the RegexSource operators' properties
+ * Created by kishorenarendran on 11/09/16.
+ */
+public class RegexSourceBeanTest {
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final RegexSourceBean regexSourceBean = new RegexSourceBean("operator1", "RegexSource", "attributes",
+                "10", "100", "regex", "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator1\",\n" +
+                "    \"operator_type\": \"RegexSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"regex\": \"regex\",\n" +
+                "    \"data_source\": \"datasource\"\n" +
+                "}";
+        RegexSourceBean deserializedObject = MAPPER.readValue(jsonString, RegexSourceBean.class);
+        assertEquals(regexSourceBean.equals(deserializedObject), true);
+    }
+
+    @Test
+    public void testInvalidDeserialization() throws IOException {
+        final RegexSourceBean regexSourceBean = new RegexSourceBean("operator1", "RegexSource", "attributes",
+                "10", "100", "regex", "datasource");
+        String jsonString = "{\n" +
+                "    \"operator_id\": \"operator2\",\n" +
+                "    \"operator_type\": \"RegexSource\",\n" +
+                "    \"attributes\":  \"attributes\",\n" +
+                "    \"limit\": \"10\",\n" +
+                "    \"offset\": \"100\",\n" +
+                "    \"regex\": \"regex1\",\n" +
+                "    \"data_source\": \"datasource1\"\n" +
+                "}";
+        RegexSourceBean deserializedObject = MAPPER.readValue(jsonString, RegexSourceBean.class);
+        assertEquals(regexSourceBean.equals(deserializedObject), false);
+    }
+}

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
@@ -50,6 +50,29 @@ public class QueryPlanResourceTest {
             "    }]\n" +
             "}";
 
+    public static final String faultyQueryPlanRequestString = "{\n" +
+            "    \"operators\": [{\n" +
+            "        \"operator_id\": \"operator1\",\n" +
+            "        \"operator_type\": \"DictionaryMatcher\",\n" +
+            "        \"attributes\": \"attributes\",\n" +
+            "        \"limit\": \"10\",\n" +
+            "        \"offset\": \"100\",\n" +
+            "        \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+            "    }, {\n" +
+            "\n" +
+            "        \"operator_id\": \"operator2\",\n" +
+            "        \"operator_type\": \"DictionaryMatcher\",\n" +
+            "        \"attributes\": \"attributes\",\n" +
+            "        \"limit\": \"10\",\n" +
+            "        \"offset\": \"100\",\n" +
+            "        \"dictionary\": \"dict2\"\n" +
+            "    }],\n" +
+            "    \"links\": [{\n" +
+            "        \"from\": \"operator1\",\n" +
+            "        \"to\": \"operator2\"    \n" +
+            "    }]\n" +
+            "}";
+
     /**
      * Tests the query plan execution endpoint.
      */
@@ -64,5 +87,12 @@ public class QueryPlanResourceTest {
                 .post(Entity.entity(queryPlanRequestString, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
+
+        response = client.target(
+                String.format("http://localhost:%d/queryplan/execute", RULE.getLocalPort()))
+                .request()
+                .post(Entity.entity(faultyQueryPlanRequestString, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 }


### PR DESCRIPTION
* This PR introduces the necessary Bean classes for completing the JSON translation on the `textdb-web` layer. 
* This PR introduces beans for the remaining operators which are - `FileSink`, `FuzzyTokenMatcher`, `FuzzyTokenSource`, `IndexSink`, `Join`, `KeywordMatcher`, `KeywordSource`, `NlpExtractor`, `Projection`, `RegexMatcher`, `RegexSource`
* Adds deserialization tests for all the aforementioned beans
* Adds check for essential operator properties, and changes behavior for `LogicalPlan` creation in such scenarios - this check has been added in every operator bean's `getOperatorProperties()` function. 