### PR TITLE
[312] fix the zika sample extractor to generate a file supported by Windows

### DIFF
--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -1,8 +1,10 @@
 package edu.uci.ics.textdb.perftest.sample;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Scanner;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -147,9 +149,12 @@ public class SampleExtraction {
         ProjectionPredicate projectionPredicateIdAndSpan = new ProjectionPredicate(
                 Arrays.asList(PromedSchema.ID, SchemaConstants.SPAN_LIST));
         ProjectionOperator projectionOperatorIdAndSpan = new ProjectionOperator(projectionPredicateIdAndSpan);
-
+         
+        SimpleDateFormat sdf = new SimpleDateFormat("MM-dd-yyyy-HH-mm-ss");
         FileSink fileSink = new FileSink( 
-                new File("./sample-data-files/person-location-result-"+PerfTestUtils.formatTime(System.currentTimeMillis())+".txt"));
+                new File("./sample-data-files/person-location-result-" 
+                		+ sdf.format(new Date(System.currentTimeMillis())).toString() + ".txt"));
+
         fileSink.setToStringFunction((tuple -> Utils.getTupleString(tuple)));
         
         


### PR DESCRIPTION
Reason: the old program generated a file with ":" in the name, which is not supported on Windows. In this fix, we change the file name to avoid using ":".