### PR TITLE
[Issue #332] Modify Before and After to BeforeClass and AfterClass in keyword matcher test cases

### DIFF
--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordConjunctionTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordConjunctionTest.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.queryparser.classic.ParseException;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
@@ -40,13 +40,13 @@ public class KeywordConjunctionTest {
     
     public static final KeywordMatchingType conjunction = KeywordMatchingType.CONJUNCTION_INDEXBASED;
     
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         KeywordTestHelper.writeTestTables();
     }
 
-    @After
-    public void cleanUp() throws Exception {
+    @AfterClass
+    public static void cleanUp() throws Exception {
         KeywordTestHelper.deleteTestTables();
     }
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordPhraseTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordPhraseTest.java
@@ -4,25 +4,20 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.exception.TextDBException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -31,8 +26,6 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
-import edu.uci.ics.textdb.common.utils.Utils;
-import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.DataStore;
 import edu.uci.ics.textdb.storage.writer.DataWriter;
@@ -41,7 +34,6 @@ import edu.uci.ics.textdb.storage.writer.DataWriter;
  * @author Prakul
  *
  */
-
 public class KeywordPhraseTest {
 
     public static final String PEOPLE_TABLE = KeywordTestHelper.PEOPLE_TABLE;
@@ -49,13 +41,13 @@ public class KeywordPhraseTest {
     
     public static final KeywordMatchingType phrase = KeywordMatchingType.PHRASE_INDEXBASED;
     
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         KeywordTestHelper.writeTestTables();
     }
 
-    @After
-    public void cleanUp() throws Exception {
+    @AfterClass
+    public static void cleanUp() throws Exception {
         KeywordTestHelper.deleteTestTables();
     }
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordSubstringTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordSubstringTest.java
@@ -4,25 +4,18 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.exception.TextDBException;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
-import edu.uci.ics.textdb.api.storage.IDataWriter;
-import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
-import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.DataTuple;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -31,17 +24,12 @@ import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
-import edu.uci.ics.textdb.common.utils.Utils;
-import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
-import edu.uci.ics.textdb.storage.DataStore;
-import edu.uci.ics.textdb.storage.writer.DataWriter;
 
 /**
  * @author ZhenfengQi
  *
  */
-
 public class KeywordSubstringTest {
 
     public static final String PEOPLE_TABLE = KeywordTestHelper.PEOPLE_TABLE;
@@ -49,13 +37,13 @@ public class KeywordSubstringTest {
     
     public static final KeywordMatchingType substring = KeywordMatchingType.SUBSTRING_SCANBASED;
     
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         KeywordTestHelper.writeTestTables();
     }
 
-    @After
-    public void cleanUp() throws Exception {
+    @AfterClass
+    public static void cleanUp() throws Exception {
         KeywordTestHelper.deleteTestTables();
     }
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
@@ -14,23 +14,32 @@ import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.relation.RelationManager;
 
+/**
+ * A helper class for functions that used in multiple keyword matcher tests.
+ * This class contains functions that: 
+ *   creates and writes test tables,
+ *   deletes test tables
+ *   gets the results from a keyword matcher
+ * @author Zuozhi Wang
+ *
+ */
 public class KeywordTestHelper {
     
-    public static final String PEOPLE_TABLE = "keywordtest_people";
-    public static final String MEDLINE_TABLE = "keywordtest_medline";
+    public static final String PEOPLE_TABLE = "keyword_test_people";
+    public static final String MEDLINE_TABLE = "keyword_test_medline";
     
     public static void writeTestTables() throws TextDBException {
         RelationManager relationManager = RelationManager.getRelationManager();
         
         // create the people table and write tuples
-        relationManager.createTable(PEOPLE_TABLE, "../index/keywordtest/people/", 
+        relationManager.createTable(PEOPLE_TABLE, "../index/test_tables/" + PEOPLE_TABLE, 
                 TestConstants.SCHEMA_PEOPLE, LuceneAnalyzerConstants.standardAnalyzerString());        
         for (ITuple tuple : TestConstants.getSamplePeopleTuples()) {
             relationManager.insertTuple(PEOPLE_TABLE, tuple);
         }
         
         // create the medline table and write tuples
-        relationManager.createTable(MEDLINE_TABLE, "../index/keywordtest/medline/",
+        relationManager.createTable(MEDLINE_TABLE, "../index/test_tables/" + MEDLINE_TABLE,
                 keywordTestConstants.SCHEMA_MEDLINE, LuceneAnalyzerConstants.standardAnalyzerString());       
         for (ITuple tuple : keywordTestConstants.getSampleMedlineRecord()) {
             relationManager.insertTuple(MEDLINE_TABLE, tuple);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
@@ -15,11 +15,11 @@ import edu.uci.ics.textdb.dataflow.utils.TestUtils;
 import edu.uci.ics.textdb.storage.relation.RelationManager;
 
 /**
- * A helper class for functions that used in multiple keyword matcher tests.
+ * A helper class for functions that are used in multiple keyword matcher tests.
  * This class contains functions that: 
- *   creates and writes test tables,
- *   deletes test tables
- *   gets the results from a keyword matcher
+ *   create and write test tables,
+ *   delete test tables
+ *   get the results from a keyword matcher
  * @author Zuozhi Wang
  *
  */

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
@@ -9,7 +9,6 @@ import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.constants.TestConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
-import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
 import edu.uci.ics.textdb.dataflow.utils.TestUtils;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
@@ -86,11 +86,12 @@ public class KeywordTestHelper {
     
     public static List<ITuple> getScanSourceResults(String tableName, String keywordQuery, List<String> attributeNames,
             KeywordMatchingType matchingType, int limit, int offset) throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
         
         ScanBasedSourceOperator scanSource = new ScanBasedSourceOperator(tableName);
         
         KeywordPredicate keywordPredicate = new KeywordPredicate(
-                keywordQuery, attributeNames, LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
+                keywordQuery, attributeNames, relationManager.getTableAnalyzer(tableName), matchingType);
         KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
         keywordMatcher.setLimit(limit);
         keywordMatcher.setOffset(offset);
@@ -113,7 +114,7 @@ public class KeywordTestHelper {
             KeywordMatchingType matchingType, int limit, int offset) throws TextDBException {
         RelationManager relationManager = RelationManager.getRelationManager();
         KeywordPredicate keywordPredicate = new KeywordPredicate(
-                keywordQuery, attributeNames, LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
+                keywordQuery, attributeNames, relationManager.getTableAnalyzer(tableName), matchingType);
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
                 keywordPredicate, relationManager.getTableDataStore(tableName));
         keywordSource.setLimit(limit);


### PR DESCRIPTION
This PR changes the `@Before` and `@After` to `@BeforeClass` and `@AfterClass` in the keyword matcher test cases. 

This PR also changes the test table's directory to be consistent with other test cases.