### PR TITLE
[Issue #243] Rename DataReader isPayloadAdded function, add a new helper function

### DIFF
--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -245,10 +245,6 @@ public class Utils {
                 List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue();
                 sb.append(getSpanListString(spanList));
                 sb.append("\n");
-            } else if (attribute.getFieldName().equals(SchemaConstants.PAYLOAD)) {
-                List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.PAYLOAD)).getValue();
-                sb.append(getSpanListString(spanList));
-                sb.append("\n");
             } else {
                 sb.append(attribute.getFieldName());
                 sb.append("(");

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -13,6 +13,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.DateTools;
@@ -244,6 +245,10 @@ public class Utils {
                 List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue();
                 sb.append(getSpanListString(spanList));
                 sb.append("\n");
+            } else if (attribute.getFieldName().equals(SchemaConstants.PAYLOAD)) {
+                List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.PAYLOAD)).getValue();
+                sb.append(getSpanListString(spanList));
+                sb.append("\n");
             } else {
                 sb.append(attribute.getFieldName());
                 sb.append("(");
@@ -319,17 +324,11 @@ public class Utils {
 
     public static List<Span> generatePayloadFromTuple(ITuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate
-                                                                         // payload
-                                                                         // only
-                                                                         // for
-                                                                         // TEXT
-                                                                         // field
+                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate payload only for TEXT field
                 .map(attr -> attr.getFieldName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))
-                .flatMap(payload -> payload.stream()) // flatten a list of lists
-                                                      // to a list
+                .flatMap(payload -> payload.stream()) // flatten a list of lists to a list
                 .collect(Collectors.toList());
 
         return tuplePayload;
@@ -337,23 +336,27 @@ public class Utils {
 
     public static List<Span> generatePayload(String fieldName, String fieldValue, Analyzer luceneAnalyzer) {
         List<Span> payload = new ArrayList<>();
-
+        
         try {
             TokenStream tokenStream = luceneAnalyzer.tokenStream(null, new StringReader(fieldValue));
+            System.out.println(tokenStream.getClass());
             OffsetAttribute offsetAttribute = tokenStream.addAttribute(OffsetAttribute.class);
             CharTermAttribute charTermAttribute = tokenStream.addAttribute(CharTermAttribute.class);
-
-            int tokenCounter = 0;
+            PositionIncrementAttribute positionIncrementAttribute = 
+                    tokenStream.addAttribute(PositionIncrementAttribute.class);
+            
+            int tokenPositionCounter = -1;
             tokenStream.reset();
             while (tokenStream.incrementToken()) {
-                int tokenPosition = tokenCounter;
+                tokenPositionCounter += positionIncrementAttribute.getPositionIncrement();
+                
+                int tokenPosition = tokenPositionCounter;
                 int charStart = offsetAttribute.startOffset();
                 int charEnd = offsetAttribute.endOffset();
                 String analyzedTermStr = charTermAttribute.toString();
                 String originalTermStr = fieldValue.substring(charStart, charEnd);
 
                 payload.add(new Span(fieldName, charStart, charEnd, analyzedTermStr, originalTermStr, tokenPosition));
-                tokenCounter++;
             }
             tokenStream.close();
         } catch (IOException e) {

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -339,7 +339,6 @@ public class Utils {
         
         try {
             TokenStream tokenStream = luceneAnalyzer.tokenStream(null, new StringReader(fieldValue));
-            System.out.println(tokenStream.getClass());
             OffsetAttribute offsetAttribute = tokenStream.addAttribute(OffsetAttribute.class);
             CharTermAttribute charTermAttribute = tokenStream.addAttribute(CharTermAttribute.class);
             PositionIncrementAttribute positionIncrementAttribute = 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -108,7 +108,7 @@ public class FuzzyTokenPredicate implements IPredicate {
 
     public DataReaderPredicate getDataReaderPredicate(IDataStore dataStore) {
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, dataStore, this.luceneAnalyzer);
-        dataReaderPredicate.seIsPayloadAdded(true);
+        dataReaderPredicate.setIsPayloadAdded(true);
         return dataReaderPredicate;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -108,7 +108,7 @@ public class FuzzyTokenPredicate implements IPredicate {
 
     public DataReaderPredicate getDataReaderPredicate(IDataStore dataStore) {
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, dataStore, this.luceneAnalyzer);
-        dataReaderPredicate.setIsSpanInformationAdded(true);
+        dataReaderPredicate.seIsPayloadAdded(true);
         return dataReaderPredicate;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -65,7 +65,7 @@ public class RegexPredicate implements IPredicate {
         }
         
         DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, dataStore, luceneAnalyzer);
-        predicate.seIsPayloadAdded(false);
+        predicate.setIsPayloadAdded(false);
         return predicate;
     }
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -65,7 +65,7 @@ public class RegexPredicate implements IPredicate {
         }
         
         DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, dataStore, luceneAnalyzer);
-        predicate.setIsSpanInformationAdded(false);
+        predicate.seIsPayloadAdded(false);
         return predicate;
     }
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -57,7 +57,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         Query luceneQuery = createLuceneQueryObject();
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
                 luceneQuery, dataStore, this.predicate.getLuceneAnalyzer());
-        dataReaderPredicate.setIsSpanInformationAdded(true);
+        dataReaderPredicate.seIsPayloadAdded(true);
         dataReader = new DataReader(dataReaderPredicate);
         
         // generate KeywordMatcher

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -57,7 +57,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         Query luceneQuery = createLuceneQueryObject();
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
                 luceneQuery, dataStore, this.predicate.getLuceneAnalyzer());
-        dataReaderPredicate.seIsPayloadAdded(true);
+        dataReaderPredicate.setIsPayloadAdded(true);
         dataReader = new DataReader(dataReaderPredicate);
         
         // generate KeywordMatcher

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -35,7 +35,7 @@ public class ScanBasedSourceOperator implements ISourceOperator {
             DataReaderPredicate predicate = new DataReaderPredicate(
                     new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
             // TODO add an option to set if payload is added in the future.
-            predicate.seIsPayloadAdded(false);
+            predicate.setIsPayloadAdded(false);
             this.dataReader = new DataReader(predicate);
             this.dataReader.open();
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -34,6 +34,8 @@ public class ScanBasedSourceOperator implements ISourceOperator {
         try {
             DataReaderPredicate predicate = new DataReaderPredicate(
                     new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
+            // TODO add an option to set if payload is added in the future.
+            predicate.seIsPayloadAdded(false);
             this.dataReader = new DataReader(predicate);
             this.dataReader.open();
         } catch (Exception e) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -87,6 +87,8 @@ public class DictionaryMatcherTest {
         List<ITuple> dictionaryMatcherResults = getDictionaryMatcherResults(dictionary, srcOpType, attributes, limit,
                 offset);
 
+        System.out.println("\n\nsource:\n"+Utils.getTupleListString(dictionaryMatcherSourceOperatorResults));
+        System.out.println("\nmatcher:\n"+Utils.getTupleListString(dictionaryMatcherResults));
         Assert.assertTrue(
                 TestUtils.containsAllResults(dictionaryMatcherSourceOperatorResults, dictionaryMatcherResults));
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -1,7 +1,6 @@
 
 package edu.uci.ics.textdb.dataflow.dictionarymatcher;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,16 +16,13 @@ import org.junit.Test;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IDictionary;
 import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -87,8 +83,6 @@ public class DictionaryMatcherTest {
         List<ITuple> dictionaryMatcherResults = getDictionaryMatcherResults(dictionary, srcOpType, attributes, limit,
                 offset);
 
-        System.out.println("\n\nsource:\n"+Utils.getTupleListString(dictionaryMatcherSourceOperatorResults));
-        System.out.println("\nmatcher:\n"+Utils.getTupleListString(dictionaryMatcherResults));
         Assert.assertTrue(
                 TestUtils.containsAllResults(dictionaryMatcherSourceOperatorResults, dictionaryMatcherResults));
 

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -34,7 +34,7 @@ public class DataReaderPredicate implements IPredicate {
         return luceneAnalyzer;
     }
 
-    public void seIsPayloadAdded(boolean isPayloadAdded) {
+    public void setIsPayloadAdded(boolean isPayloadAdded) {
         this.payloadAdded = isPayloadAdded;
     }
     

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -14,16 +14,12 @@ public class DataReaderPredicate implements IPredicate {
     private IDataStore dataStore;
     private Query luceneQuery;
     private Analyzer luceneAnalyzer;
-    private boolean isSpanInformationAdded = false;
+    private boolean payloadAdded = false;
 
     public DataReaderPredicate(Query luceneQuery, IDataStore dataStore, Analyzer analyzer) {
         this.dataStore = dataStore;
         this.luceneQuery = luceneQuery;
         this.luceneAnalyzer = analyzer;
-    }
-
-    public void setIsSpanInformationAdded(boolean flag) {
-        isSpanInformationAdded = flag;
     }
 
     public IDataStore getDataStore() {
@@ -38,7 +34,11 @@ public class DataReaderPredicate implements IPredicate {
         return luceneAnalyzer;
     }
 
-    public boolean getIsSpanInformationAdded() {
-        return isSpanInformationAdded;
+    public void seIsPayloadAdded(boolean isPayloadAdded) {
+        this.payloadAdded = isPayloadAdded;
+    }
+    
+    public boolean isPayloadAdded() {
+        return this.payloadAdded;
     }
 }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -22,7 +22,6 @@ import org.apache.lucene.store.FSDirectory;
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.IPredicate;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataReader;
@@ -55,10 +54,11 @@ public class DataReader implements IDataReader {
 
     private int limit;
     private int offset;
-    private boolean payloadAdded = true;
+    private boolean payloadAdded;
 
     public DataReader(DataReaderPredicate dataReaderPredicate) {
         predicate = dataReaderPredicate;
+        payloadAdded = dataReaderPredicate.isPayloadAdded();
     }
 
     @Override
@@ -180,12 +180,7 @@ public class DataReader implements IDataReader {
                 }
                 // for each term, go through its postings
                 for (int i = 0; i < termPostings.freq(); i++) {
-                    int tokenPosition = termPostings.nextPosition(); // nextPosition
-                                                                     // needs to
-                                                                     // be
-                                                                     // called
-                                                                     // first
-
+                    int tokenPosition = termPostings.nextPosition(); // nextPosition needs to be called first
                     int charStart = termPostings.startOffset();
                     int charEnd = termPostings.endOffset();
                     String analyzedTermStr = termsEnum.term().utf8ToString();
@@ -217,15 +212,17 @@ public class DataReader implements IDataReader {
         this.offset = offset;
     }
 
-    public boolean isTermVecAdded() {
-        return payloadAdded;
-    }
-
-    public void setTermVecAdded(boolean termVecAdded) {
-        this.payloadAdded = termVecAdded;
-    }
-
     public Schema getOutputSchema() {
         return outputSchema;
     }
+    
+    public static boolean isIndexExist(String directory) {
+        try {
+            return DirectoryReader.indexExists(
+                    FSDirectory.open(Paths.get(directory)));
+        } catch (IOException e) {
+            return false;
+        }
+    }
+    
 }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -215,7 +215,7 @@ public class DataReader implements IDataReader {
         return outputSchema;
     }
     
-    public static boolean checkIndexExists(String directory) {
+    public static boolean checkIndexExistence(String directory) {
         try {
             return DirectoryReader.indexExists(
                     FSDirectory.open(Paths.get(directory)));

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -28,6 +28,7 @@ import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
@@ -62,7 +63,7 @@ public class DataReader implements IDataReader {
     }
 
     @Override
-    public void open() throws DataFlowException {
+    public void open() throws StorageException {
         if (cursor != CLOSED) {
             return;
         }
@@ -83,17 +84,16 @@ public class DataReader implements IDataReader {
             }
 
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
+            throw new StorageException(e.getMessage(), e);
         }
 
         cursor = OPENED;
     }
 
     @Override
-    public ITuple getNextTuple() throws DataFlowException {
+    public ITuple getNextTuple() throws StorageException {
         if (cursor == CLOSED) {
-            throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
+            throw new StorageException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
 
         ITuple resultTuple;
@@ -105,8 +105,7 @@ public class DataReader implements IDataReader {
             resultTuple = constructTuple(docID);
 
         } catch (IOException | ParseException e) {
-            e.printStackTrace();
-            throw new DataFlowException(e.getMessage(), e);
+            throw new StorageException(e.getMessage(), e);
         }
 
         cursor++;
@@ -114,14 +113,14 @@ public class DataReader implements IDataReader {
     }
 
     @Override
-    public void close() throws DataFlowException {
+    public void close() throws StorageException {
         cursor = CLOSED;
         if (luceneIndexReader != null) {
             try {
                 luceneIndexReader.close();
                 luceneIndexReader = null;
             } catch (IOException e) {
-                throw new DataFlowException(e.getMessage(), e);
+                throw new StorageException(e.getMessage(), e);
             }
         }
     }
@@ -216,7 +215,7 @@ public class DataReader implements IDataReader {
         return outputSchema;
     }
     
-    public static boolean indexExists(String directory) {
+    public static boolean checkIndexExists(String directory) {
         try {
             return DirectoryReader.indexExists(
                     FSDirectory.open(Paths.get(directory)));

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -216,7 +216,7 @@ public class DataReader implements IDataReader {
         return outputSchema;
     }
     
-    public static boolean isIndexExist(String directory) {
+    public static boolean indexExists(String directory) {
         try {
             return DirectoryReader.indexExists(
                     FSDirectory.open(Paths.get(directory)));


### PR DESCRIPTION
This PR has some minor modifications of `DataReaer` and `DataReaderPredicate`.
The changes in this PR is necessary for the implementation of `RelationManager`.

`DataReader` has a function to set `termVec`, and `DataReaderPredicate` has a function to set `spanList`. Both of them essentially mean whether the `payload` is added to the results from DataReader. (Payload contains all positional information of a TEXT field. We either get it from Lucene or build it at runtime for keyword matching).

This PR removes both functions and adds `setIsPayloadAdded` function to DataReaderPredicate.

This PR also adds a new helper function to DataReader, which checks if a directory contains Lucene index.

This PR accidentally reveals a bug in `generatePayload` function. `generatePayload` function is called when payload is not added in DataReader, and KeywordMatcher must add it at runtime. `generatePayload` incorrectly handles the position gap caused by stopwords, now it's fixed.