### PR TITLE
[Issue #243] Remove analyzer in datareader predicate

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/FuzzyTokenPredicate.java
@@ -107,7 +107,7 @@ public class FuzzyTokenPredicate implements IPredicate {
     }
 
     public DataReaderPredicate getDataReaderPredicate(IDataStore dataStore) {
-        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, dataStore, this.luceneAnalyzer);
+        DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(this.luceneQuery, dataStore);
         dataReaderPredicate.setIsPayloadAdded(true);
         return dataReaderPredicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/RegexPredicate.java
@@ -64,7 +64,7 @@ public class RegexPredicate implements IPredicate {
             throw new DataFlowException(e.getMessage(), e);
         }
         
-        DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, dataStore, luceneAnalyzer);
+        DataReaderPredicate predicate = new DataReaderPredicate(luceneQuery, dataStore);
         predicate.setIsPayloadAdded(false);
         return predicate;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -77,7 +77,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
             if (predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
                 // For Substring matching, create a scan source operator.
-                indexSource = new ScanBasedSourceOperator(dataStore, predicate.getAnalyzer());
+                indexSource = new ScanBasedSourceOperator(dataStore);
                 indexSource.open();
 
                 // Substring matching's output schema needs to contains span

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -56,7 +56,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         // generate dataReader
         Query luceneQuery = createLuceneQueryObject();
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                luceneQuery, dataStore, this.predicate.getLuceneAnalyzer());
+                luceneQuery, dataStore);
         dataReaderPredicate.setIsPayloadAdded(true);
         dataReader = new DataReader(dataReaderPredicate);
         

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperator.java
@@ -2,9 +2,6 @@ package edu.uci.ics.textdb.dataflow.source;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.search.MatchAllDocsQuery;
-
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
@@ -20,20 +17,17 @@ import edu.uci.ics.textdb.storage.reader.DataReader;
 public class ScanBasedSourceOperator implements ISourceOperator {
 
     private IDataStore dataStore;
-    private Analyzer luceneAnalyzer;
     
     private IDataReader dataReader;
 
-    public ScanBasedSourceOperator(IDataStore dataStore, Analyzer luceneAnalyzer) throws DataFlowException {
+    public ScanBasedSourceOperator(IDataStore dataStore) throws DataFlowException {
         this.dataStore = dataStore;
-        this.luceneAnalyzer = luceneAnalyzer;
     }
 
     @Override
     public void open() throws TextDBException {
         try {
-            DataReaderPredicate predicate = new DataReaderPredicate(
-                    new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
+            DataReaderPredicate predicate = DataReaderPredicate.getScanPredicate(dataStore);
             // TODO add an option to set if payload is added in the future.
             predicate.setIsPayloadAdded(false);
             this.dataReader = new DataReader(predicate);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcherTest.java
@@ -37,7 +37,7 @@ public class ComparableMatcherTest {
     private Analyzer analyzer;
 
     private ScanBasedSourceOperator getScanSourceOperator(IDataStore dataStore) throws DataFlowException {
-        ScanBasedSourceOperator scanSource = new ScanBasedSourceOperator(dataStore, analyzer);
+        ScanBasedSourceOperator scanSource = new ScanBasedSourceOperator(dataStore);
         return scanSource;
     }
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/connector/OneToNBroadcastConnectorTest.java
@@ -56,7 +56,7 @@ public class OneToNBroadcastConnectorTest {
     
     private IOperator getScanSourceOperator(IDataStore dataStore) throws DataFlowException {
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
-                new MatchAllDocsQuery(), dataStore, luceneAnalyzer);
+                new MatchAllDocsQuery(), dataStore);
         IndexBasedSourceOperator sourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
         return sourceOperator;
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTest.java
@@ -114,7 +114,7 @@ public class DictionaryMatcherTest {
                 srcOpType);
 
         DictionaryMatcher dictionaryMatcher = new DictionaryMatcher(dictionaryPredicate);
-        ScanBasedSourceOperator indexSource = new ScanBasedSourceOperator(dataStore, luceneAnalyzer);
+        ScanBasedSourceOperator indexSource = new ScanBasedSourceOperator(dataStore);
         dictionaryMatcher.setInputOperator(indexSource);
 
         dictionaryMatcher.open();

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTest.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.Query;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,7 +14,6 @@ import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
-import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.api.storage.IDataWriter;
 import edu.uci.ics.textdb.common.constants.DataConstants;
@@ -25,9 +22,7 @@ import edu.uci.ics.textdb.dataflow.nlpextrator.NlpExtractor;
 import edu.uci.ics.textdb.dataflow.nlpextrator.NlpPredicate;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.reader.DataReader;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
@@ -375,7 +370,7 @@ public class NlpExtractorTest {
             dataWriter.insertTuple(tuple);
         }
 
-        ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataStore, analyzer);
+        ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataStore);
         return sourceOperator;
 
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperatorTest.java
@@ -87,7 +87,7 @@ public class ProjectionOperatorTest {
         ITuple tuple6 = new DataTuple(projectionSchema, fields6);
         
         List<ITuple> expectedResults = Arrays.asList(tuple1, tuple2, tuple3, tuple4, tuple5, tuple6);
-        List<ITuple> returnedResults = getProjectionResults(new ScanBasedSourceOperator(dataStore, luceneAnalyzer), projectionFields);
+        List<ITuple> returnedResults = getProjectionResults(new ScanBasedSourceOperator(dataStore), projectionFields);
         
         Assert.assertTrue(TestUtils.containsAllResults(expectedResults, returnedResults));
     }
@@ -113,7 +113,7 @@ public class ProjectionOperatorTest {
         ITuple tuple6 = new DataTuple(projectionSchema, fields6);
         
         List<ITuple> expectedResults = Arrays.asList(tuple1, tuple2, tuple3, tuple4, tuple5, tuple6);
-        List<ITuple> returnedResults = getProjectionResults(new ScanBasedSourceOperator(dataStore, luceneAnalyzer), projectionFields);
+        List<ITuple> returnedResults = getProjectionResults(new ScanBasedSourceOperator(dataStore), projectionFields);
         
         Assert.assertTrue(TestUtils.containsAllResults(expectedResults, returnedResults));
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -60,7 +60,7 @@ public class IndexBasedSourceOperatorTest {
         String defaultField = TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName();
         QueryParser queryParser = new QueryParser(defaultField, luceneAnalyzer);
         Query queryObject = queryParser.parse(query);
-        dataReaderPredicate = new DataReaderPredicate(queryObject, dataStore, luceneAnalyzer);
+        dataReaderPredicate = new DataReaderPredicate(queryObject, dataStore);
 
         indexBasedSourceOperator = new IndexBasedSourceOperator(dataReaderPredicate);
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/ScanBasedSourceOperatorTest.java
@@ -46,7 +46,7 @@ public class ScanBasedSourceOperatorTest {
             dataWriter.insertTuple(tuple);
         }
         
-        scanBasedSourceOperator = new ScanBasedSourceOperator(dataStore, luceneAnalyzer);
+        scanBasedSourceOperator = new ScanBasedSourceOperator(dataStore);
     }
 
     @After

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -104,7 +104,7 @@ public class NlpExtractorPerformanceTest {
 
         List<Attribute> attributeList = Arrays.asList(MedlineIndexWriter.ABSTRACT_ATTR);
 
-        ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataStore, analyzer);
+        ISourceOperator sourceOperator = new ScanBasedSourceOperator(dataStore);
 
         NlpPredicate nlpPredicate = new NlpPredicate(tokenType, attributeList);
         NlpExtractor nlpExtractor = new NlpExtractor(nlpPredicate);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReaderPredicate.java
@@ -1,6 +1,6 @@
 package edu.uci.ics.textdb.storage;
 
-import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
 import edu.uci.ics.textdb.api.common.IPredicate;
@@ -13,13 +13,11 @@ import edu.uci.ics.textdb.api.storage.IDataStore;
 public class DataReaderPredicate implements IPredicate {
     private IDataStore dataStore;
     private Query luceneQuery;
-    private Analyzer luceneAnalyzer;
     private boolean payloadAdded = false;
 
-    public DataReaderPredicate(Query luceneQuery, IDataStore dataStore, Analyzer analyzer) {
+    public DataReaderPredicate(Query luceneQuery, IDataStore dataStore) {
         this.dataStore = dataStore;
         this.luceneQuery = luceneQuery;
-        this.luceneAnalyzer = analyzer;
     }
 
     public IDataStore getDataStore() {
@@ -29,16 +27,16 @@ public class DataReaderPredicate implements IPredicate {
     public Query getLuceneQuery() {
         return luceneQuery;
     }
-
-    public Analyzer getLuceneAnalyzer() {
-        return luceneAnalyzer;
-    }
-
+    
     public void setIsPayloadAdded(boolean isPayloadAdded) {
         this.payloadAdded = isPayloadAdded;
     }
     
     public boolean isPayloadAdded() {
         return this.payloadAdded;
+    }
+    
+    public static DataReaderPredicate getScanPredicate(IDataStore dataStore) {
+        return new DataReaderPredicate(new MatchAllDocsQuery(), dataStore);
     }
 }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/reader/DataReader.java
@@ -26,7 +26,6 @@ import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.storage.IDataReader;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.common.field.DataTuple;

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataReaderPredicateTest.java
@@ -24,7 +24,7 @@ public class DataReaderPredicateTest {
         QueryParser luceneQueryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(),
                 new StandardAnalyzer());
         luceneQuery = luceneQueryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(luceneQuery, dataStore, new StandardAnalyzer());
+        dataReaderPredicate = new DataReaderPredicate(luceneQuery, dataStore);
     }
 
     @Test

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -38,7 +38,7 @@ public class DataWriterReaderTest {
         dataWriter = new DataWriter(dataStore, luceneAnalyzer);
         QueryParser queryParser = new QueryParser(TestConstants.ATTRIBUTES_PEOPLE[0].getFieldName(), luceneAnalyzer);
         query = queryParser.parse(DataConstants.SCAN_QUERY);
-        dataReaderPredicate = new DataReaderPredicate(query, dataStore, luceneAnalyzer);
+        dataReaderPredicate = new DataReaderPredicate(query, dataStore);
         dataReader = new DataReader(dataReaderPredicate);
     }
 


### PR DESCRIPTION
This PR removes `luceneAnalyzer` in DataReader Predicate's constructor.

I just noticed that `luceneAnalyzer` exists because of the legacy design, and it's no longer needed. This PR removes it from `DataReaderPredicate` and `ScanBasedSourceOperator`, all use cases have been adjusted accordingly.

