### PR TITLE
[Issue #272] Change KeywordPredicate constructor's attributeList to attributeNames

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -6,7 +6,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -117,6 +116,30 @@ public class Utils {
         IField[] fieldsDuplicate = fieldListDuplicate.toArray(new IField[fieldListDuplicate.size()]);
         return new DataTuple(spanSchema, fieldsDuplicate);
     }
+    
+    /**
+     * Converts a list of attributes to a list of attribute names
+     * 
+     * @param attributeList, a list of attributes
+     * @return a list of attribute names
+     */
+    public static List<String> getAttributeNames(List<Attribute> attributeList) {
+        return attributeList.stream()
+                .map(attr -> attr.getFieldName())
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Converts a list of attributes to a list of attribute names
+     * 
+     * @param attributeList, a list of attributes
+     * @return a list of attribute names
+     */
+    public static List<String> getAttributeNames(Attribute... attributeList) {
+        return Arrays.asList(attributeList).stream()
+                .map(attr -> attr.getFieldName())
+                .collect(Collectors.toList());
+    }
 
     /**
      *
@@ -143,15 +166,6 @@ public class Utils {
         attributes.add(attribute);
         Schema newSchema = new Schema(attributes.toArray(new Attribute[attributes.size()]));
         return newSchema;
-    }
-    
-    /**
-     * Get the field names of a list of attributes
-     * @param attributeList
-     * @return a list of strings, which are names of each attribute
-     */
-    public static List<String> getAttributeNameList(List<Attribute> attributeList) {
-        return attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList());
     }
 
     /**

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -36,7 +36,7 @@ import edu.uci.ics.textdb.storage.DataReaderPredicate;
  */
 public class KeywordPredicate implements IPredicate {
 
-    private List<Attribute> attributeList;
+    private List<String> attributeNames;
     private String query;
     private Query luceneQuery;
     private ArrayList<String> queryTokenList;
@@ -50,7 +50,7 @@ public class KeywordPredicate implements IPredicate {
      * searched in TextField, we would consider both tokens New and York; if
      * searched in String field we search for Exact string.
      */
-    public KeywordPredicate(String query, List<Attribute> attributeList, Analyzer luceneAnalyzer,
+    public KeywordPredicate(String query, List<String> attributeNames, Analyzer luceneAnalyzer,
             KeywordMatchingType operatorType) throws DataFlowException {
         try {
             this.query = query;
@@ -58,11 +58,10 @@ public class KeywordPredicate implements IPredicate {
             this.queryTokenSet = new HashSet<>(this.queryTokenList);
             this.queryTokensWithStopwords = Utils.tokenizeQueryWithStopwords(query);
 
-            this.attributeList = attributeList;
+            this.attributeNames = attributeNames;
             this.operatorType = operatorType;
 
             this.luceneAnalyzer = luceneAnalyzer;
-            this.luceneQuery = createLuceneQueryObject();
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -70,121 +69,7 @@ public class KeywordPredicate implements IPredicate {
         }
     }
 
-    /**
-     * Creates a Query object as a boolean Query on all attributes Example: For
-     * creating a query like (TestConstants.DESCRIPTION + ":lin" + " AND " +
-     * TestConstants.LAST_NAME + ":lin") we provide a list of AttributeFields
-     * (Description, Last_name) to search on and a query string (lin)
-     *
-     * @return Query
-     * @throws ParseException
-     * @throws DataFlowException
-     */
-    private Query createLuceneQueryObject() throws DataFlowException {
-        Query query = null;
-        if (this.operatorType == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-            query = buildConjunctionQuery();
-        }
-        if (this.operatorType == KeywordMatchingType.PHRASE_INDEXBASED) {
-            query = buildPhraseQuery();
-        }
-        if (this.operatorType == KeywordMatchingType.SUBSTRING_SCANBASED) {
-            query = buildScanQuery();
-        }
 
-        return query;
-    }
-
-    private Query buildConjunctionQuery() throws DataFlowException {
-        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
-
-        for (Attribute attribute : this.attributeList) {
-            String fieldName = attribute.getFieldName();
-            FieldType fieldType = attribute.getFieldType();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
-                throw new DataFlowException(
-                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
-            }
-
-            if (fieldType == FieldType.STRING) {
-                Query termQuery = new TermQuery(new Term(fieldName, this.query));
-                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
-            }
-            if (fieldType == FieldType.TEXT) {
-                BooleanQuery.Builder fieldQueryBuilder = new BooleanQuery.Builder();
-                for (String token : this.queryTokenSet) {
-                    Query termQuery = new TermQuery(new Term(fieldName, token.toLowerCase()));
-                    fieldQueryBuilder.add(termQuery, BooleanClause.Occur.MUST);
-                }
-                booleanQueryBuilder.add(fieldQueryBuilder.build(), BooleanClause.Occur.SHOULD);
-            }
-
-        }
-
-        return booleanQueryBuilder.build();
-    }
-
-    private Query buildPhraseQuery() throws DataFlowException {
-        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
-
-        for (Attribute attribute : this.attributeList) {
-            String fieldName = attribute.getFieldName();
-            FieldType fieldType = attribute.getFieldType();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
-                throw new DataFlowException(
-                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
-            }
-
-            if (fieldType == FieldType.STRING) {
-                Query termQuery = new TermQuery(new Term(fieldName, this.query));
-                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
-            }
-            if (fieldType == FieldType.TEXT) {
-                if (queryTokenList.size() == 1) {
-                    Query termQuery = new TermQuery(new Term(fieldName, this.query.toLowerCase()));
-                    booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
-                } else {
-                    PhraseQuery.Builder phraseQueryBuilder = new PhraseQuery.Builder();
-                    for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
-                        if (!StandardAnalyzer.STOP_WORDS_SET.contains(queryTokensWithStopwords.get(i))) {
-                            phraseQueryBuilder.add(new Term(fieldName, queryTokensWithStopwords.get(i).toLowerCase()),
-                                    i);
-                        }
-                    }
-                    PhraseQuery phraseQuery = phraseQueryBuilder.build();
-                    booleanQueryBuilder.add(phraseQuery, BooleanClause.Occur.SHOULD);
-                }
-            }
-
-        }
-
-        return booleanQueryBuilder.build();
-    }
-
-    private Query buildScanQuery() throws DataFlowException {
-        for (Attribute attribute : this.attributeList) {
-            FieldType fieldType = attribute.getFieldType();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
-                throw new DataFlowException(
-                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
-            }
-        }
-
-        return new MatchAllDocsQuery();
-    }
-
-    public DataReaderPredicate generateDataReaderPredicate(IDataStore dataStore) {
-        DataReaderPredicate predicate = new DataReaderPredicate(this.luceneQuery, this.query, dataStore,
-                this.attributeList, this.luceneAnalyzer);
-        predicate.setIsSpanInformationAdded(true);
-        return predicate;
-    }
 
     public KeywordMatchingType getOperatorType() {
         return operatorType;
@@ -194,8 +79,8 @@ public class KeywordPredicate implements IPredicate {
         return query;
     }
 
-    public List<Attribute> getAttributeList() {
-        return attributeList;
+    public List<String> getAttributeNames() {
+        return attributeNames;
     }
 
     public Query getQueryObject() {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/KeywordPredicate.java
@@ -5,33 +5,16 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.IPredicate;
-import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.utils.Utils;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 
 /**
- *  @author prakul
- *  @author Zhenfeng Qi
- *  @author Zuozhi Wang
+ * @author Zuozhi Wang
+ * @author prakul
  *
- */
-
-/**
  * This class handles creation of predicate for querying using Keyword Matcher
  */
 public class KeywordPredicate implements IPredicate {
@@ -51,25 +34,17 @@ public class KeywordPredicate implements IPredicate {
      * searched in String field we search for Exact string.
      */
     public KeywordPredicate(String query, List<String> attributeNames, Analyzer luceneAnalyzer,
-            KeywordMatchingType operatorType) throws DataFlowException {
-        try {
-            this.query = query;
-            this.queryTokenList = Utils.tokenizeQuery(luceneAnalyzer, query);
-            this.queryTokenSet = new HashSet<>(this.queryTokenList);
-            this.queryTokensWithStopwords = Utils.tokenizeQueryWithStopwords(query);
+            KeywordMatchingType operatorType) {
+        this.query = query;
+        this.queryTokenList = Utils.tokenizeQuery(luceneAnalyzer, query);
+        this.queryTokenSet = new HashSet<>(this.queryTokenList);
+        this.queryTokensWithStopwords = Utils.tokenizeQueryWithStopwords(query);
 
-            this.attributeNames = attributeNames;
-            this.operatorType = operatorType;
+        this.attributeNames = attributeNames;
+        this.operatorType = operatorType;
 
-            this.luceneAnalyzer = luceneAnalyzer;
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
-        }
+        this.luceneAnalyzer = luceneAnalyzer;
     }
-
-
 
     public KeywordMatchingType getOperatorType() {
         return operatorType;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -1,5 +1,7 @@
 package edu.uci.ics.textdb.dataflow.dictionarymatcher;
 
+import java.util.stream.Collectors;
+
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
@@ -52,7 +54,8 @@ public class DictionaryMatcher implements IOperator {
             }
 
             KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeList(), predicate.getAnalyzer(), predicate.getKeywordMatchingType());
+                    predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                    predicate.getAnalyzer(), predicate.getKeywordMatchingType());
 
             keywordMatcher = new KeywordMatcher(keywordPredicate);
             keywordMatcher.setInputOperator(inputOperator);
@@ -97,7 +100,8 @@ public class DictionaryMatcher implements IOperator {
             inputOperator.close();
 
             KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeList(), predicate.getAnalyzer(), predicate.getKeywordMatchingType());
+                    predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                    predicate.getAnalyzer(), predicate.getKeywordMatchingType());
 
             keywordMatcher = new KeywordMatcher(keywordPredicate);
             keywordMatcher.setInputOperator(inputOperator);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcher.java
@@ -7,6 +7,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
@@ -54,7 +55,7 @@ public class DictionaryMatcher implements IOperator {
             }
 
             KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                    Utils.getAttributeNames(predicate.getAttributeList()),
                     predicate.getAnalyzer(), predicate.getKeywordMatchingType());
 
             keywordMatcher = new KeywordMatcher(keywordPredicate);
@@ -100,7 +101,7 @@ public class DictionaryMatcher implements IOperator {
             inputOperator.close();
 
             KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                    Utils.getAttributeNames(predicate.getAttributeList()),
                     predicate.getAnalyzer(), predicate.getKeywordMatchingType());
 
             keywordMatcher = new KeywordMatcher(keywordPredicate);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -92,7 +92,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                 // For other keyword matching types (conjunction and phrase),
                 // create keyword matcher based on index.
                 KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                        predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                        Utils.getAttributeNames(predicate.getAttributeList()),
                         predicate.getAnalyzer(),
                         predicate.getKeywordMatchingType());
 
@@ -174,7 +174,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                 keywordSource.close();
 
                 KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                        predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                        Utils.getAttributeNames(predicate.getAttributeList()),
                         predicate.getAnalyzer(), keywordMatchingType);
 
                 keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
@@ -21,8 +22,7 @@ import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
-import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
-import edu.uci.ics.textdb.dataflow.source.IndexBasedSourceOperator;
+import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 
 /**
@@ -33,7 +33,8 @@ import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
     private ISourceOperator indexSource;
-    private KeywordMatcher keywordMatcher;
+    
+    private KeywordMatcherSourceOperator keywordSource;
 
     private Schema inputSchema;
     private Schema outputSchema;
@@ -91,18 +92,17 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                 // For other keyword matching types (conjunction and phrase),
                 // create keyword matcher based on index.
                 KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                        predicate.getAttributeList(), predicate.getAnalyzer(), predicate.getKeywordMatchingType());
+                        predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                        predicate.getAnalyzer(),
+                        predicate.getKeywordMatchingType());
 
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(
-                        keywordPredicate.generateDataReaderPredicate(dataStore));
-                keywordMatcher = new KeywordMatcher(keywordPredicate);
-                keywordMatcher.setInputOperator(indexInputOperator);
-                keywordMatcher.open();
+                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+                keywordSource.open();
 
                 // Other keyword matching types uses a KeywordMatcher, so the
                 // output schema is the same as keywordMatcher's schema
-                inputSchema = indexInputOperator.getOutputSchema();
-                outputSchema = keywordMatcher.getOutputSchema();
+                inputSchema = keywordSource.getOutputSchema();
+                outputSchema = keywordSource.getOutputSchema();
             }
 
         } catch (Exception e) {
@@ -149,7 +149,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
             while (true) {
                 // If there's result from current keywordMatcher, return it.
-                if ((sourceTuple = keywordMatcher.getNextTuple()) != null) {
+                if ((sourceTuple = keywordSource.getNextTuple()) != null) {
                     resultCursor++;
                     if (resultCursor >= offset) {
                         return sourceTuple;
@@ -171,17 +171,14 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                     keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
                 }
 
-                keywordMatcher.close();
+                keywordSource.close();
 
                 KeywordPredicate keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                        predicate.getAttributeList(), predicate.getAnalyzer(), keywordMatchingType);
+                        predicate.getAttributeList().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                        predicate.getAnalyzer(), keywordMatchingType);
 
-                IndexBasedSourceOperator indexInputOperator = new IndexBasedSourceOperator(
-                        keywordPredicate.generateDataReaderPredicate(dataStore));
-                keywordMatcher = new KeywordMatcher(keywordPredicate);
-                keywordMatcher.setInputOperator(indexInputOperator);
-
-                keywordMatcher.open();
+                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+                keywordSource.open();
             }
         }
         // Substring matching (based on scan)
@@ -286,8 +283,8 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     @Override
     public void close() throws DataFlowException {
         try {
-            if (keywordMatcher != null) {
-                keywordMatcher.close();
+            if (keywordSource != null) {
+                keywordSource.close();
             }
             if (indexSource != null) {
                 indexSource.close();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -9,7 +9,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -91,8 +90,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            String fieldName = attribute.getFieldName();
-            FieldType fieldType = attribute.getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
@@ -136,9 +134,8 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
-        for (Attribute attribute : this.predicate.getAttributeList()) {
-            String fieldName = attribute.getFieldName();
-            FieldType fieldType = attribute.getFieldType();
+        for (String fieldName : this.predicate.getAttributeNames()) {
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
@@ -233,9 +230,8 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     private ITuple computeSubstringMatchingResult(ITuple sourceTuple) throws DataFlowException {
         List<Span> matchingResults = new ArrayList<>();
 
-        for (Attribute attribute : this.predicate.getAttributeList()) {
-            String fieldName = attribute.getFieldName();
-            FieldType fieldType = attribute.getFieldType();
+        for (String fieldName : this.predicate.getAttributeNames()) {
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -90,7 +90,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
-        for (Attribute attribute : this.predicate.getAttributeList()) {
+        for (String fieldName : this.predicate.getAttributeNames()) {
             String fieldName = attribute.getFieldName();
             FieldType fieldType = attribute.getFieldType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -1,7 +1,5 @@
 package edu.uci.ics.textdb.dataflow.keywordmatch;
 
-import java.util.List;
-
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -12,7 +10,6 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -64,7 +61,14 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         // input schema must be setup first
         this.inputSchema = dataStore.getSchema();
 
-        dataReader = new DataReader(generateDataReaderPredicate(dataStore));
+        // generate dataReader
+        Query luceneQuery = createLuceneQueryObject();
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
+                luceneQuery, dataStore, this.predicate.getLuceneAnalyzer());
+        dataReaderPredicate.setIsSpanInformationAdded(true);
+        dataReader = new DataReader(dataReaderPredicate);
+        
+        // generate KeywordMatcher
         keywordMatcher = new KeywordMatcher(predicate);
         keywordMatcher.setInputOperator(dataReader);
         inputOperator = this.keywordMatcher;
@@ -205,11 +209,5 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         return new MatchAllDocsQuery();
     }
 
-    public DataReaderPredicate generateDataReaderPredicate(IDataStore dataStore, Query luceneQuery) {
-        DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, this.keywordQuery, dataStore,
-                this.predicate.getAttributeNames(), this.predicate.getLuceneAnalyzer());
-        predicate.setIsSpanInformationAdded(true);
-        return predicate;
-    }
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -44,20 +44,12 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     private Schema inputSchema;
     private Schema outputSchema;
 
-    public KeywordMatcherSourceOperator(KeywordPredicate predicate, IDataStore dataStore) {
+    public KeywordMatcherSourceOperator(KeywordPredicate predicate, IDataStore dataStore) throws DataFlowException {
         this.predicate = predicate;
         this.dataStore = dataStore;
 
         this.keywordQuery = predicate.getQuery();
-    }
-
-    @Override
-    public Schema getOutputSchema() {
-        return this.outputSchema;
-    }
-
-    @Override
-    protected void setUp() throws DataFlowException {
+        
         // input schema must be setup first
         this.inputSchema = dataStore.getSchema();
 
@@ -71,8 +63,17 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         // generate KeywordMatcher
         keywordMatcher = new KeywordMatcher(predicate);
         keywordMatcher.setInputOperator(dataReader);
-        inputOperator = this.keywordMatcher;
+        
+        this.inputOperator = this.keywordMatcher;
+    }
 
+    @Override
+    public Schema getOutputSchema() {
+        return this.outputSchema;
+    }
+
+    @Override
+    protected void setUp() throws DataFlowException {
         this.outputSchema = keywordMatcher.getOutputSchema();
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -1,14 +1,28 @@
 package edu.uci.ics.textdb.dataflow.keywordmatch;
 
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataStore;
+import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
+import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.reader.DataReader;
 
 /**
@@ -22,6 +36,9 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     private KeywordPredicate predicate;
     private IDataStore dataStore;
     
+    private KeywordMatchingType operatorType;
+    private List<String> attributeNames;
+    
     private DataReader dataReader;
     private KeywordMatcher keywordMatcher;
     
@@ -31,10 +48,8 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         this.predicate = predicate;
         this.dataStore = dataStore;
         
-        dataReader = new DataReader(predicate.generateDataReaderPredicate(dataStore));
-        keywordMatcher = new KeywordMatcher(predicate);
-        keywordMatcher.setInputOperator(dataReader);
-        inputOperator = this.keywordMatcher;
+        this.operatorType = predicate.getOperatorType();
+        this.attributeNames = prediate.getAttributeNames();
     }
 
     @Override
@@ -44,6 +59,11 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
 
     @Override
     protected void setUp() throws DataFlowException {
+        dataReader = new DataReader(generateDataReaderPredicate(dataStore));
+        keywordMatcher = new KeywordMatcher(predicate);
+        keywordMatcher.setInputOperator(dataReader);
+        inputOperator = this.keywordMatcher;
+        
         this.outputSchema = this.keywordMatcher.getOutputSchema();        
     }
 
@@ -69,6 +89,123 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     
     public IDataStore getDataStore() {
         return this.dataStore;
+    }
+    
+    
+    /**
+     * Creates a Query object as a boolean Query on all attributes Example: For
+     * creating a query like (TestConstants.DESCRIPTION + ":lin" + " AND " +
+     * TestConstants.LAST_NAME + ":lin") we provide a list of AttributeFields
+     * (Description, Last_name) to search on and a query string (lin)
+     *
+     * @return Query
+     * @throws ParseException
+     * @throws DataFlowException
+     */
+    private Query createLuceneQueryObject() throws DataFlowException {
+        Query query = null;
+        if (this.operatorType == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+            query = buildConjunctionQuery();
+        }
+        if (this.operatorType == KeywordMatchingType.PHRASE_INDEXBASED) {
+            query = buildPhraseQuery();
+        }
+        if (this.operatorType == KeywordMatchingType.SUBSTRING_SCANBASED) {
+            query = buildScanQuery();
+        }
+
+        return query;
+    }
+
+    private Query buildConjunctionQuery() throws DataFlowException {
+        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+
+        for (String attribute : this.attributeNames) {
+            String fieldName = attribute.getFieldName();
+            FieldType fieldType = attribute.getFieldType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            if (fieldType == FieldType.STRING) {
+                Query termQuery = new TermQuery(new Term(fieldName, this.query));
+                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+            }
+            if (fieldType == FieldType.TEXT) {
+                BooleanQuery.Builder fieldQueryBuilder = new BooleanQuery.Builder();
+                for (String token : this.queryTokenSet) {
+                    Query termQuery = new TermQuery(new Term(fieldName, token.toLowerCase()));
+                    fieldQueryBuilder.add(termQuery, BooleanClause.Occur.MUST);
+                }
+                booleanQueryBuilder.add(fieldQueryBuilder.build(), BooleanClause.Occur.SHOULD);
+            }
+
+        }
+
+        return booleanQueryBuilder.build();
+    }
+
+    private Query buildPhraseQuery() throws DataFlowException {
+        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+
+        for (Attribute attribute : this.attributeList) {
+            String fieldName = attribute.getFieldName();
+            FieldType fieldType = attribute.getFieldType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            if (fieldType == FieldType.STRING) {
+                Query termQuery = new TermQuery(new Term(fieldName, this.query));
+                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+            }
+            if (fieldType == FieldType.TEXT) {
+                if (queryTokenList.size() == 1) {
+                    Query termQuery = new TermQuery(new Term(fieldName, this.query.toLowerCase()));
+                    booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+                } else {
+                    PhraseQuery.Builder phraseQueryBuilder = new PhraseQuery.Builder();
+                    for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
+                        if (!StandardAnalyzer.STOP_WORDS_SET.contains(queryTokensWithStopwords.get(i))) {
+                            phraseQueryBuilder.add(new Term(fieldName, queryTokensWithStopwords.get(i).toLowerCase()),
+                                    i);
+                        }
+                    }
+                    PhraseQuery phraseQuery = phraseQueryBuilder.build();
+                    booleanQueryBuilder.add(phraseQuery, BooleanClause.Occur.SHOULD);
+                }
+            }
+
+        }
+
+        return booleanQueryBuilder.build();
+    }
+
+    private Query buildScanQuery() throws DataFlowException {
+        for (Attribute attribute : this.attributeList) {
+            FieldType fieldType = attribute.getFieldType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+        }
+
+        return new MatchAllDocsQuery();
+    }
+
+    public DataReaderPredicate generateDataReaderPredicate(IDataStore dataStore) {
+        DataReaderPredicate predicate = new DataReaderPredicate(this.luceneQuery, this.query, dataStore,
+                this.attributeList, this.luceneAnalyzer);
+        predicate.setIsSpanInformationAdded(true);
+        return predicate;
     }
 
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
@@ -11,6 +11,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
 import edu.uci.ics.textdb.plangen.PlanGenUtils;
@@ -54,7 +55,7 @@ public class KeywordMatcherBuilder {
         // build KeywordMatcher
         KeywordPredicate keywordPredicate;
         keywordPredicate = new KeywordPredicate(keyword, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                Utils.getAttributeNames(attributeList),
                 LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
         
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
@@ -53,12 +53,10 @@ public class KeywordMatcherBuilder {
 
         // build KeywordMatcher
         KeywordPredicate keywordPredicate;
-        try {
-            keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                    LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
-        } catch (DataFlowException e) {
-            throw new PlanGenException(e.getMessage(), e);
-        }
+        keywordPredicate = new KeywordPredicate(keyword, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
+        
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
 
         // set limit and offset

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -58,7 +58,12 @@ public class KeywordSourceBuilder {
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
 
-        KeywordMatcherSourceOperator sourceOperator = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+        KeywordMatcherSourceOperator sourceOperator;
+        try {
+            sourceOperator = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+        } catch (DataFlowException e) {
+            throw new PlanGenException(e.getMessage(), e);
+        }
    
         return sourceOperator;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -9,6 +9,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
 import edu.uci.ics.textdb.plangen.PlanGenUtils;
@@ -52,7 +53,7 @@ public class KeywordSourceBuilder {
         
         KeywordPredicate keywordPredicate;
         keywordPredicate = new KeywordPredicate(keyword, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                Utils.getAttributeNames(attributeList),
                 LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -2,6 +2,7 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
@@ -50,12 +51,9 @@ public class KeywordSourceBuilder {
                 + "It must be one of " + KeywordMatcherBuilder.keywordMatchingTypeMap.keySet());
         
         KeywordPredicate keywordPredicate;
-        try {
-            keywordPredicate = new KeywordPredicate(keyword, attributeList,
-                    LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
-        } catch (DataFlowException e) {
-            throw new PlanGenException(e.getMessage(), e);
-        }
+        keywordPredicate = new KeywordPredicate(keyword, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()),
+                LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -1015,7 +1015,7 @@ public class JoinTest {
                 Utils.getAttributeNames(modBookAttr), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
-        keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+        keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
 
 
         List<ITuple> resultList = getJoinResults(keywordSourceOuter, keywordSourceInner, idAttr, reviewAttr, 20, maxVal, 0);
@@ -1093,7 +1093,7 @@ public class JoinTest {
                 Utils.getAttributeNames(modBookAttr2), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
-        keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+        keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
 
         List<ITuple> resultList = getJoinResults(keywordSourceOuter, keywordSourceInner, idAttr, reviewAttr, 20, maxVal, 0);
 
@@ -1198,7 +1198,7 @@ public class JoinTest {
                 Utils.getAttributeNames(modBookAttr2), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
-        keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+        keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
 
         List<ITuple> resultList = getJoinResults(keywordSourceOuter, keywordSourceInner, idAttr, reviewAttr1, 20, maxVal, 0);
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -28,12 +28,12 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
 import edu.uci.ics.textdb.dataflow.common.IJoinPredicate;
 import edu.uci.ics.textdb.dataflow.common.JoinDistancePredicate;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;
-import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
 import edu.uci.ics.textdb.dataflow.projection.ProjectionOperator;
 import edu.uci.ics.textdb.dataflow.projection.ProjectionPredicate;
@@ -159,12 +159,12 @@ public class JoinTest {
             if (whichOperator == "outer") {
                 dataStore = dataStoreForOuter;
                 keywordPredicate = new KeywordPredicate(query, 
-                        modifiedAttributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                        Utils.getAttributeNames(modifiedAttributeList), analyzer,
                         DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
             } else if (whichOperator == "inner") {
                 dataStore = dataStoreForInner;
                 keywordPredicate = new KeywordPredicate(query, 
-                        modifiedAttributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                        Utils.getAttributeNames(modifiedAttributeList), analyzer,
                         DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
             }
             break;
@@ -172,12 +172,12 @@ public class JoinTest {
             if (whichOperator == "outer") {
                 dataStore = dataStoreForOuter;
                 keywordPredicate = new KeywordPredicate(query, 
-                        modifiedAttributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                        Utils.getAttributeNames(modifiedAttributeList), analyzer,
                         DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
             } else if (whichOperator == "inner") {
                 dataStore = dataStoreForInner;
                 keywordPredicate = new KeywordPredicate(query, 
-                        modifiedAttributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                        Utils.getAttributeNames(modifiedAttributeList), analyzer,
                         DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
             }
             break;
@@ -463,7 +463,7 @@ public class JoinTest {
         fuzzyMatcherInner.setInputOperator(new IndexBasedSourceOperator(fuzzyPredicateInner.getDataReaderPredicate(dataStoreForInner)));
 
         ProjectionPredicate removeSpanListPredicate = new ProjectionPredicate(
-                dataStoreForInner.getSchema().getAttributes().stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()));
+                Utils.getAttributeNames(dataStoreForInner.getSchema().getAttributes()));
         ProjectionOperator removeSpanListProjection = new ProjectionOperator(removeSpanListPredicate);
         removeSpanListProjection.setInputOperator(fuzzyMatcherInner);
         
@@ -732,7 +732,7 @@ public class JoinTest {
         String query = "special";
         keywordSourceOuter = (KeywordMatcherSourceOperator) setupOperators(query, "index", "outer");
         query = "kind";
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, modifiedAttributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, Utils.getAttributeNames(modifiedAttributeList), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
 
         keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -804,14 +804,14 @@ public class JoinTest {
         String query = "special";
         dataStore = dataStoreForOuter;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr1).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr1), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
 
         query = "writer";
         dataStore = dataStoreForInner;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr2).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr2), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
 
@@ -906,7 +906,7 @@ public class JoinTest {
         String query = "special";
         dataStore = dataStoreForOuter;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -914,7 +914,7 @@ public class JoinTest {
         query = "writer";
         dataStore = dataStoreForInner;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceInner = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1004,7 +1004,7 @@ public class JoinTest {
         String query = "special";
         dataStore = dataStoreForOuter;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
 
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1012,7 +1012,7 @@ public class JoinTest {
         query = "writer";
         dataStore = dataStoreForInner;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1082,7 +1082,7 @@ public class JoinTest {
         String query = "special";
         dataStore = dataStoreForOuter;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr1).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr1), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
 
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1090,7 +1090,7 @@ public class JoinTest {
         query = "writer";
         dataStore = dataStoreForInner;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr2).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr2), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1187,7 +1187,7 @@ public class JoinTest {
         String query = "special";
         dataStore = dataStoreForOuter;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr1).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr1), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -1195,7 +1195,7 @@ public class JoinTest {
         query = "writer";
         dataStore = dataStoreForInner;
         keywordPredicate = new KeywordPredicate(query, 
-                Arrays.asList(modBookAttr2).stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(modBookAttr2), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         keywordSourceOuter = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -90,7 +91,8 @@ public class KeywordMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
             throws TextDBException, ParseException {
 
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, analyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query,
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherTest.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -92,7 +91,7 @@ public class KeywordMatcherTest {
             throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query,
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), analyzer,
+                Utils.getAttributeNames(attributeList), analyzer,
                 DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -87,7 +88,8 @@ public class PhraseMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList, int limit, int offset)
             throws TextDBException, ParseException {
 
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), luceneAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -352,7 +354,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         // Perform Query
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         
         KeywordMatcherSourceOperator keywordMatcherSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);
@@ -417,7 +420,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         // Perform Query
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);
@@ -492,7 +496,8 @@ public class PhraseMatcherTest {
         expectedResultList.add(tuple1);
 
         // Perform Query
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, MedAnalyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/PhraseMatcherTest.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -31,6 +30,7 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -89,7 +89,7 @@ public class PhraseMatcherTest {
             throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), luceneAnalyzer,
+                Utils.getAttributeNames(attributeList), luceneAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -355,7 +355,7 @@ public class PhraseMatcherTest {
 
         // Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
+                Utils.getAttributeNames(attributeList), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
         
         KeywordMatcherSourceOperator keywordMatcherSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);
@@ -421,7 +421,7 @@ public class PhraseMatcherTest {
 
         // Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
+                Utils.getAttributeNames(attributeList), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);
@@ -497,7 +497,7 @@ public class PhraseMatcherTest {
 
         // Perform Query
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), MedAnalyzer,
+                Utils.getAttributeNames(attributeList), MedAnalyzer,
                 DataConstants.KeywordMatchingType.PHRASE_INDEXBASED);
 
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, medDataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -77,7 +78,8 @@ public class SubstringMatcherTest {
     public List<ITuple> getPeopleQueryResults(String query, ArrayList<Attribute> attributeList)
             throws TextDBException, ParseException {
 
-        KeywordPredicate keywordPredicate = new KeywordPredicate(query, attributeList, luceneAnalyzer,
+        KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
+                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), luceneAnalyzer,
                 DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
         
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
@@ -85,7 +87,7 @@ public class SubstringMatcherTest {
 
         List<ITuple> results = new ArrayList<>();
         ITuple nextTuple = null;
-
+ 
         while ((nextTuple = keywordSource.getNextTuple()) != null) {
             results.add(nextTuple);
         }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/SubstringMatcherTest.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
@@ -31,6 +30,7 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
@@ -79,7 +79,7 @@ public class SubstringMatcherTest {
             throws TextDBException, ParseException {
 
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
-                attributeList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()), luceneAnalyzer,
+                Utils.getAttributeNames(attributeList), luceneAnalyzer,
                 DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED);
         
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -43,7 +44,8 @@ public class KeywordMatcherBuilderTest {
         Assert.assertEquals("zika", keywordZika.getPredicate().getQuery());
         List<Attribute> zikaAttrList = Arrays.asList(
                 new Attribute("content", FieldType.TEXT));
-        Assert.assertEquals(zikaAttrList.toString(), keywordZika.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(zikaAttrList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+                keywordZika.getPredicate().getAttributeNames().toString());
         Assert.assertEquals(KeywordMatchingType.CONJUNCTION_INDEXBASED, keywordZika.getPredicate().getOperatorType());
         Assert.assertEquals(Integer.MAX_VALUE, keywordZika.getLimit());
         Assert.assertEquals(0, keywordZika.getOffset());
@@ -76,7 +78,8 @@ public class KeywordMatcherBuilderTest {
                 new Attribute("city", FieldType.STRING),
                 new Attribute("location", FieldType.STRING),
                 new Attribute("content", FieldType.TEXT));
-        Assert.assertEquals(irvineAttrList.toString(), keywordIrvine.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(irvineAttrList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+                keywordIrvine.getPredicate().getAttributeNames().toString());
         Assert.assertEquals(KeywordMatchingType.SUBSTRING_SCANBASED, keywordIrvine.getPredicate().getOperatorType());
         Assert.assertEquals(10, keywordIrvine.getLimit());
         Assert.assertEquals(2, keywordIrvine.getOffset());     

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
@@ -12,6 +12,7 @@ import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
 import junit.framework.Assert;
 
@@ -44,7 +45,8 @@ public class KeywordMatcherBuilderTest {
         Assert.assertEquals("zika", keywordZika.getPredicate().getQuery());
         List<Attribute> zikaAttrList = Arrays.asList(
                 new Attribute("content", FieldType.TEXT));
-        Assert.assertEquals(zikaAttrList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+        Assert.assertEquals(
+                Utils.getAttributeNames(zikaAttrList).toString(),
                 keywordZika.getPredicate().getAttributeNames().toString());
         Assert.assertEquals(KeywordMatchingType.CONJUNCTION_INDEXBASED, keywordZika.getPredicate().getOperatorType());
         Assert.assertEquals(Integer.MAX_VALUE, keywordZika.getLimit());
@@ -78,7 +80,8 @@ public class KeywordMatcherBuilderTest {
                 new Attribute("city", FieldType.STRING),
                 new Attribute("location", FieldType.STRING),
                 new Attribute("content", FieldType.TEXT));
-        Assert.assertEquals(irvineAttrList.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+        Assert.assertEquals(
+                Utils.getAttributeNames(irvineAttrList).toString(),
                 keywordIrvine.getPredicate().getAttributeNames().toString());
         Assert.assertEquals(KeywordMatchingType.SUBSTRING_SCANBASED, keywordIrvine.getPredicate().getOperatorType());
         Assert.assertEquals(10, keywordIrvine.getLimit());

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
@@ -54,7 +54,8 @@ public class KeywordSourceBuilderTest {
                 schemaAttrs.stream().collect(Collectors.toList()).toString(), 
                 sourceOperator.getDataStore().getSchema().getAttributes().stream().collect(Collectors.toList()).toString());
         // compare the keyword matcher attribute list
-        Assert.assertEquals(keywordAttributes.toString(), sourceOperator.getPredicate().getAttributeList().toString());
+        Assert.assertEquals(keywordAttributes.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+                sourceOperator.getPredicate().getAttributeNames().toString());
 
     }
     

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
 import junit.framework.Assert;
 
@@ -54,7 +55,8 @@ public class KeywordSourceBuilderTest {
                 schemaAttrs.stream().collect(Collectors.toList()).toString(), 
                 sourceOperator.getDataStore().getSchema().getAttributes().stream().collect(Collectors.toList()).toString());
         // compare the keyword matcher attribute list
-        Assert.assertEquals(keywordAttributes.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList()).toString(), 
+        Assert.assertEquals(
+                Utils.getAttributeNames(keywordAttributes).toString(),
                 sourceOperator.getPredicate().getAttributeNames().toString());
 
     }


### PR DESCRIPTION
This PR changes the`attributeList` parameter in KeywordPredicate constructor's to attributeNames.

All uses cases of this parameter are also changed.