### PR TITLE
[Issue #272] Remove the attribute type requirement in KeywordBuilder

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilder.java
@@ -43,8 +43,8 @@ public class KeywordMatcherBuilder {
         // check if keyword is empty
         PlanGenUtils.planGenAssert(!keyword.trim().isEmpty(), "keyword is empty");
 
-        // generate attribute list
-        List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);
+        // generate attribute names
+        List<String> attributeNames = OperatorBuilderUtils.constructAttributeNames(operatorProperties);
 
         // generate matching type
         KeywordMatchingType matchingType = KeywordMatcherBuilder.getKeywordMatchingType(matchingTypeStr);
@@ -54,8 +54,7 @@ public class KeywordMatcherBuilder {
 
         // build KeywordMatcher
         KeywordPredicate keywordPredicate;
-        keywordPredicate = new KeywordPredicate(keyword, 
-                Utils.getAttributeNames(attributeList),
+        keywordPredicate = new KeywordPredicate(keyword, attributeNames,
                 LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
         
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -42,8 +42,8 @@ public class KeywordSourceBuilder {
         // check if the keyword is empty
         PlanGenUtils.planGenAssert(!keyword.trim().isEmpty(), "the keyword is empty");
 
-        // generate the attribute list
-        List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);
+        // generate the attribute names
+        List<String> attributeNames = OperatorBuilderUtils.constructAttributeNames(operatorProperties);
 
         // generate the keyword matching type
         KeywordMatchingType matchingType = KeywordMatcherBuilder.getKeywordMatchingType(matchingTypeStr);
@@ -52,9 +52,8 @@ public class KeywordSourceBuilder {
                 + "It must be one of " + KeywordMatcherBuilder.keywordMatchingTypeMap.keySet());
         
         KeywordPredicate keywordPredicate;
-        keywordPredicate = new KeywordPredicate(keyword, 
-                Utils.getAttributeNames(attributeList),
-                LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);     
+        keywordPredicate = new KeywordPredicate(keyword, attributeNames,
+                LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);  
         
         DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/OperatorBuilderUtils.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/OperatorBuilderUtils.java
@@ -119,6 +119,8 @@ public class OperatorBuilderUtils {
      *   "attributeTypes" : "attribute1Type, attribute2Type, attribute3Type"
      * }
      * 
+     * TODO: this function should be deleted after all attributeLists are changed to attributeNames
+     * 
      * @param operatorProperties
      * @return a list of attributes
      * @throws PlanGenException
@@ -139,6 +141,31 @@ public class OperatorBuilderUtils {
                 .collect(Collectors.toList());
 
         return attributeList;
+    }
+    
+    /**
+     * This function finds properties related to constructing the attribute names in
+     * operatorProperties, and converts them to a list of attribute names.
+     * 
+     * It currently needs the following properties from operatorProperties: 
+     *   attributeNames: a list of attributes' names (separated by comma)
+     *   
+     * Here's a sample JSON representation of these properties:
+     * 
+     * {
+     *   "attributeNames" : "attribute1Name, attribute2Name, attribute3Name"
+     * }
+     * 
+     * @param operatorProperties
+     * @return a list of attribute names
+     * @throws PlanGenException
+     */
+    public static List<String> constructAttributeNames(Map<String, String> operatorProperties) throws PlanGenException {
+        String attributeNamesStr = getRequiredProperty(ATTRIBUTE_NAMES, operatorProperties);
+
+        List<String> attributeNames = splitStringByComma(attributeNamesStr);
+
+        return attributeNames;
     }
 
     private static Attribute constructAttribute(String attributeNameStr, String attributeTypeStr) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -37,17 +36,15 @@ public class KeywordMatcherBuilderTest {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "zika");
         keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "conjunction_indexbased");
         
         KeywordMatcher keywordZika = KeywordMatcherBuilder.buildKeywordMatcher(keywordProperties);
         
         Assert.assertEquals("zika", keywordZika.getPredicate().getQuery());
-        List<Attribute> zikaAttrList = Arrays.asList(
-                new Attribute("content", FieldType.TEXT));
+        List<String> zikaAttrList = Arrays.asList("content");
         Assert.assertEquals(
-                Utils.getAttributeNames(zikaAttrList).toString(),
-                keywordZika.getPredicate().getAttributeNames().toString());
+                zikaAttrList,
+                keywordZika.getPredicate().getAttributeNames());
         Assert.assertEquals(KeywordMatchingType.CONJUNCTION_INDEXBASED, keywordZika.getPredicate().getOperatorType());
         Assert.assertEquals(Integer.MAX_VALUE, keywordZika.getLimit());
         Assert.assertEquals(0, keywordZika.getOffset());
@@ -68,7 +65,6 @@ public class KeywordMatcherBuilderTest {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "Irvine");
         keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
         keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
         keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
@@ -76,13 +72,10 @@ public class KeywordMatcherBuilderTest {
         KeywordMatcher keywordIrvine = KeywordMatcherBuilder.buildKeywordMatcher(keywordProperties);
                
         Assert.assertEquals("Irvine", keywordIrvine.getPredicate().getQuery());
-        List<Attribute> irvineAttrList = Arrays.asList(
-                new Attribute("city", FieldType.STRING),
-                new Attribute("location", FieldType.STRING),
-                new Attribute("content", FieldType.TEXT));
+        List<String> irvineAttrList = Arrays.asList("city", "location", "content");
         Assert.assertEquals(
-                Utils.getAttributeNames(irvineAttrList).toString(),
-                keywordIrvine.getPredicate().getAttributeNames().toString());
+                irvineAttrList,
+                keywordIrvine.getPredicate().getAttributeNames());
         Assert.assertEquals(KeywordMatchingType.SUBSTRING_SCANBASED, keywordIrvine.getPredicate().getOperatorType());
         Assert.assertEquals(10, keywordIrvine.getLimit());
         Assert.assertEquals(2, keywordIrvine.getOffset());     
@@ -95,7 +88,6 @@ public class KeywordMatcherBuilderTest {
     public void testInvalidKeywordMatcherBuilder1() throws PlanGenException, DataFlowException {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
         keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
         keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
@@ -111,7 +103,6 @@ public class KeywordMatcherBuilderTest {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "");
         keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
         keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
         keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
@@ -126,7 +117,6 @@ public class KeywordMatcherBuilderTest {
     public void testInvalidKeywordMatcherBuilder3() throws PlanGenException, DataFlowException {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "Irvine");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
         keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
         keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
@@ -134,37 +124,6 @@ public class KeywordMatcherBuilderTest {
         KeywordMatcherBuilder.buildKeywordMatcher(keywordProperties);       
     }
     
-    /*
-     * test invalid KeywordMatcherBuilder with missing invalid attribute types property
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidKeywordMatcherBuilder4() throws PlanGenException, DataFlowException {
-        HashMap<String, String> keywordProperties = new HashMap<>();
-        keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "Irvine");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "invalid_type, another_invalid_type, TEXT");
-        keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
-        keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
-        keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
-        
-        KeywordMatcherBuilder.buildKeywordMatcher(keywordProperties);       
-    }
-    
-    /*
-     * test invalid KeywordMatcherBuilder with inconsistent attribute names and types
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidKeywordMatcherBuilder5() throws PlanGenException, DataFlowException {
-        HashMap<String, String> keywordProperties = new HashMap<>();
-        keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "Irvine");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT, TEXT, TEXT");
-        keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "SUBSTRING_SCANBASED");
-        keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
-        keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");
-        
-        KeywordMatcherBuilder.buildKeywordMatcher(keywordProperties);  
-    }
     
     /*
      * test invalid KeywordMatcherBuilder with invalid matching type
@@ -174,7 +133,6 @@ public class KeywordMatcherBuilderTest {
         HashMap<String, String> keywordProperties = new HashMap<>();
         keywordProperties.put(KeywordMatcherBuilder.KEYWORD, "Irvine");
         keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        keywordProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         keywordProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "invalid_matching_type");
         keywordProperties.put(OperatorBuilderUtils.LIMIT, "10");
         keywordProperties.put(OperatorBuilderUtils.OFFSET, "2");

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
@@ -39,7 +39,6 @@ public class KeywordSourceBuilderTest {
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, keyword);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
         operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         
@@ -77,7 +76,6 @@ public class KeywordSourceBuilderTest {
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
         operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         
@@ -100,7 +98,6 @@ public class KeywordSourceBuilderTest {
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
         operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         
@@ -123,7 +120,6 @@ public class KeywordSourceBuilderTest {
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
         operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         
@@ -146,7 +142,6 @@ public class KeywordSourceBuilderTest {
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
         operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
         operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         


### PR DESCRIPTION
This PR follows the changes made in PR #275 . After removing the attribute types in KeywordPredicate's constructor, KeywordMatcherBuilder and KeywordSourceBuilder don't need attribute types anymore. This PR removes the attribute types in their operator properties.