### PR TITLE
[Issue #242] Enabling Cross Origin Resource Sharing on /queryplan/execute for the GUI

### DIFF
--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
@@ -40,7 +40,10 @@ public class QueryPlanResource {
             SampleResponse sampleResponse = new SampleResponse(0, "Successful");
             return Response.status(200)
                     .entity(objectMapper.writeValueAsString(sampleResponse))
-                    .type(MediaType.APPLICATION_JSON)
+                    .header("Access-Control-Allow-Origin", "*")
+                    .header("Access-Control-Allow-Methods", "OPTIONS,GET,PUT,POST,DELETE,HEAD")
+                    .header("Access-Control-Allow-Headers", "X-Requested-With,Content-Type,Accept,Origin")
+                    .header("Access-Control-Max-Age", "1728000")
                     .build();
         }
         else {
@@ -48,7 +51,10 @@ public class QueryPlanResource {
             SampleResponse sampleResponse = new SampleResponse(1, "Unsuccessful");
             return Response.status(400)
                     .entity(objectMapper.writeValueAsString(sampleResponse))
-                    .type(MediaType.APPLICATION_JSON)
+                    .header("Access-Control-Allow-Origin", "*")
+                    .header("Access-Control-Allow-Methods", "OPTIONS,GET,PUT,POST,DELETE,HEAD")
+                    .header("Access-Control-Allow-Headers", "X-Requested-With,Content-Type,Accept,Origin")
+                    .header("Access-Control-Max-Age", "1728000")
                     .build();
         }
     }


### PR DESCRIPTION
* This PR introduces the necessary `CORS` headers at the `/queryplan/execute` endpoint
* These CORS headers are necessary at the moment for running the GUI and for testing purposes until the GUI can be permanently hosted with the engine. 


A resource makes a cross-origin HTTP request when it requests a resource from a different domain than the one which the first resource itself serves. This is what happens when our GUI calls our `textdb-web` module. The Cross-Origin Resource Sharing (CORS) mechanism gives web servers cross-domain access controls, which enable secure cross-domain data transfers. Modern web browsers regulate AJAX calls which do not return the appropriate CORS headers. This PR enables CORS on the `queryplan/execute` URL, which involved the addition of the following headers:
* `Access-Control-Allow-Origin`
* `Access-Control-Allow-Methods`
* `Access-Control-Allow-Headers`
* `Access-Control-Max-Age`

Check the following link -https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS