### PR TITLE
[Issue #243] Add constants for Lucene analyzers

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/DataConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/DataConstants.java
@@ -3,16 +3,6 @@
  */
 package edu.uci.ics.textdb.common.constants;
 
-import java.io.IOException;
-
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
-import org.apache.lucene.analysis.custom.CustomAnalyzer;
-import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-
-import edu.uci.ics.textdb.common.exception.DataFlowException;
-
 /**
  * @author sandeepreddy602
  * @author Zuozhi Wang (zuozhi)
@@ -89,50 +79,6 @@ public class DataConstants {
         LESS_THAN_OR_EQUAL_TO,
 
         NOT_EQUAL_TO
-    }
-    
-    
-    public static String getStandardAnalyzerString() {
-        return "standard";
-    }
-    
-    public static String getNGramAnalyzerString(int gramNum) {
-        return gramNum + "-gram";
-    }
-
-    /**
-     * @return a n-gram analyzer that is used by RegexMatcher
-     * @throws IOException
-     */
-    public static Analyzer getNGramAnalyzer(int gramNum) throws DataFlowException {
-        try {
-            return CustomAnalyzer.builder()
-                    .withTokenizer(NGramTokenizerFactory.class, 
-                            new String[] { "minGramSize", Integer.toString(gramNum), "maxGramSize", Integer.toString(gramNum) })
-                    .addTokenFilter(LowerCaseFilterFactory.class).build();
-        } catch (IOException e) {
-            throw new DataFlowException(e.getMessage(), e);
-        }
-    }
-
-    public static Analyzer getStandardAnalyzer() {
-        return new StandardAnalyzer();
-    }
-    
-    public Analyzer getLuceneAnalyzer(String luceneAnalyzerString) throws DataFlowException {
-        if (luceneAnalyzerString.equals("standard")) {
-            return getStandardAnalyzer();
-        }
-        else if (luceneAnalyzerString.endsWith("-gram")) {
-            try {
-                Integer gramNum = Integer.parseInt(
-                        luceneAnalyzerString.substring(0, luceneAnalyzerString.indexOf('-')));
-                return getNGramAnalyzer(gramNum);
-            } catch (NumberFormatException e) {
-                throw new DataFlowException(e.getMessage(), e);
-            }
-        }
-        throw new DataFlowException(luceneAnalyzerString + " is not a valid lucene analyzer");
     }
 
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/LuceneAnalyzerConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/LuceneAnalyzerConstants.java
@@ -1,0 +1,79 @@
+package edu.uci.ics.textdb.common.constants;
+
+import java.io.IOException;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.custom.CustomAnalyzer;
+import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+
+import edu.uci.ics.textdb.common.exception.DataFlowException;
+
+/**
+ * LuceneAnalyzerConstants contains helper functions specifically
+ *   used when dealing with different Lucene analyzers.
+ * 
+ * @author Zuozhi Wang
+ *
+ */
+public class LuceneAnalyzerConstants {
+    
+    
+    public static String standardAnalyzerString() {
+        return "standard";
+    }
+
+    
+    public static String nGramAnalyzerString(int gramNum) {
+        return gramNum + "-gram";
+    }
+    
+    /**
+     * Gets the lucene analyzer based on the string, currently analyzers supported are:
+     *   "standard", same as calling standardAnalyzerString().
+     *   
+     *   "n-gram", n represents the number of grams, for example, "3-gram",
+     *     same as calling nGramAnalyzerString(3).
+     * 
+     * @param luceneAnalyzerString
+     * @return
+     * @throws DataFlowException, if the luceneAnalyzerString is invalid
+     */
+    public static Analyzer getLuceneAnalyzer(String luceneAnalyzerString) throws DataFlowException {
+        if (luceneAnalyzerString.equals("standard")) {
+            return LuceneAnalyzerConstants.getStandardAnalyzer();
+        }
+        else if (luceneAnalyzerString.endsWith("-gram")) {
+            try {
+                Integer gramNum = Integer.parseInt(
+                        luceneAnalyzerString.substring(0, luceneAnalyzerString.indexOf('-')));
+                return getNGramAnalyzer(gramNum);
+            } catch (NumberFormatException e) {
+                throw new DataFlowException(luceneAnalyzerString + " is not a valid lucene analyzer");
+            }
+        }
+        throw new DataFlowException(luceneAnalyzerString + " is not a valid lucene analyzer");
+    }
+
+
+    public static Analyzer getStandardAnalyzer() {
+        return new StandardAnalyzer();
+    }
+
+    /**
+     * @return a n-gram analyzer that tokenizes the text into grams of length n.
+     * @throws DataFlowException
+     */
+    public static Analyzer getNGramAnalyzer(int gramNum) throws DataFlowException {
+        try {
+            return CustomAnalyzer.builder()
+                    .withTokenizer(NGramTokenizerFactory.class, 
+                            new String[] { "minGramSize", Integer.toString(gramNum), "maxGramSize", Integer.toString(gramNum) })
+                    .addTokenFilter(LowerCaseFilterFactory.class).build();
+        } catch (IOException e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionaryMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionaryMatcherBuilder.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.Dictionary;
@@ -53,7 +53,7 @@ public class DictionaryMatcherBuilder {
 
         // build DictionaryMatcher
         DictionaryPredicate predicate = new DictionaryPredicate(dictionary, attributeList,
-                DataConstants.getStandardAnalyzer(), matchingType);
+                LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
         DictionaryMatcher operator = new DictionaryMatcher(predicate);
 
         // set limit and offset

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilder.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.Dictionary;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
@@ -53,7 +53,7 @@ public class DictionarySourceBuilder {
                 + "must be one of " + KeywordMatcherBuilder.keywordMatchingTypeMap.keySet());
         
         DictionaryPredicate predicate = new DictionaryPredicate(
-                dictionary, attributeList, DataConstants.getStandardAnalyzer(), matchingType);
+                dictionary, attributeList, LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
         

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilder.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
@@ -48,7 +48,7 @@ public class FuzzyTokenMatcherBuilder {
         FuzzyTokenPredicate fuzzyTokenPredicate;
         try {
             fuzzyTokenPredicate = new FuzzyTokenPredicate(query, attributeList,
-                    DataConstants.getStandardAnalyzer(), thresholdRatioDouble);
+                    LuceneAnalyzerConstants.getStandardAnalyzer(), thresholdRatioDouble);
         } catch (DataFlowException e) {
             throw new PlanGenException(e.getMessage(), e);
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
@@ -7,8 +7,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
@@ -55,7 +55,7 @@ public class KeywordMatcherBuilder {
         KeywordPredicate keywordPredicate;
         try {
             keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                    DataConstants.getStandardAnalyzer(), matchingType);
+                    LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
         } catch (DataFlowException e) {
             throw new PlanGenException(e.getMessage(), e);
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
@@ -52,7 +52,7 @@ public class KeywordSourceBuilder {
         KeywordPredicate keywordPredicate;
         try {
             keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                    DataConstants.getStandardAnalyzer(), matchingType);     
+                    LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
         } catch (DataFlowException e) {
             throw new PlanGenException(e.getMessage(), e);
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
@@ -43,8 +43,8 @@ public class RegexMatcherBuilder {
         RegexPredicate regexPredicate;
         try {
             regexPredicate = new RegexPredicate(regex, attributeList,
-                    DataConstants.getTrigramAnalyzer());
-        } catch (DataFlowException | IOException e) {
+                    DataConstants.getNGramAnalyzer(3));
+        } catch (DataFlowException e) {
             throw new PlanGenException(e.getMessage(), e);
         }
         RegexMatcher regexMatcher = new RegexMatcher(regexPredicate);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilder.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
@@ -43,7 +43,7 @@ public class RegexMatcherBuilder {
         RegexPredicate regexPredicate;
         try {
             regexPredicate = new RegexPredicate(regex, attributeList,
-                    DataConstants.getNGramAnalyzer(3));
+                    LuceneAnalyzerConstants.getNGramAnalyzer(3));
         } catch (DataFlowException e) {
             throw new PlanGenException(e.getMessage(), e);
         }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import org.apache.lucene.analysis.Analyzer;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.ITuple;
-import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.StorageException;
@@ -99,7 +99,7 @@ public class RegexMatcherPerformanceTest {
         for(String regex: regexes){
 	        // analyzer should generate grams all in lower case to build a lower
 	        // case index.
-	        Analyzer luceneAnalyzer = DataConstants.getNGramAnalyzer(3);
+	        Analyzer luceneAnalyzer = LuceneAnalyzerConstants.getNGramAnalyzer(3);
 	        RegexPredicate regexPredicate = new RegexPredicate(regex, Arrays.asList(attributeList), luceneAnalyzer);
 	        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(
 	                regexPredicate.generateDataReaderPredicate(dataStore));

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -99,7 +99,7 @@ public class RegexMatcherPerformanceTest {
         for(String regex: regexes){
 	        // analyzer should generate grams all in lower case to build a lower
 	        // case index.
-	        Analyzer luceneAnalyzer = DataConstants.getTrigramAnalyzer();
+	        Analyzer luceneAnalyzer = DataConstants.getNGramAnalyzer(3);
 	        RegexPredicate regexPredicate = new RegexPredicate(regex, Arrays.asList(attributeList), luceneAnalyzer);
 	        IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(
 	                regexPredicate.generateDataReaderPredicate(dataStore));

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -182,7 +182,7 @@ public class PerfTestUtils {
             if (file.isDirectory()) {
                 continue;
             }
-            writeIndex(file.getName(), DataConstants.getTrigramAnalyzer(), "trigram");
+            writeIndex(file.getName(), DataConstants.getNGramAnalyzer(3), "trigram");
         }
 
     }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -13,7 +13,7 @@ import java.util.Scanner;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
-import edu.uci.ics.textdb.common.constants.DataConstants;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.engine.Engine;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -182,7 +182,7 @@ public class PerfTestUtils {
             if (file.isDirectory()) {
                 continue;
             }
-            writeIndex(file.getName(), DataConstants.getNGramAnalyzer(3), "trigram");
+            writeIndex(file.getName(), LuceneAnalyzerConstants.getNGramAnalyzer(3), "trigram");
         }
 
     }


### PR DESCRIPTION
This PR introduces a new "constants" class, `LuceneAnalyzerConstants`. It's purpose is to manage the helper functions related to lucene analyzers, such as getting a lucene analyzer based on a string.

This PR add 3 new functions: 
`standardAnalyzerString`, which returns a string "standard" 
`nGramAanlyzerString(int n)`, which returns a string "n-gram"
`getLuceneAnalyzer(String luceneAnalyzerString)`. which returns a lucene analyzer based on the string.

Previously, Lucene Analyzer constants reside in `DataFlowConstants` class, however, with more and more functions being introduced, I feel it's better to make it a separate class.