### PR TITLE
[Issue #320] Refactor KeywordSource and DictionarySource to use RelationManager layer

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -5,14 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.ITuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
-import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -43,7 +40,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     private String currentDictionaryEntry;
 
     private final DictionaryPredicate predicate;
-    private IDataStore dataStore;
+    private String tableName;
 
     private int resultCursor;
     private int limit;
@@ -55,12 +52,12 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * @param predicate
      * 
      */
-    public DictionaryMatcherSourceOperator(DictionaryPredicate predicate, IDataStore dataStore) {
+    public DictionaryMatcherSourceOperator(DictionaryPredicate predicate, String tableName) {
         this.resultCursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;
         this.predicate = predicate;
-        this.dataStore = dataStore;
+        this.tableName = tableName;
     }
 
     /**
@@ -77,7 +74,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
             if (predicate.getKeywordMatchingType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
                 // For Substring matching, create a scan source operator.
-                indexSource = new ScanBasedSourceOperator(dataStore);
+                indexSource = new ScanBasedSourceOperator(tableName);
                 indexSource.open();
 
                 // Substring matching's output schema needs to contains span
@@ -96,7 +93,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                         predicate.getAnalyzer(),
                         predicate.getKeywordMatchingType());
 
-                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, tableName);
                 keywordSource.open();
 
                 // Other keyword matching types uses a KeywordMatcher, so the
@@ -177,7 +174,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                         predicate.getAttributeNames(),
                         predicate.getAnalyzer(), keywordMatchingType);
 
-                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
+                keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, tableName);
                 keywordSource.open();
             }
         }
@@ -304,8 +301,8 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
         return this.predicate;
     }
 
-    public IDataStore getDataStore() {
-        return this.dataStore;
+    public String getTableName() {
+        return this.tableName;
     }
     
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -18,11 +18,13 @@ import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.storage.IDataStore;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.storage.DataReaderPredicate;
 import edu.uci.ics.textdb.storage.reader.DataReader;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
 
 /**
  * KeywordMatcherSourceOperator is a source operator with a keyword query.
@@ -34,25 +36,25 @@ import edu.uci.ics.textdb.storage.reader.DataReader;
 public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator implements ISourceOperator {
 
     private KeywordPredicate predicate;
-    private IDataStore dataStore;
+    private String tableName;
 
     private String keywordQuery;
 
     private DataReader dataReader;
     private KeywordMatcher keywordMatcher;
-
+    
     private Schema inputSchema;
-    private Schema outputSchema;
 
-    public KeywordMatcherSourceOperator(KeywordPredicate predicate, IDataStore dataStore) throws DataFlowException {
+    public KeywordMatcherSourceOperator(KeywordPredicate predicate, String tableName) 
+            throws DataFlowException, StorageException {
         this.predicate = predicate;
-        this.dataStore = dataStore;
-
+        this.tableName = tableName;
+        
         this.keywordQuery = predicate.getQuery();
         
-        // input schema must be setup first
+        IDataStore dataStore = RelationManager.getRelationManager().getTableDataStore(tableName);
         this.inputSchema = dataStore.getSchema();
-
+        
         // generate dataReader
         Query luceneQuery = createLuceneQueryObject();
         DataReaderPredicate dataReaderPredicate = new DataReaderPredicate(
@@ -102,9 +104,9 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     public KeywordPredicate getPredicate() {
         return this.predicate;
     }
-
-    public IDataStore getDataStore() {
-        return this.dataStore;
+    
+    public String getTableName() {
+        return this.tableName;
     }
 
     /**

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilder.java
@@ -3,7 +3,6 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 import java.util.List;
 import java.util.Map;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
@@ -11,7 +10,6 @@ import edu.uci.ics.textdb.dataflow.common.Dictionary;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
 import edu.uci.ics.textdb.dataflow.dictionarymatcher.DictionaryMatcherSourceOperator;
 import edu.uci.ics.textdb.plangen.PlanGenUtils;
-import edu.uci.ics.textdb.storage.DataStore;
 
 /**
  * DictionarySourceBuilder provides a static function that builds a DictionaryMatcherSourceOperator.
@@ -37,6 +35,7 @@ public class DictionarySourceBuilder {
     public static DictionaryMatcherSourceOperator buildSourceOperator(Map<String, String> operatorProperties) throws PlanGenException {
         String dictionaryStr = OperatorBuilderUtils.getRequiredProperty(DICTIONARY, operatorProperties);
         String matchingTypeStr = OperatorBuilderUtils.getRequiredProperty(MATCHING_TYPE, operatorProperties);
+        String tableNameStr = OperatorBuilderUtils.getRequiredProperty(OperatorBuilderUtils.DATA_SOURCE, operatorProperties);
 
         // check if dictionary is empty       
         PlanGenUtils.planGenAssert(!dictionaryStr.trim().isEmpty(), "dictionary is empty");
@@ -54,10 +53,8 @@ public class DictionarySourceBuilder {
         
         DictionaryPredicate predicate = new DictionaryPredicate(
                 dictionary, attributeNames, LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);
-        
-        DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
-        
-        DictionaryMatcherSourceOperator sourceOperator = new DictionaryMatcherSourceOperator(predicate, dataStore);
+                
+        DictionaryMatcherSourceOperator sourceOperator = new DictionaryMatcherSourceOperator(predicate, tableNameStr);
                 
         return sourceOperator;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -2,18 +2,15 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
-import edu.uci.ics.textdb.common.utils.Utils;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
 import edu.uci.ics.textdb.plangen.PlanGenUtils;
-import edu.uci.ics.textdb.storage.DataStore;
 
 /**
  * KeywordSourceBuilder provides a static function that builds a KeywordMatcherSourceOperator.
@@ -38,6 +35,8 @@ public class KeywordSourceBuilder {
                 KeywordMatcherBuilder.KEYWORD, operatorProperties);
         String matchingTypeStr = OperatorBuilderUtils.getRequiredProperty(
                 KeywordMatcherBuilder.MATCHING_TYPE, operatorProperties);
+        String tableNameStr = OperatorBuilderUtils.getRequiredProperty(
+                OperatorBuilderUtils.DATA_SOURCE, operatorProperties);
 
         // check if the keyword is empty
         PlanGenUtils.planGenAssert(!keyword.trim().isEmpty(), "the keyword is empty");
@@ -55,12 +54,10 @@ public class KeywordSourceBuilder {
         keywordPredicate = new KeywordPredicate(keyword, attributeNames,
                 LuceneAnalyzerConstants.getStandardAnalyzer(), matchingType);  
         
-        DataStore dataStore = OperatorBuilderUtils.constructDataStore(operatorProperties);
-
         KeywordMatcherSourceOperator sourceOperator;
         try {
-            sourceOperator = new KeywordMatcherSourceOperator(keywordPredicate, dataStore);
-        } catch (DataFlowException e) {
+            sourceOperator = new KeywordMatcherSourceOperator(keywordPredicate, tableNameStr);
+        } catch (DataFlowException | StorageException e) {
             throw new PlanGenException(e.getMessage(), e);
         }
    

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/OperatorBuilderUtils.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/OperatorBuilderUtils.java
@@ -4,16 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import org.json.JSONObject;
-
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
-import edu.uci.ics.textdb.plangen.PlanGenUtils;
-import edu.uci.ics.textdb.storage.DataStore;
 
 public class OperatorBuilderUtils {
     
@@ -22,8 +14,7 @@ public class OperatorBuilderUtils {
     public static final String LIMIT = "limit";
     public static final String OFFSET = "offset";
     
-    public static String DATA_DIRECTORY = "directory";
-    public static String SCHEMA = "schema";
+    public static String DATA_SOURCE = "data_source";
     
     
     /**
@@ -35,11 +26,13 @@ public class OperatorBuilderUtils {
      * @throws PlanGenException, if the operator properties do not contain the key.
      */
     public static String getRequiredProperty(String key, Map<String, String> operatorProperties) throws PlanGenException {
-        if (operatorProperties.containsKey(key)) {
-            return operatorProperties.get(key);
-        } else {
+        if (! operatorProperties.containsKey(key)) {
             throw new PlanGenException("Required key missing: " + key);
         }
+        if (operatorProperties.get(key).trim().isEmpty()) {
+            throw new PlanGenException("Required key is empty: " + key);
+        }
+        return operatorProperties.get(key);
     }
 
     /**
@@ -51,57 +44,6 @@ public class OperatorBuilderUtils {
      */
     public static String getOptionalProperty(String key, Map<String, String> operatorProperties) {
         return operatorProperties.get(key);
-    }
-    
-    /**
-     * This function constructs a DataStore from operator properties.
-     * 
-     * It currently needs the following properties from operatorProperties:
-     * 
-     *   directory: the directory of data store
-     *   schema: schema of data store, which is a JSON-format string. 
-     *   "attributeNames" key's value is a string of comma-separated attribute names, 
-     *   "attirbuteTypes" key's value is a string of comma-separated attribute types corresponding to attribute names.
-     * 
-     * Here's a sample JSON representation of these properties:
-     * 
-     * {
-     *   "directory" : "directoryOfDatastore",
-     *   "schema" : {
-     *     "attributeNames" : "attribute1Name, attribute2Name, attribute3Name",
-     *     "attributeTypes" : "integer, string, text"
-     *   }
-     * }
-     * 
-     * @param operatorProperties
-     * @return dataStore, dataStore constructed according to directory and schema.
-     * @throws PlanGenException
-     */
-    public static DataStore constructDataStore(Map<String, String> operatorProperties) throws PlanGenException {
-        String directoryStr = OperatorBuilderUtils.getRequiredProperty(DATA_DIRECTORY, operatorProperties);
-        String schemaStr = OperatorBuilderUtils.getRequiredProperty(SCHEMA, operatorProperties);
-        
-        JSONObject schemaJsonObject = new JSONObject(schemaStr);
-        
-        String attributeNamesStr = schemaJsonObject.getString(ATTRIBUTE_NAMES);
-        String attributeTypesStr = schemaJsonObject.getString(ATTRIBUTE_TYPES);
-        
-        List<String> attributeNames = splitStringByComma(attributeNamesStr);
-        List<String> attributeTypes = splitStringByComma(attributeTypesStr);
-
-        PlanGenUtils.planGenAssert(attributeNames.size() == attributeTypes.size(), "attribute names and attribute types are not coherent");
-        PlanGenUtils.planGenAssert(attributeTypes.stream().allMatch(typeStr -> PlanGenUtils.isValidAttributeType(typeStr))
-                ,"attribute type is not valid");
-
-        List<Attribute> attributeList = IntStream.range(0, attributeNames.size()) // for each index in the list
-                .mapToObj(i -> constructAttribute(attributeNames.get(i), attributeTypes.get(i))) // construct an attribute
-                .collect(Collectors.toList());
-
-        Schema schema = new Schema(attributeList.stream().toArray(Attribute[]::new));
-        
-        DataStore dataStore = new DataStore(directoryStr, schema);
-        
-        return dataStore;
     }
 
     /**
@@ -127,11 +69,6 @@ public class OperatorBuilderUtils {
         List<String> attributeNames = splitStringByComma(attributeNamesStr);
 
         return attributeNames;
-    }
-
-    private static Attribute constructAttribute(String attributeNameStr, String attributeTypeStr) {
-        FieldType fieldType = FieldType.valueOf(attributeTypeStr.toUpperCase());
-        return new Attribute(attributeNameStr, fieldType);
     }
 
     public static List<String> splitStringByComma(String str) {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherTestHelper.java
@@ -144,7 +144,7 @@ public class DictionaryMatcherTestHelper {
         DictionaryPredicate dictiaonryPredicate = new DictionaryPredicate(
                 dictionary, attributeNames, luceneAnalyzer, matchingType);
         DictionaryMatcherSourceOperator dictionarySource = new DictionaryMatcherSourceOperator(
-                dictiaonryPredicate, relationManager.getTableDataStore(tableName));
+                dictiaonryPredicate, tableName);
 
         dictionarySource.setLimit(limit);
         dictionarySource.setOffset(offset);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceHelper.java
@@ -117,11 +117,10 @@ public class JoinDistanceHelper {
      */
     public static KeywordMatcherSourceOperator getKeywordSource(String tableName, String query, 
             KeywordMatchingType matchingType) throws TextDBException {
-        DataStore tableDataStore = RelationManager.getRelationManager().getTableDataStore(tableName);
         KeywordPredicate keywordPredicate = new KeywordPredicate(query, 
                 Arrays.asList(JoinTestConstants.AUTHOR, JoinTestConstants.TITLE, JoinTestConstants.REVIEW),
                 RelationManager.getRelationManager().getTableAnalyzer(tableName), matchingType);
-        KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, tableDataStore);
+        KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(keywordPredicate, tableName);
         return keywordSource;
     }
     

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordTestHelper.java
@@ -124,7 +124,7 @@ public class KeywordTestHelper {
         KeywordPredicate keywordPredicate = new KeywordPredicate(
                 keywordQuery, attributeNames, relationManager.getTableAnalyzer(tableName), matchingType);
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
-                keywordPredicate, relationManager.getTableDataStore(tableName));
+                keywordPredicate, tableName);
         keywordSource.setLimit(limit);
         keywordSource.setOffset(offset);
         

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
@@ -4,12 +4,19 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISink;
 import edu.uci.ics.textdb.api.plan.Plan;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.dataflow.connector.OneToNBroadcastConnector;
 import edu.uci.ics.textdb.dataflow.connector.OneToNBroadcastConnector.ConnectorOutputOperator;
 import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;
@@ -25,10 +32,29 @@ import edu.uci.ics.textdb.plangen.operatorbuilder.KeywordMatcherBuilder;
 import edu.uci.ics.textdb.plangen.operatorbuilder.NlpExtractorBuilder;
 import edu.uci.ics.textdb.plangen.operatorbuilder.OperatorBuilderUtils;
 import edu.uci.ics.textdb.plangen.operatorbuilder.RegexMatcherBuilder;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
 import junit.framework.Assert;
 
 public class LogicalPlanTest {
-
+    
+    public static final String TEST_TABLE = "logical_plan_test_table";
+    
+    public static final Schema TEST_SCHEMA = new Schema(
+            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
+            new Attribute("content", FieldType.TEXT));
+    
+    @BeforeClass
+    public static void setUp() throws StorageException {
+        RelationManager.getRelationManager().createTable(
+                TEST_TABLE, "../index/test_tables/"+TEST_TABLE,
+                TEST_SCHEMA, LuceneAnalyzerConstants.standardAnalyzerString());
+    }
+    
+    @AfterClass
+    public static void cleanUp() throws StorageException {
+        RelationManager.getRelationManager().deleteTable(TEST_TABLE);
+    }
+    
     public static HashMap<String, String> keywordSourceProperties = new HashMap<String, String>() {
         {
             JSONObject schemaJsonJSONObject = new JSONObject();
@@ -39,8 +65,7 @@ public class LogicalPlanTest {
             put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
             put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
             put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
-            put(OperatorBuilderUtils.DATA_DIRECTORY, "./index");
-            put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
+            put(OperatorBuilderUtils.DATA_SOURCE, TEST_TABLE);
         }
     };
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
@@ -21,7 +21,7 @@ import junit.framework.Assert;
 
 public class DictionarySourceBuilderTest {
     
-    public static final String TEST_TABLE = "dict_source_buidler_test_table";
+    public static final String TEST_TABLE = "dictionary_source_buidler_test_table";
     
     public static final Schema TEST_SCHEMA = new Schema(
             new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
@@ -4,32 +4,44 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.dataflow.dictionarymatcher.DictionaryMatcherSourceOperator;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
 import junit.framework.Assert;
 
 public class DictionarySourceBuilderTest {
     
+    public static final String TEST_TABLE = "dict_source_buidler_test_table";
+    
+    public static final Schema TEST_SCHEMA = new Schema(
+            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
+            new Attribute("content", FieldType.TEXT));
+    
+    @BeforeClass
+    public static void setUp() throws StorageException {
+        RelationManager.getRelationManager().createTable(
+                TEST_TABLE, "../index/test_tables/"+TEST_TABLE,
+                TEST_SCHEMA, LuceneAnalyzerConstants.standardAnalyzerString());
+    }
+    
+    @AfterClass
+    public static void cleanUp() throws StorageException {
+        RelationManager.getRelationManager().deleteTable(TEST_TABLE);
+    }
+    
     @Test
     public void testDictionarySourceBuilder1() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonObject = new JSONObject();
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
-                
-        List<Attribute> schemaAttrs = Arrays.asList(
-                new Attribute("id", FieldType.INTEGER),
-                new Attribute("city", FieldType.STRING),
-                new Attribute("location", FieldType.STRING),
-                new Attribute("content", FieldType.TEXT));
-        
+
         String dictionaryStr = "Irvine, Anaheim, Costa Mesa, Santa Ana";
         List<String> dictionaryList = Arrays.asList(
                 "Irvine",
@@ -43,11 +55,9 @@ public class DictionarySourceBuilderTest {
         operatorProperties.put(DictionaryMatcherBuilder.DICTIONARY, dictionaryStr);
         operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonObject.toString());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, TEST_TABLE);
         
         DictionaryMatcherSourceOperator sourceOperator = DictionarySourceBuilder.buildSourceOperator(operatorProperties);
-
         
         String dictionaryEntry = null;
         ArrayList<String> actualDictionary = new ArrayList<>();
@@ -57,27 +67,18 @@ public class DictionarySourceBuilderTest {
         
         // compare dict
         Assert.assertEquals(dictionaryList, actualDictionary);
-        // compare dataStore directory
-        Assert.assertEquals(directoryStr, sourceOperator.getDataStore().getDataDirectory());
-        // compare dataStore schema
-        Assert.assertEquals(
-                schemaAttrs.stream().collect(Collectors.toList()).toString(), 
-                sourceOperator.getDataStore().getSchema().getAttributes().stream().collect(Collectors.toList()).toString());
+        // compare table name
+        Assert.assertEquals(TEST_TABLE, sourceOperator.getTableName());
         // compare dictMatcher attribute list
         Assert.assertEquals(dictAttrNames, sourceOperator.getPredicate().getAttributeNames());
 
     }
     
     /*
-     * Test invalid DictionaryMatcherSourceOperator with an invalid attribute type
+     * Test invalid DictionaryMatcherSourceOperator with an empty data source (table name)
      */
     @Test(expected = PlanGenException.class)
-    public void testInvalidBuilder1() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonObject = new JSONObject();
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "random_type, string, type-that-doesnt-exist, text");
-         
+    public void testInvalidBuilder1() throws Exception {       
         String dictionaryStr = "Irvine, Anaheim, Costa Mesa, Santa Ana";
    
         HashMap<String, String> operatorProperties = new HashMap<>();
@@ -85,21 +86,16 @@ public class DictionarySourceBuilderTest {
         operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonObject.toString());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, "");
         
         DictionarySourceBuilder.buildSourceOperator(operatorProperties);
     }
     
     /*
-     * Test invalid DictionaryMatcherSourceOperator with inconsistent attribute names and types
+     * Test invalid DictionaryMatcherSourceOperator without the data source attribute
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidBuilder2() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonObject = new JSONObject();
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
          
         String dictionaryStr = "Irvine, Anaheim, Costa Mesa, Santa Ana";
    
@@ -108,54 +104,6 @@ public class DictionarySourceBuilderTest {
         operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonObject.toString());
-        
-        DictionarySourceBuilder.buildSourceOperator(operatorProperties);
-    }
-    
-    /*
-     * Test invalid DictionaryMatcherSourceOperator with an empty directory
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidBuilder3() throws Exception {
-        String directoryStr = "";
-        JSONObject schemaJsonObject = new JSONObject();
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
-         
-        String dictionaryStr = "Irvine, Anaheim, Costa Mesa, Santa Ana";
-   
-        HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(DictionaryMatcherBuilder.DICTIONARY, dictionaryStr);
-        operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonObject.toString());
-        
-        DictionarySourceBuilder.buildSourceOperator(operatorProperties);
-    }
-    
-    /*
-     * Test invalid DictionaryMatcherSourceOperator with an empty directory
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidBuilder4() throws Exception {
-        String directoryStr = "      ";
-        JSONObject schemaJsonObject = new JSONObject();
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
-         
-        String dictionaryStr = "Irvine, Anaheim, Costa Mesa, Santa Ana";
-   
-        HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(DictionaryMatcherBuilder.DICTIONARY, dictionaryStr);
-        operatorProperties.put(DictionaryMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "STRING, STRING, TEXT");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonObject.toString());
         
         DictionarySourceBuilder.buildSourceOperator(operatorProperties);
     }

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
@@ -2,148 +2,92 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
-import edu.uci.ics.textdb.common.utils.Utils;
+import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
 import junit.framework.Assert;
 
 public class KeywordSourceBuilderTest {
     
+    public static final String TEST_TABLE = "keyword_source_buidler_test_table";
+    
+    public static final Schema TEST_SCHEMA = new Schema(
+            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
+            new Attribute("content", FieldType.TEXT));
+    
+    @BeforeClass
+    public static void setUp() throws StorageException {
+        RelationManager.getRelationManager().createTable(
+                TEST_TABLE, "../index/test_tables/"+TEST_TABLE,
+                TEST_SCHEMA, LuceneAnalyzerConstants.standardAnalyzerString());
+    }
+    
+    @AfterClass
+    public static void cleanUp() throws StorageException {
+        RelationManager.getRelationManager().deleteTable(TEST_TABLE);
+    }
+    
     @Test
-    public void testKeywordSourceBuilder1() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonJSONObject = new JSONObject();
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, string, text");
-                
-        List<Attribute> schemaAttrs = Arrays.asList(
-                new Attribute("id", FieldType.INTEGER),
-                new Attribute("city", FieldType.STRING),
-                new Attribute("location", FieldType.STRING),
-                new Attribute("content", FieldType.TEXT));
-        
+    public void testKeywordSourceBuilder1() throws Exception {        
         String keyword = "Irvine";
-        List<Attribute> keywordAttributes = schemaAttrs.stream()
-                .filter(attr -> ! attr.getFieldName().equals("id")).collect(Collectors.toList());
-
         
         HashMap<String, String> operatorProperties = new HashMap<>();
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, keyword);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, TEST_TABLE);
         
         KeywordMatcherSourceOperator sourceOperator = KeywordSourceBuilder.buildSourceOperator(operatorProperties);
 
         
         // compare the keyword
         Assert.assertEquals(keyword, sourceOperator.getPredicate().getQuery());
-        // compare the dataStore directory
-        Assert.assertEquals(directoryStr, sourceOperator.getDataStore().getDataDirectory());
-        // compare the dataStore schema
-        Assert.assertEquals(
-                schemaAttrs.stream().collect(Collectors.toList()).toString(), 
-                sourceOperator.getDataStore().getSchema().getAttributes().stream().collect(Collectors.toList()).toString());
+        // compare the data source (table name)
+        Assert.assertEquals(TEST_TABLE, sourceOperator.getTableName());
         // compare the keyword matcher attribute list
         Assert.assertEquals(
-                Utils.getAttributeNames(keywordAttributes).toString(),
-                sourceOperator.getPredicate().getAttributeNames().toString());
+                Arrays.asList("city", "location", "content"),
+                sourceOperator.getPredicate().getAttributeNames());
 
     }
     
     /*
-     * Test invalid KeywordMatcherSourceOperator with an invalid attribute type
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidBuilder1() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonJSONObject = new JSONObject();
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "random_type, string, type-that-doesnt-exist, text");
-         
-        String KeywordStr = "Irvine";
-   
-        HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
-        operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
-        
-        KeywordSourceBuilder.buildSourceOperator(operatorProperties);
-    }
-    
-    /*
-     * Test invalid KeywordMatcherSourceOperator with inconsistent attribute names and types
-     */
-    @Test(expected = PlanGenException.class)
-    public void testInvalidBuilder2() throws Exception {
-        String directoryStr = "./index";
-        JSONObject schemaJsonJSONObject = new JSONObject();
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
-         
-        String KeywordStr = "Irvine";
-   
-        HashMap<String, String> operatorProperties = new HashMap<>();
-        operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
-        operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
-        operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
-        
-        KeywordSourceBuilder.buildSourceOperator(operatorProperties);
-    }
-    
-    /*
-     * Test invalid KeywordMatcherSourceOperator with an empty directory
+     * Test invalid KeywordMatcherSourceOperator with an empty data source
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidBuilder3() throws Exception {
-        String directoryStr = "";
-        JSONObject schemaJsonJSONObject = new JSONObject();
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
-         
         String KeywordStr = "Irvine";
    
         HashMap<String, String> operatorProperties = new HashMap<>();
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, "  ");
         
         KeywordSourceBuilder.buildSourceOperator(operatorProperties);
     }
     
     /*
-     * Test invalid KeywordMatcherSourceOperator with an empty directory with only spaces
+     * Test invalid KeywordMatcherSourceOperator without a data source attribute
      */
     @Test(expected = PlanGenException.class)
     public void testInvalidBuilder4() throws Exception {
-        String directoryStr = "      ";
-        JSONObject schemaJsonJSONObject = new JSONObject();
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "id, city, location, content");
-        schemaJsonJSONObject.put(OperatorBuilderUtils.ATTRIBUTE_TYPES, "integer, string, text");
-         
         String KeywordStr = "Irvine";
    
         HashMap<String, String> operatorProperties = new HashMap<>();
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, KeywordStr);
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, "PHRASE_INDEXBASED");
         operatorProperties.put(OperatorBuilderUtils.ATTRIBUTE_NAMES, "city, location, content");
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, directoryStr);
-        operatorProperties.put(OperatorBuilderUtils.SCHEMA, schemaJsonJSONObject.toString());
         
         KeywordSourceBuilder.buildSourceOperator(operatorProperties);
     }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -125,7 +125,7 @@ public class DictionaryMatcherPerformanceTest {
         DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributeNames, luceneAnalyzer,
                 opType);
         DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate,
-                RelationManager.getRelationManager().getTableDataStore(tableName));
+                tableName);
 
         long startMatchTime = System.currentTimeMillis();
         dictionaryMatcher.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -144,7 +144,7 @@ public class KeywordMatcherPerformanceTest {
                     opType);
 
             KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
-                    keywordPredicate, RelationManager.getRelationManager().getTableDataStore(tableName));
+                    keywordPredicate, tableName);
 
             long startMatchTime = System.currentTimeMillis();
             keywordSource.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -119,7 +119,7 @@ public class SampleExtraction {
                 new StandardAnalyzer(), KeywordMatchingType.CONJUNCTION_INDEXBASED);
         
         KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
-                keywordPredicateZika, RelationManager.getRelationManager().getTableDataStore(PROMED_SAMPLE_TABLE));
+                keywordPredicateZika, PROMED_SAMPLE_TABLE);
         
         ProjectionPredicate projectionPredicateIdAndContent = new ProjectionPredicate(
                 Arrays.asList(PromedSchema.ID, PromedSchema.CONTENT));

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/planbuilder/beans/ScanSourceBean.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/planbuilder/beans/ScanSourceBean.java
@@ -55,7 +55,7 @@ public class ScanSourceBean extends OperatorBean {
         HashMap<String, String> operatorProperties = super.getOperatorProperties();
         if(this.getDataSource() == null || operatorProperties == null)
             return null;
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, this.getDataSource());
         return operatorProperties;
     }
 

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionarySourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/DictionarySourceBean.java
@@ -72,7 +72,7 @@ public class DictionarySourceBean extends OperatorBean {
             return null;
         operatorProperties.put(DictionarySourceBuilder.DICTIONARY, this.getDictionary());
         operatorProperties.put(DictionarySourceBuilder.MATCHING_TYPE, this.getMatchingType());
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, this.getDataSource());
         return operatorProperties;
     }
 

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/FuzzyTokenSourceBean.java
@@ -71,7 +71,7 @@ public class FuzzyTokenSourceBean extends OperatorBean {
             return null;
         operatorProperties.put(FuzzyTokenMatcherBuilder.FUZZY_STRING, this.getQuery());
         operatorProperties.put(FuzzyTokenMatcherBuilder.THRESHOLD_RATIO, this.getThresholdRatio());
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, this.getDataSource());
         return operatorProperties;
     }
 

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/KeywordSourceBean.java
@@ -72,7 +72,7 @@ public class KeywordSourceBean extends OperatorBean {
             return null;
         operatorProperties.put(KeywordMatcherBuilder.KEYWORD, this.getKeyword());
         operatorProperties.put(KeywordMatcherBuilder.MATCHING_TYPE, this.getMatchingType());
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, this.getDataSource());
         return operatorProperties;
     }
 

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/beans/RegexSourceBean.java
@@ -57,7 +57,7 @@ public class RegexSourceBean extends OperatorBean {
         if(this.getRegex() == null || this.getDataSource() == null || operatorProperties == null)
             return null;
         operatorProperties.put(RegexMatcherBuilder.REGEX, this.getRegex());
-        operatorProperties.put(OperatorBuilderUtils.DATA_DIRECTORY, this.getDataSource());
+        operatorProperties.put(OperatorBuilderUtils.DATA_SOURCE, this.getDataSource());
         return operatorProperties;
     }
 


### PR DESCRIPTION
This PR modifies KeywordMatcherSourceOperator and DictionaryMatcherSourceOperator to use `tableName` as a parameter instead of `dataStore`. The two source operators will then use the RelationManager to get the `dataStore`. This PR is part of the plan stated in Issue #320 .

Because the parameters of KeywordSource and DictionarySource are modified, this PR also modifies the operator builders for these two operators. Now they are changed to following the [API specification](https://github.com/TextDB/textdb/wiki/Operator-property-specification) .