### PR TITLE
[Issue #272] Remove attribute type in Join and JoinBuilder

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/IJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/IJoinPredicate.java
@@ -1,6 +1,5 @@
 package edu.uci.ics.textdb.dataflow.common;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 
@@ -12,9 +11,9 @@ import edu.uci.ics.textdb.api.common.Schema;
  */
 public interface IJoinPredicate {
 
-	Attribute getIDAttribute();
+	String getIDAttributeName();
 
-	Attribute getJoinAttribute();
+	String getJoinAttributeName();
 
 	ITuple joinTuples(ITuple outerTuple, ITuple innerTuple, Schema outputSchema)
 			throws Exception;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -21,8 +21,8 @@ import edu.uci.ics.textdb.common.field.Span;
  */
 public class JoinDistancePredicate implements IJoinPredicate {
 
-    private Attribute idAttribute;
-    private Attribute joinAttribute;
+    private String idAttributeName;
+    private String joinAttributeName;
     private Integer threshold;
 
     /**
@@ -90,18 +90,18 @@ public class JoinDistancePredicate implements IJoinPredicate {
      * @param threshold
      *            is the maximum distance (in characters) between any two spans
      */
-    public JoinDistancePredicate(Attribute idAttribute, Attribute joinAttribute, Integer threshold) {
-        this.idAttribute = idAttribute;
-        this.joinAttribute = joinAttribute;
+    public JoinDistancePredicate(String idAttributeName, String joinAttributeName, Integer threshold) {
+        this.idAttributeName = idAttributeName;
+        this.joinAttributeName = joinAttributeName;
         this.threshold = threshold;
     }
 
-    public Attribute getIDAttribute() {
-        return this.idAttribute;
+    public String getIDAttributeName() {
+        return this.idAttributeName;
     }
 
-    public Attribute getJoinAttribute() {
-        return this.joinAttribute;
+    public String getJoinAttributeName() {
+        return this.joinAttributeName;
     }
 
     public Integer getThreshold() {
@@ -123,12 +123,12 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	     * For other fields, we use the value from innerTuple.
 	     * check if the ID fields are the same
 	     */
-	    if (! compareField(innerTuple, outerTuple, this.getIDAttribute().getFieldName())) {
+	    if (! compareField(innerTuple, outerTuple, this.getIDAttributeName())) {
 	        return null;
 	    }
 	
 	    // check if the fields to be joined are the same
-	    if (! compareField(innerTuple, outerTuple, this.getJoinAttribute().getFieldName())) {
+	    if (! compareField(innerTuple, outerTuple, this.getJoinAttributeName())) {
 	        return null;
 	    }
 
@@ -168,13 +168,13 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	        Span outerSpan = outerSpanIter.next();
 	        // Check if the field matches the filed over which we want to join.
 	        // If not return null.
-	        if (!outerSpan.getFieldName().equals(this.getJoinAttribute().getFieldName())) {
+	        if (!outerSpan.getFieldName().equals(this.getJoinAttributeName())) {
 	            continue;
 	        }
 	        Iterator<Span> innerSpanIter = innerSpanList.iterator();
 	        while (innerSpanIter.hasNext()) {
 	            Span innerSpan = innerSpanIter.next();
-	            if (!innerSpan.getFieldName().equals(this.getJoinAttribute().getFieldName())) {
+	            if (!innerSpan.getFieldName().equals(this.getJoinAttributeName())) {
 	                continue;
 	            }
 	            Integer threshold = this.getThreshold();
@@ -182,7 +182,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	                    && Math.abs(outerSpan.getEnd() - innerSpan.getEnd()) <= threshold) {
 	                Integer newSpanStartIndex = Math.min(outerSpan.getStart(), innerSpan.getStart());
 	                Integer newSpanEndIndex = Math.max(outerSpan.getEnd(), innerSpan.getEnd());
-	                String fieldName = this.getJoinAttribute().getFieldName();
+	                String fieldName = this.getJoinAttributeName();
 	                String fieldValue = (String) innerTuple.getField(fieldName).getValue();
 	                String newFieldValue = fieldValue.substring(newSpanStartIndex, newSpanEndIndex);
 	                String spanKey = outerSpan.getKey() + "_" + innerSpan.getKey();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -237,7 +237,7 @@ public class Join implements IOperator {
         }
         
         // check if join attribute is TEXT or STRING
-        FieldType joinAttrType = outputSchema.getAttribute(joinPredicate.getJoinAttributeName()).getFieldType();
+        FieldType joinAttrType = intersectionSchema.getAttribute(joinPredicate.getJoinAttributeName()).getFieldType();
         if (joinAttrType != FieldType.TEXT && joinAttrType != FieldType.STRING) {
             throw new DataFlowException(
                     String.format("Join attribute %s must be either TEXT or STRING.", joinPredicate.getJoinAttributeName()));

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -57,7 +57,6 @@ public class Join implements IOperator {
     // Cursor to maintain the position of tuple to be obtained from
     // innerTupleList.
     private Integer innerOperatorCursor = 0;
-    private List<Attribute> outputAttrList;
     private Schema outputSchema;
 
     private int cursor = CLOSED;
@@ -86,42 +85,33 @@ public class Join implements IOperator {
 
     @Override
     public void open() throws TextDBException {
-        if (!(joinPredicate.getJoinAttribute().getFieldType().equals(FieldType.STRING)
-                || joinPredicate.getJoinAttribute().getFieldType().equals(FieldType.TEXT))) {
-            throw new TextDBException("Fields other than \"STRING\" and \"TEXT\" are not supported by Join yet.");
-        }
-
         if (cursor != CLOSED) {
         	return;
         }
-
-        try {
-            innerOperator.open();
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
-        }
-
-        shouldIGetOuterOperatorNextTuple = true;
-
-        // Load the inner tuple list into memory on open.
+        
+        // generate output schema from schema of inner and outer operator
+        innerOperator.open();
+        Schema innerOperatorSchema = innerOperator.getOutputSchema();
+        innerOperator.close();
+        
+        outerOperator.open();
+        Schema outerOperatorSchema = outerOperator.getOutputSchema();
+        outerOperator.close();
+        
+        this.outputSchema = generateIntersectionSchema(innerOperatorSchema, outerOperatorSchema);
+        
+        // load all tuples from inner operator into memory
+        innerOperator.open();
         while ((innerTuple = innerOperator.getNextTuple()) != null) {
             innerTupleList.add(innerTuple);
         }
+        innerOperator.close();
 
-        // Close the inner operator as all the required tuples are already
-        // loaded into memory.
-        try {
-            innerOperator.close();
-            outerOperator.open();
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
-        }
+        // open outer operator
+        outerOperator.open();
 
+        shouldIGetOuterOperatorNextTuple = true;
         cursor = OPENED;
-        generateIntersectionSchema();
-        outputAttrList = outputSchema.getAttributes();
     }
 
     /**
@@ -224,26 +214,36 @@ public class Join implements IOperator {
      * 
      * @return outputSchema
      */
-    private void generateIntersectionSchema() throws DataFlowException {
-        List<Attribute> innerAttributes = innerOperator.getOutputSchema().getAttributes();
-        List<Attribute> outerAttributes = outerOperator.getOutputSchema().getAttributes();
+    private Schema generateIntersectionSchema(Schema innerOperatorSchema, Schema outerOperatorSchema) throws DataFlowException {
+        List<Attribute> innerAttributes = innerOperatorSchema.getAttributes();
+        List<Attribute> outerAttributes = outerOperatorSchema.getAttributes();
         
         List<Attribute> intersectionAttributes = 
                 innerAttributes.stream()
                 .filter(attr -> outerAttributes.contains(attr))
                 .collect(Collectors.toList());
         
-        if (intersectionAttributes.isEmpty()) {
-            throw new DataFlowException("inner operator and outer operator don't share any common attributes");
-        } else if (! intersectionAttributes.contains(joinPredicate.getJoinAttribute())) {
-            throw new DataFlowException("inner operator or outer operator doesn't contain join attribute");
-        } else if (! intersectionAttributes.contains(joinPredicate.getIDAttribute())) {
-            throw new DataFlowException("inner operator or outer operator doesn't contain ID attribute");
-        } else if (! intersectionAttributes.contains(SchemaConstants.SPAN_LIST_ATTRIBUTE)) {
-            throw new DataFlowException("inner operator or outer operator doesn't contain spanList attribute");
-        } 
+        Schema intersectionSchema = new Schema(intersectionAttributes.stream().toArray(Attribute[]::new));
         
-        outputSchema = new Schema(intersectionAttributes.stream().toArray(Attribute[]::new));
+        // check if output schema contain necessary attributes
+        if (intersectionSchema.getAttributes().isEmpty()) {
+            throw new DataFlowException("inner operator and outer operator don't share any common attributes");
+        } else if (intersectionSchema.getAttribute(joinPredicate.getJoinAttributeName()) == null) {
+            throw new DataFlowException("inner operator or outer operator doesn't contain join attribute");
+        } else if (intersectionSchema.getAttribute(joinPredicate.getIDAttributeName()) == null) {
+            throw new DataFlowException("inner operator or outer operator doesn't contain ID attribute");
+        } else if (intersectionSchema.getAttribute(SchemaConstants.SPAN_LIST) == null) {
+            throw new DataFlowException("inner operator or outer operator doesn't contain spanList attribute");
+        }
+        
+        // check if join attribute is TEXT or STRING
+        FieldType joinAttrType = outputSchema.getAttribute(joinPredicate.getJoinAttributeName()).getFieldType();
+        if (joinAttrType != FieldType.TEXT && joinAttrType != FieldType.STRING) {
+            throw new DataFlowException(
+                    String.format("Join attribute %s must be either TEXT or STRING.", joinPredicate.getJoinAttributeName()));
+        }
+        
+        return intersectionSchema;        
     }
     
     public void setInnerInputOperator(IOperator innerInputOperator) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilder.java
@@ -22,7 +22,7 @@ import edu.uci.ics.textdb.plangen.PlanGenUtils;
  *   properties required for constructing attributeList, see OperatorBuilderUtils.constructAttributeList
  *   (As of now, join must have one attribute in the attribute list.)
  *   
- *   idAttributeName and idAttributeType (required): the name and type of the "ID" attribute
+ *   idAttributeName (required): the name of the "ID" attribute
  *   
  *   requirements for differnt join predicates:
  *   
@@ -35,9 +35,7 @@ import edu.uci.ics.textdb.plangen.PlanGenUtils;
  *      "distance" : "100",
  *      
  *      "attributeName" : "content",
- *      "attributeType" : "Text",
  *      "idAttributeName" : "id",
- *      "idAttributeType" : "String",   
  *   }
  * 
  * @author Zuozhi Wang
@@ -48,7 +46,6 @@ public class JoinBuilder {
     public static final String JOIN_PREDICATE = "predicateType";
     
     public static final String JOIN_ID_ATTRIBUTE_NAME = "idAttributeName";
-    public static final String JOIN_ID_ATTRIBUTE_TYPE = "idAttributeType";
     
     public static final String JOIN_CHARACTER_DISTANCE = "CharacterDistance";
     public static final String JOIN_DISTANCE = "distance";
@@ -97,14 +94,9 @@ public class JoinBuilder {
             Map<String, String> operatorProperties) throws PlanGenException{
         String distanceStr = OperatorBuilderUtils.getRequiredProperty(JOIN_DISTANCE, operatorProperties);
         String joinIDAttributeName = OperatorBuilderUtils.getRequiredProperty(JOIN_ID_ATTRIBUTE_NAME, operatorProperties);
-        String joinIDAttributeType = OperatorBuilderUtils.getRequiredProperty(JOIN_ID_ATTRIBUTE_TYPE, operatorProperties);
         
         PlanGenUtils.planGenAssert(! joinIDAttributeName.trim().isEmpty(), 
                 "Join character distance predicate: ID attribute name is empty.");
-        PlanGenUtils.planGenAssert(PlanGenUtils.isValidAttributeType(joinIDAttributeType), 
-                "Join character distance predicate: ID attribute type is invalid.");
-        Attribute joinIDAttribute = new Attribute(joinIDAttributeName, PlanGenUtils.convertAttributeType(joinIDAttributeType));
-        
         
         List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);       
         PlanGenUtils.planGenAssert(attributeList.size() == 1, 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilder.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.common.IJoinPredicate;
 import edu.uci.ics.textdb.dataflow.common.JoinDistancePredicate;
@@ -98,10 +97,10 @@ public class JoinBuilder {
         PlanGenUtils.planGenAssert(! joinIDAttributeName.trim().isEmpty(), 
                 "Join character distance predicate: ID attribute name is empty.");
         
-        List<Attribute> attributeList = OperatorBuilderUtils.constructAttributeList(operatorProperties);       
-        PlanGenUtils.planGenAssert(attributeList.size() == 1, 
-                "Join character distance predicate allows only 1 attribute, got " + attributeList.size()+  " attributes.");
-        Attribute joinAttribute = attributeList.get(0);
+        List<String> attributeNames = OperatorBuilderUtils.constructAttributeNames(operatorProperties);
+        PlanGenUtils.planGenAssert(attributeNames.size() == 1, 
+                "Join character distance predicate allows only 1 attribute, got " + attributeNames.size()+  " attributes.");
+        String joinAttributeName = attributeNames.get(0);
         
         int distance;
         try {
@@ -113,7 +112,7 @@ public class JoinBuilder {
             throw new PlanGenException("Join character distance predicate: distance must be greater than 0.");
         }
         
-        return new JoinDistancePredicate(joinIDAttribute, joinAttribute, distance);
+        return new JoinDistancePredicate(joinIDAttributeName, joinAttributeName, distance);
     }
 
 }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTest.java
@@ -110,7 +110,8 @@ public class JoinTest {
     // A helper method to get join result. Called from each test case
     public List<ITuple> getJoinResults(IOperator outer, IOperator inner, Attribute idAttribute, Attribute joinAttribute,
             Integer threshold, int limit, int offset) throws Exception {
-        IJoinPredicate joinDistancePredicate = new JoinDistancePredicate(idAttribute, joinAttribute, threshold);
+        IJoinPredicate joinDistancePredicate = new JoinDistancePredicate(
+                idAttribute.getFieldName(), joinAttribute.getFieldName(), threshold);
         join = new Join(outer, inner, joinDistancePredicate);
         join.setLimit(limit);
         join.setOffset(offset);
@@ -1954,7 +1955,8 @@ public class JoinTest {
         Attribute idAttr = attributeList.get(0);
         Attribute reviewAttr = attributeList.get(4);
 
-        IJoinPredicate joinDistancePredicate = new JoinDistancePredicate(idAttr, reviewAttr, 90);
+        IJoinPredicate joinDistancePredicate = new JoinDistancePredicate(
+                idAttr.getFieldName(), reviewAttr.getFieldName(), 90);
         join = new Join(keywordMatcherOuter, keywordMatcherInner, joinDistancePredicate);
         join.setLimit(2);
         join.setOffset(2);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
@@ -74,9 +74,7 @@ public class LogicalPlanTest {
             put(JoinBuilder.JOIN_PREDICATE, "CharacterDistance");
             put(JoinBuilder.JOIN_DISTANCE, "100");
             put(JoinBuilder.JOIN_ID_ATTRIBUTE_NAME, "id");
-            put(JoinBuilder.JOIN_ID_ATTRIBUTE_TYPE, "integer");
             put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "content");
-            put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "text");
         }
     };
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/JoinBuilderTest.java
@@ -15,28 +15,21 @@ public class JoinBuilderTest {
         
         String joinPredicateType = JoinBuilder.JOIN_CHARACTER_DISTANCE;
         String idAttributeName = "ID";
-        String idAttributeType = "String";
         String attributeName = "content";
-        String attributeType = "Text";
         String distanceStr = "10";
         
         HashMap<String, String> operatorProperties = new HashMap<>();
         
         operatorProperties.put(JoinBuilder.JOIN_PREDICATE, joinPredicateType);
         operatorProperties.put(JoinBuilder.JOIN_ID_ATTRIBUTE_NAME, idAttributeName);
-        operatorProperties.put(JoinBuilder.JOIN_ID_ATTRIBUTE_TYPE, idAttributeType);
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, attributeName);
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, attributeType);
         operatorProperties.put(JoinBuilder.JOIN_DISTANCE, distanceStr);
         
         Join join = JoinBuilder.buildOperator(operatorProperties);
         
-        Assert.assertEquals(join.getPredicate().getIDAttribute().getFieldName(), idAttributeName);
-        Assert.assertEquals(join.getPredicate().getIDAttribute().getFieldType().toString().toLowerCase(), 
-                idAttributeType.toLowerCase());
-        Assert.assertEquals(join.getPredicate().getJoinAttribute().getFieldName(), attributeName);
-        Assert.assertEquals(join.getPredicate().getJoinAttribute().getFieldType().toString().toLowerCase(), 
-                attributeType.toLowerCase());
+        Assert.assertEquals(join.getPredicate().getIDAttributeName(), idAttributeName);
+        Assert.assertEquals(join.getPredicate().getJoinAttributeName(), attributeName);
+
         
         Assert.assertTrue(join.getPredicate() instanceof JoinDistancePredicate);
         JoinDistancePredicate joinDistancePredicate = (JoinDistancePredicate) join.getPredicate();


### PR DESCRIPTION
This PR follows PR #276 .

Similar to PR #275 and PR #276 , this PR changes the `attribute` in `JoinPredicate` to `attributeName`. And remove `attributeType` in JoinBuilder.

Because `attributeType` can only be accessed from input schema, this PR also changes the code that checks if the `joinAttribute` is `STRING` or `TEXT`.