### PR TITLE
[Issue #259] Add processOneInputTuple to AbstractSingleSourceOperator

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/AbstractSingleInputOperator.java
@@ -92,6 +92,8 @@ public abstract class AbstractSingleInputOperator implements IOperator {
      */
     protected abstract ITuple computeNextMatchingTuple() throws TextDBException;
 
+    public abstract ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException;
+
     @Override
     public void close() throws TextDBException {
         if (cursor == CLOSED) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -32,28 +32,36 @@ public class ComparableMatcher<T extends Comparable> extends AbstractSingleInput
         ITuple resultTuple = null;
 
         while ((inputTuple = inputOperator.getNextTuple()) != null) {
-            Attribute attribute = predicate.getAttribute();
-            DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
-
-            FieldType fieldType = attribute.getFieldType();
-            String fieldName = attribute.getFieldName();
-
-            T value;
-            T threshold;
-            try {
-                value = (T) inputTuple.getField(fieldName).getValue();
-                threshold = (T) predicate.getThreshold();
-            } catch (ClassCastException e) {
-                continue;
-            }
-
-            if (compareValues(value, threshold, operatorType)) {
-                resultTuple = inputTuple;
-            }
+            resultTuple = processOneInputTuple(inputTuple);
 
             if (resultTuple != null) {
                 break;
             }
+        }
+        return resultTuple;
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+        ITuple resultTuple = null;
+
+        Attribute attribute = predicate.getAttribute();
+        DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
+
+        FieldType fieldType = attribute.getFieldType();
+        String fieldName = attribute.getFieldName();
+
+        T value;
+        T threshold;
+        try {
+            value = (T) inputTuple.getField(fieldName).getValue();
+            threshold = (T) predicate.getThreshold();
+        } catch (ClassCastException e) {
+            return null;
+        }
+
+        if (compareValues(value, threshold, operatorType)) {
+            resultTuple = inputTuple;
         }
         return resultTuple;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -75,8 +75,9 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
         }
         return resultTuple;
     }
-    
-    private ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
         List<Span> payload = (List<Span>) inputTuple.getField(SchemaConstants.PAYLOAD).getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -49,34 +49,42 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     protected ITuple computeNextMatchingTuple() throws TextDBException {
         ITuple inputTuple = null;
         ITuple resultTuple = null;
-        
-        while ((inputTuple = inputOperator.getNextTuple()) != null) {
-            
-            // There's an implicit assumption that, in open() method, PAYLOAD is
-            // checked before SPAN_LIST.
-            // Therefore, PAYLOAD needs to be checked and added first
-            if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
-                inputTuple = Utils.getSpanTuple(inputTuple.getFields(),
-                        Utils.generatePayloadFromTuple(inputTuple, predicate.getLuceneAnalyzer()), outputSchema);
-            }
-            if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
-                inputTuple = Utils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
-            }
 
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-                resultTuple = computeConjunctionMatchingResult(inputTuple);
-            }
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
-                resultTuple = computePhraseMatchingResult(inputTuple);
-            }
-            if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
-                resultTuple = computeSubstringMatchingResult(inputTuple);
-            }
-            
+        while ((inputTuple = inputOperator.getNextTuple()) != null) {
+            resultTuple = processOneInputTuple(inputTuple);
+
             if (resultTuple != null) {
                 break;
             }
         }
+        return resultTuple;
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+        ITuple resultTuple = null;
+
+        // There's an implicit assumption that, in open() method, PAYLOAD is
+        // checked before SPAN_LIST.
+        // Therefore, PAYLOAD needs to be checked and added first
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            inputTuple = Utils.getSpanTuple(inputTuple.getFields(),
+                    Utils.generatePayloadFromTuple(inputTuple, predicate.getLuceneAnalyzer()), outputSchema);
+        }
+        if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+            inputTuple = Utils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
+        }
+
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+            resultTuple = computeConjunctionMatchingResult(inputTuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+            resultTuple = computePhraseMatchingResult(inputTuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
+            resultTuple = computeSubstringMatchingResult(inputTuple);
+        }
+
         return resultTuple;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -83,6 +83,11 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     }
 
     @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+        return this.keywordMatcher.processOneInputTuple(inputTuple);
+    }
+
+    @Override
     protected void cleanUp() throws DataFlowException {
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -79,7 +79,8 @@ public class NlpExtractor extends AbstractSingleInputOperator {
         return resultTuple;
     }
 
-    private ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
         List<Span> matchingResults = new ArrayList<>();
         for (Attribute attribute : predicate.getAttributeList()) {
             String fieldName = attribute.getFieldName();

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
@@ -43,15 +43,19 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
         if (inputTuple == null) {
             return null;
         }
-        
-        IField[] outputFields = 
-                outputSchema.getAttributes()
-                .stream()
-                .map(attr -> inputTuple.getField(attr.getFieldName()))
-                .toArray(IField[]::new);
-        
-        return new DataTuple(outputSchema, outputFields); 
 
+        return processOneInputTuple(inputTuple);
+    }
+
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws TextDBException {
+        IField[] outputFields =
+                outputSchema.getAttributes()
+                        .stream()
+                        .map(attr -> inputTuple.getField(attr.getFieldName()))
+                        .toArray(IField[]::new);
+
+        return new DataTuple(outputSchema, outputFields);
     }
 
     @Override

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -115,7 +115,8 @@ public class RegexMatcher extends AbstractSingleInputOperator {
      *         in the document
      * @throws DataFlowException
      */
-    private ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
+    @Override
+    public ITuple processOneInputTuple(ITuple inputTuple) throws DataFlowException {
         if (inputTuple == null) {
             return null;
         }


### PR DESCRIPTION
Copied from Issue #259

This issue is related to Efficient Text Widget Recommendations to Users, which is, for the given document with highlighted substring, we would like to recommend which plans we have match that, so that user can reuse pre-defined plans.

This can be done by executing plans we have on that given single document(or on just substring), and since some of extended class of AbstractSingleSourceOperator already have such method, I think it's good idea to make it abstract method. We need to come up with a converter which evaluates JSON query to actual query plan object, and a slightly different conversion can be applied to a plan so that it can efficiently run on a single document.