### PR TITLE
[Issue #272] Add getAttribute in Schema

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
@@ -1,8 +1,8 @@
 package edu.uci.ics.textdb.api.common;
 
 public class Attribute {
-    private String fieldName;
-    private FieldType fieldType;
+    private final String fieldName;
+    private final FieldType fieldType;
 
     public Attribute(String fieldName, FieldType type) {
         this.fieldName = fieldName;
@@ -20,5 +20,34 @@ public class Attribute {
     @Override
     public String toString() {
         return "Attribute [fieldName=" + fieldName + ", fieldType=" + fieldType + "]";
+    }
+    
+    @Override
+    public boolean equals(Object toCompare) {
+        if (this == toCompare) {
+            return true;
+        }
+        if (toCompare == null) {
+            return false;
+        }
+        if (this.getClass() != toCompare.getClass()) {
+            return false;
+        }
+        
+        Attribute that = (Attribute) toCompare;
+        
+        if (this.fieldName == null) {
+            return that.fieldName == null;
+        }
+        if (this.fieldType == null) {
+            return that.fieldType == null;
+        }
+        
+        return this.fieldName.equals(that.fieldName) && this.fieldType.equals(that.fieldType);
+    }
+    
+    @Override
+    public int hashCode() {
+        return this.fieldName.hashCode() + this.fieldType.toString().hashCode();
     }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -30,8 +30,8 @@ public class Schema {
         return attributes;
     }
 
-    public Integer getIndex(String fieldName) {
-        return fieldNameVsIndex.get(fieldName.toLowerCase());
+    public Attribute getAttribute(String fieldName) {
+        return attributes.get(fieldNameVsIndex.get(fieldName.toLowerCase()));
     }
 
     public boolean containsField(String fieldName) {

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -30,8 +30,16 @@ public class Schema {
         return attributes;
     }
 
+    public Integer getIndex(String fieldName) {
+        return fieldNameVsIndex.get(fieldName.toLowerCase());
+    }
+    
     public Attribute getAttribute(String fieldName) {
-        return attributes.get(fieldNameVsIndex.get(fieldName.toLowerCase()));
+        Integer attrIndex = getIndex(fieldName);
+        if (attrIndex == null) {
+            return null;
+        }
+        return attributes.get(attrIndex);
     }
 
     public boolean containsField(String fieldName) {

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Schema {
     private List<Attribute> attributes;
@@ -28,6 +29,10 @@ public class Schema {
 
     public List<Attribute> getAttributes() {
         return attributes;
+    }
+    
+    public List<String> getAttributeNames() {
+        return attributes.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList());
     }
 
     public Integer getIndex(String fieldName) {

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -31,9 +31,7 @@ public class SchemaTest {
     }
 
     @Test
-    public void testGetAttribute() {
-        
-        
+    public void testGetIndex() {
 
         int expectedIndex1 = 0;
         int expectedIndex2 = 1;
@@ -42,6 +40,27 @@ public class SchemaTest {
         Assert.assertEquals(expectedIndex1, retrievedIndex1);
         Assert.assertEquals(expectedIndex2, retrievedIndex2);
 
+    }
+    
+    @Test
+    public void testGetAttribute() {
+        
+        Attribute expectedAttribute1 = new Attribute("sampleField_1", FieldType.STRING);
+        Attribute expectedAttribute2 = new Attribute("sampleField_2", FieldType.STRING);
+
+        Attribute retrievedAttribute1 = schema.getAttribute(fieldName1);
+        Attribute retrievedAttribute2 = schema.getAttribute(fieldName2.toUpperCase());
+        
+        Assert.assertEquals(expectedAttribute1, retrievedAttribute1);
+        Assert.assertEquals(expectedAttribute2, retrievedAttribute2);
+
+    }
+    
+    @Test
+    public void testGetInvalidAttribute() {
+        Attribute retrievedAttribute1 = schema.getAttribute("invalid_attribute");
+        
+        Assert.assertNull(retrievedAttribute1);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -31,7 +31,9 @@ public class SchemaTest {
     }
 
     @Test
-    public void testGetIndex() {
+    public void testGetAttribute() {
+        
+        
 
         int expectedIndex1 = 0;
         int expectedIndex2 = 1;

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.api.common;
 
+import java.util.Arrays;
 import java.util.List;
 
 import junit.framework.Assert;
@@ -54,6 +55,14 @@ public class SchemaTest {
         Assert.assertEquals(expectedAttribute1, retrievedAttribute1);
         Assert.assertEquals(expectedAttribute2, retrievedAttribute2);
 
+    }
+    
+    @Test
+    public void testGetAttributeNames() {
+        List<String> expectedAttrNames = Arrays.asList("sampleField_1", "sampleField_2");
+        List<String> actualAttrNames = schema.getAttributeNames();
+        
+        Assert.assertEquals(expectedAttrNames, actualAttrNames);
     }
     
     @Test

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -288,8 +288,8 @@ public class Utils {
     }
 
     public static ITuple removePayload(ITuple tuple) {
-        Attribute payloadAttribute = tuple.getSchema().getAttribute(SchemaConstants.PAYLOAD);
-        if (payloadAttribute == null) {
+        Integer payloadIndex = tuple.getSchema().getIndex(SchemaConstants.PAYLOAD);
+        if (payloadIndex == null) {
             return tuple;
         } else {
             Attribute[] attrWithoutPayload = tuple.getSchema().getAttributes().stream()
@@ -305,7 +305,12 @@ public class Utils {
 
     public static List<Span> generatePayloadFromTuple(ITuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate payload only for TEXT field
+                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate
+                                                                         // payload
+                                                                         // only
+                                                                         // for
+                                                                         // TEXT
+                                                                         // field
                 .map(attr -> attr.getFieldName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -288,8 +288,8 @@ public class Utils {
     }
 
     public static ITuple removePayload(ITuple tuple) {
-        Integer payloadIndex = tuple.getSchema().getIndex(SchemaConstants.PAYLOAD);
-        if (payloadIndex == null) {
+        Attribute payloadAttribute = tuple.getSchema().getAttribute(SchemaConstants.PAYLOAD);
+        if (payloadAttribute == null) {
             return tuple;
         } else {
             Attribute[] attrWithoutPayload = tuple.getSchema().getAttributes().stream()
@@ -305,12 +305,7 @@ public class Utils {
 
     public static List<Span> generatePayloadFromTuple(ITuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate
-                                                                         // payload
-                                                                         // only
-                                                                         // for
-                                                                         // TEXT
-                                                                         // field
+                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate payload only for TEXT field
                 .map(attr -> attr.getFieldName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))


### PR DESCRIPTION
This PR adds a new helper function `getAttribute` in Schema to get an attribute by an attribute name. The corresponding test cases are also added.

`getAttribute` function will be used in the following changes of replacing attribute lists (which contain both attribute name and type) with lists of attribute names, as suggested in issue #272.

This PR also adds `getAttributeNames()` helper function, which returns a list of attribute names (`List<String>`)