### PR TITLE
[Issue #272] Remove unnecessary parameters in DataReaderPredicate

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -107,8 +107,7 @@ public class FuzzyTokenPredicate implements IPredicate {
     }
 
     public DataReaderPredicate getDataReaderPredicate(IDataStore dataStore) {
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, this.query, dataStore,
-                this.attributeList, this.luceneAnalyzer);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, dataStore, this.luceneAnalyzer);
         dataReaderPredicate.setIsSpanInformationAdded(true);
         return dataReaderPredicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -180,8 +180,7 @@ public class KeywordPredicate implements IPredicate {
     }
 
     public DataReaderPredicate generateDataReaderPredicate(IDataStore dataStore) {
-        DataReaderPredicate predicate = new DataReaderPredicate(this.luceneQuery, this.query, dataStore,
-                this.attributeList, this.luceneAnalyzer);
+        DataReaderPredicate predicate = new DataReaderPredicate(this.luceneQuery, dataStore,this.luceneAnalyzer);
         predicate.setIsSpanInformationAdded(true);
         return predicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -64,8 +64,7 @@ public class RegexPredicate implements IPredicate {
             throw new DataFlowException(e.getMessage(), e);
         }
         
-        DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, queryString, dataStore, attributeList,
-                luceneAnalyzer);
+        DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, dataStore, luceneAnalyzer);
         predicate.setIsSpanInformationAdded(false);
         return predicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.textdb.dataflow.source;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.MatchAllDocsQuery;
 
@@ -9,7 +10,6 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.reader.DataReader;
@@ -33,8 +33,7 @@ public class ScanBasedSourceOperator implements ISourceOperator {
     public void open() throws TextDBException {
         try {
             DataReaderPredicate predicate = new DataReaderPredicate(
-                    new MatchAllDocsQuery(), DataConstants.SCAN_QUERY, dataStore,
-                    dataStore.getSchema().getAttributes(), luceneAnalyzer);
+                    new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
             this.dataReader = new DataReader(predicate);
             this.dataReader.open();
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
@@ -56,8 +56,7 @@ public class OneToNBroadcastConnectorTest {
     
     private IOperator getScanSourceOperator(IDataStore dataStore) throws DataFlowException {
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                new MatchAllDocsQuery(), DataConstants.SCAN_QUERY, dataStore,
-                dataStore.getSchema().getAttributes(), luceneAnalyzer);
+                new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
         IndexBasedSourceOperator sourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
         return sourceOperator;
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -4,7 +4,6 @@
 package edu.uci.ics.textdb.dataflow.source;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
@@ -61,8 +60,7 @@ public class IndexBasedSourceOperatorTest {
         String defaultField = TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName();
         QueryParser queryParser = new QueryParser(defaultField, luceneAnalyzer);
         Query queryObject = queryParser.parse(query);
-        dataReaderPredicate = new DataReaderPredicate(queryObject, query, dataStore,
-                Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE[0]), luceneAnalyzer);
+        dataReaderPredicate = new DataReaderPredicate(queryObject, dataStore, luceneAnalyzer);
 
         indexBasedSourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -1,32 +1,25 @@
 package edu.uci.ics.textdb.storage;
 
-import java.util.List;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 
 /**
- * Created by sandeepreddy602 on 05-06-2016.
+ * @author sandeepreddy602
+ * @author Zuozhi Wang
  */
 public class DataReaderPredicate implements IPredicate {
     private IDataStore dataStore;
     private Query luceneQuery;
-    private String queryString;
     private Analyzer luceneAnalyzer;
-    private List<String> attributeNames;
     private boolean isSpanInformationAdded = false;
 
-    public DataReaderPredicate(Query luceneQuery, String queryString, IDataStore dataStore,
-            List<String> attributeNames, Analyzer analyzer) {
+    public DataReaderPredicate(Query luceneQuery, IDataStore dataStore, Analyzer analyzer) {
         this.dataStore = dataStore;
         this.luceneQuery = luceneQuery;
         this.luceneAnalyzer = analyzer;
-        this.queryString = queryString;
-        this.attributeNames = attributeNames;
     }
 
     public void setIsSpanInformationAdded(boolean flag) {
@@ -41,16 +34,8 @@ public class DataReaderPredicate implements IPredicate {
         return luceneQuery;
     }
 
-    public String getQueryString() {
-        return queryString;
-    }
-
     public Analyzer getLuceneAnalyzer() {
         return luceneAnalyzer;
-    }
-
-    public List<String> getAttributeNames() {
-        return attributeNames;
     }
 
     public boolean getIsSpanInformationAdded() {

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -17,16 +17,16 @@ public class DataReaderPredicate implements IPredicate {
     private Query luceneQuery;
     private String queryString;
     private Analyzer luceneAnalyzer;
-    private List<Attribute> attributeList;
+    private List<String> attributeNames;
     private boolean isSpanInformationAdded = false;
 
     public DataReaderPredicate(Query luceneQuery, String queryString, IDataStore dataStore,
-            List<Attribute> attributeList, Analyzer analyzer) {
+            List<String> attributeNames, Analyzer analyzer) {
         this.dataStore = dataStore;
         this.luceneQuery = luceneQuery;
         this.luceneAnalyzer = analyzer;
         this.queryString = queryString;
-        this.attributeList = attributeList;
+        this.attributeNames = attributeNames;
     }
 
     public void setIsSpanInformationAdded(boolean flag) {
@@ -49,8 +49,8 @@ public class DataReaderPredicate implements IPredicate {
         return luceneAnalyzer;
     }
 
-    public List<Attribute> getAttributeList() {
-        return attributeList;
+    public List<String> getAttributeNames() {
+        return attributeNames;
     }
 
     public boolean getIsSpanInformationAdded() {

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
@@ -1,7 +1,5 @@
 package edu.uci.ics.textdb.storage;
 
-import java.util.Arrays;
-
 import junit.framework.Assert;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -26,8 +24,7 @@ public class DataReaderPredicateTest {
         QueryParser luceneQueryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(),
                 new StandardAnalyzer());
         luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(luceneQuery, DataConstants.SCAN_QUERY, dataStore,
-                Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE), new StandardAnalyzer());
+        dataReaderPredicate = new DataReaderPredicate(luceneQuery, dataStore, new StandardAnalyzer());
     }
 
     @Test

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -1,7 +1,6 @@
 package edu.uci.ics.textdb.storage;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import junit.framework.Assert;
@@ -39,8 +38,7 @@ public class DataWriterReaderTest {
         dataWriter = new DataWriter(dataStore, luceneAnalyzer);
         QueryParser queryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), luceneAnalyzer);
         query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(query, DataConstants.SCAN_QUERY, dataStore,
-                Arrays.asList(TestConstants.ATTRIBUTES_PEOPLE), luceneAnalyzer);
+        dataReaderPredicate = new DataReaderPredicate(query, dataStore, luceneAnalyzer);
         dataReader = new DataReader(dataReaderPredicate);
     }
 


### PR DESCRIPTION
This PR removes 2 unnecessary parameters passed in DataReaderPredicate, which are `queryString` and `attributeList`. 

These two parameters exist because of the legacy design of DataReader. After the refactor of DataReader and some operators in issue #182 during summer, these two parameters are no longer needed by DataReader. This is one of the steps to replace a list of attributes with a list of attribute names, as mentioned in issue #272 .

This PR also modifies all the uses cases of `DataReaderPredicate`.

This PR is built based on PR #273 .