### PR TITLE
Remove redundant "evaluate(plan)" call in Sample Extraction code

### DIFF
--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -37,7 +37,6 @@ import edu.uci.ics.textdb.dataflow.sink.IndexSink;
 import edu.uci.ics.textdb.dataflow.source.TupleStreamSourceOperator;
 import edu.uci.ics.textdb.engine.Engine;
 import edu.uci.ics.textdb.perftest.promed.PromedSchema;
-import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
 
@@ -96,9 +95,6 @@ public class SampleExtraction {
                 new StandardAnalyzer(), false);
         standardIndexSink.setInputOperator(fileSource);
         Plan standardIndexPlan = new Plan(standardIndexSink);
-
-        Engine engine = Engine.getEngine();
-        engine.evaluate(standardIndexPlan);
 
         Engine.getEngine().evaluate(standardIndexPlan);
     }


### PR DESCRIPTION
In the sample extraction code, a plan is evaluated by the engine twice. This PR removes a redundant evaluation of that plan.