### PR TITLE
Use TupleStreamSink to sent results back to front-end in a proper format

### DIFF
--- a/textdb/textdb-common/pom.xml
+++ b/textdb/textdb-common/pom.xml
@@ -34,6 +34,11 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
             <version>${lucene.version}</version>
-        </dependency>      
+        </dependency>    
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${org.json.version}</version>
+        </dependency>  
     </dependencies>
 </project>

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -287,6 +287,80 @@ public class Utils {
 
         return result;
     }
+    
+    
+    public static String getTupleListJSON(List<ITuple> tupleList) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (ITuple tuple : tupleList) {
+            sb.append(getTupleJSON(tuple));
+            sb.append(",");
+        }
+        // remove the last comma
+        if (! tupleList.isEmpty()) {
+            sb.setLength(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+    
+    public static String getTupleJSON(ITuple tuple) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        Schema schema  = tuple.getSchema();
+        for (String attrName : schema.getAttributeNames()) {
+            if (attrName.equals(SchemaConstants.SPAN_LIST)) {
+                sb.append("\"");
+                sb.append(attrName);
+                sb.append("\"");
+                sb.append(":");
+                sb.append(getSpanListJSON(((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue()));
+            } else {
+                sb.append("\"");
+                sb.append(attrName);
+                sb.append("\"");
+                sb.append(":");
+                sb.append("\"");
+                sb.append(tuple.getField(attrName).toString());
+                sb.append("\"");
+            }
+            sb.append(",");
+        }
+        if (! schema.getAttributes().isEmpty()) {
+            sb.setLength(sb.length() - 1);
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+    
+    public static String getSpanListJSON(List<Span> spanList) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (Span span : spanList) {
+            sb.append("\"");
+            sb.append(span);
+            sb.append("\"");
+        }
+        if (! spanList.isEmpty()) {
+            sb.setLength(sb.length() - 1);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+    
+    public static String getSpanJSON(Span span) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        
+        sb.append("\"field\": " + "\"" + span.getFieldName()  + "\"" + ",");
+        sb.append("\"start\": " + "\"" + span.getStart() + "\"" + ",");
+        sb.append("\"end\":   " + "\"" + span.getEnd() + "\"" + ",");
+        sb.append("\"key\":   " + "\"" + span.getKey() + "\"" + ",");
+        sb.append("\"value\": " + "\"" + span.getValue() + "\"" + ",");
+        sb.append("\"token offset\": " + "\"" + span.getTokenOffset());
+        
+        sb.append("}");
+        return sb.toString();
+    }
 
     public static String getTupleListString(List<ITuple> tupleList) {
         StringBuilder sb = new StringBuilder();

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -26,6 +26,10 @@ import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONStringer;
+import org.json.JSONWriter;
 
 import edu.uci.ics.textdb.api.common.Attribute;
 import edu.uci.ics.textdb.api.common.FieldType;
@@ -289,77 +293,52 @@ public class Utils {
     }
     
     
-    public static String getTupleListJSON(List<ITuple> tupleList) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
+    public static JSONArray getTupleListJSON(List<ITuple> tupleList) {
+        JSONArray jsonArray = new JSONArray();
+        
         for (ITuple tuple : tupleList) {
-            sb.append(getTupleJSON(tuple));
-            sb.append(",");
+            jsonArray.put(getTupleJSON(tuple));
         }
-        // remove the last comma
-        if (! tupleList.isEmpty()) {
-            sb.setLength(sb.length() - 1);
-        }
-        return sb.toString();
+        
+        return jsonArray;
     }
     
-    public static String getTupleJSON(ITuple tuple) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{");
-        Schema schema  = tuple.getSchema();
-        for (String attrName : schema.getAttributeNames()) {
-            if (attrName.equals(SchemaConstants.SPAN_LIST)) {
-                sb.append("\"");
-                sb.append(attrName);
-                sb.append("\"");
-                sb.append(":");
-                sb.append(getSpanListJSON(((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue()));
+    public static JSONObject getTupleJSON(ITuple tuple) {
+        JSONObject jsonObject = new JSONObject();
+        
+        for (String attrName : tuple.getSchema().getAttributeNames()) {
+            if (attrName.equalsIgnoreCase(SchemaConstants.SPAN_LIST)) {
+                List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+                jsonObject.put(attrName, getSpanListJSON(spanList));
             } else {
-                sb.append("\"");
-                sb.append(attrName);
-                sb.append("\"");
-                sb.append(":");
-                sb.append("\"");
-                sb.append(tuple.getField(attrName).toString());
-                sb.append("\"");
+                jsonObject.put(attrName, tuple.getField(attrName).getValue().toString());
             }
-            sb.append(",");
         }
-        if (! schema.getAttributes().isEmpty()) {
-            sb.setLength(sb.length() - 1);
-        }
-        sb.append("}");
-        return sb.toString();
+        
+        return jsonObject;
     }
     
-    public static String getSpanListJSON(List<Span> spanList) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
+    public static JSONArray getSpanListJSON(List<Span> spanList) {
+        JSONArray jsonArray = new JSONArray();
+        
         for (Span span : spanList) {
-            sb.append("\"");
-            sb.append(span);
-            sb.append("\"");
+            jsonArray.put(getSpanJSON(span));
         }
-        if (! spanList.isEmpty()) {
-            sb.setLength(sb.length() - 1);
-        }
-        sb.append("]");
-        return sb.toString();
+        
+        return jsonArray;
     }
     
-    public static String getSpanJSON(Span span) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{");
+    public static JSONObject getSpanJSON(Span span) {
+        JSONObject jsonObject = new JSONObject();
         
-        sb.append("\"field\": " + "\"" + span.getFieldName()  + "\"" + ",");
-        sb.append("\"start\": " + "\"" + span.getStart() + "\"" + ",");
-        sb.append("\"end\":   " + "\"" + span.getEnd() + "\"" + ",");
-        sb.append("\"key\":   " + "\"" + span.getKey() + "\"" + ",");
-        sb.append("\"value\": " + "\"" + span.getValue() + "\"" + ",");
-        sb.append("\"token offset\": " + "\"" + span.getTokenOffset());
-        
-        sb.append("}");
-        return sb.toString();
+        jsonObject.put("key", span.getKey());
+        jsonObject.put("value", span.getValue());
+        jsonObject.put("field", span.getFieldName());
+        jsonObject.put("start", span.getStart());
+        jsonObject.put("end", span.getEnd());
+        jsonObject.put("token offset", span.getTokenOffset());
+
+        return jsonObject;
     }
 
     public static String getTupleListString(List<ITuple> tupleList) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/OperatorArityConstants.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/OperatorArityConstants.java
@@ -30,6 +30,7 @@ public class OperatorArityConstants {
         put("IndexSink".toLowerCase(), 1);
         put("TupleStreamSink".toLowerCase(), 1);
       
+        put("Projection".toLowerCase(), 1);
         put("Join".toLowerCase(), 2);
     }};
     
@@ -50,6 +51,7 @@ public class OperatorArityConstants {
         put("KeywordSource".toLowerCase(), 1);
         put("DictionarySource".toLowerCase(), 1);
         
+        put("Projection".toLowerCase(), 1);
         put("Join".toLowerCase(), 1);  
     }};
     

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilder.java
@@ -60,6 +60,16 @@ public class KeywordSourceBuilder {
         } catch (DataFlowException | StorageException e) {
             throw new PlanGenException(e.getMessage(), e);
         }
+        
+        // set limit and offset
+        Integer limitInt = OperatorBuilderUtils.findLimit(operatorProperties);
+        if (limitInt != null) {
+            sourceOperator.setLimit(limitInt);
+        }
+        Integer offsetInt = OperatorBuilderUtils.findOffset(operatorProperties);
+        if (offsetInt != null) {
+            sourceOperator.setOffset(offsetInt);
+        }
    
         return sourceOperator;
     }

--- a/textdb/textdb-gui/js/onstart.js
+++ b/textdb/textdb-gui/js/onstart.js
@@ -323,8 +323,10 @@ var setup = function(){
 			contentType: "application/json",
 			success: function(returnedData){
 				console.log("SUCCESS\n");
-				console.log(JSON.stringify(returnedData));
-				createResultFrame(returnedData);
+
+				console.log(returnedData);
+
+				createResultFrame(JSON.parse(returnedData));
 			},
 			error: function(xhr, status, err){
 				console.log(JSON.stringify(xhr));

--- a/textdb/textdb-gui/js/onstart.js
+++ b/textdb/textdb-gui/js/onstart.js
@@ -31,19 +31,21 @@ var setup = function(){
 	var DEFAULT_DISTANCE = 10;
 	var DEFAULT_ATTRIBUTES = "first name, last name";
 	var DEFAULT_LIMIT = 10;
-	var DEFAULT_OFFSET = 5;
+	var DEFAULT_OFFSET = 0;
 	
 	/*
 		Helper Functions
 	*/
 	//Helper Function for Process Queries that displays the results after hitting "Process Query"
 	function createResultFrame(message){
+		var resultJSON = JSON.parse(message['text']);
+
 		var resultFrame = $('<div class="result-frame"><div class="result-box"><div class="result-box-band">Return Result<div class="result-frame-close"><img src="img/close-icon.png"></div></div><div class="return-result"></div></div></div>');
 		$('body').append(resultFrame);
 		
 		var node = new PrettyJSON.view.Node({
 			el:$('.return-result'),
-			data:message
+			data:resultJSON
 		});
 	}
 	
@@ -312,6 +314,8 @@ var setup = function(){
 		}
 		TEXTDBJSON.operators = operators;
 		TEXTDBJSON.links = links;
+
+		console.log(TEXTDBJSON);
 		
 		$.ajax({
 			url: "http://localhost:8080/queryplan/execute",
@@ -321,8 +325,6 @@ var setup = function(){
 			contentType: "application/json",
 			success: function(returnedData){
 				console.log("SUCCESS\n");
-
-				console.log(returnedData);
 
 				createResultFrame(JSON.parse(returnedData));
 			},

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -38,7 +38,7 @@ import edu.uci.ics.textdb.storage.relation.RelationManager;
 
 public class SampleExtraction {
     
-    public static final String PROMED_SAMPLE_TABLE = "sample_extraction_promed";
+    public static final String PROMED_SAMPLE_TABLE = "sample";
         
     public static final String promedFilesDirectory = "./sample-data-files/promed/";
     public static final String promedIndexDirectory = "./index/standard/promed/"; 
@@ -51,7 +51,7 @@ public class SampleExtraction {
         writeSampleIndex();
         
         // perform the extraction task
-        extractPersonLocation();
+//        extractPersonLocation();
     }
     
     public static ITuple parsePromedHTML(String fileName, String content) {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -38,7 +38,7 @@ import edu.uci.ics.textdb.storage.relation.RelationManager;
 
 public class SampleExtraction {
     
-    public static final String PROMED_SAMPLE_TABLE = "sample";
+    public static final String PROMED_SAMPLE_TABLE = "sample_extraction_promed";
         
     public static final String promedFilesDirectory = "./sample-data-files/promed/";
     public static final String promedIndexDirectory = "./index/standard/promed/"; 
@@ -51,7 +51,7 @@ public class SampleExtraction {
         writeSampleIndex();
         
         // perform the extraction task
-//        extractPersonLocation();
+        extractPersonLocation();
     }
     
     public static ITuple parsePromedHTML(String fileName, String content) {

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
@@ -53,7 +53,7 @@ public class QueryPlanResource {
                 List<ITuple> results = sink.collectAllTuples();
                 sink.close();
                 
-                SampleResponse sampleResponse = new SampleResponse(0, Utils.getTupleListString(results));
+                SampleResponse sampleResponse = new SampleResponse(0, Utils.getTupleListJSON(results));
                 return Response.status(200)
                         .entity(objectMapper.writeValueAsString(sampleResponse))
                         .header("Access-Control-Allow-Origin", "*")

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
@@ -48,7 +48,10 @@ public class QueryPlanResource {
             Plan plan = queryPlanRequest.getLogicalPlan().buildQueryPlan();
             if (plan.getRoot() instanceof TupleStreamSink) {
                 TupleStreamSink sink = (TupleStreamSink) plan.getRoot();
+                
+                sink.open();
                 List<ITuple> results = sink.collectAllTuples();
+                sink.close();
                 
                 SampleResponse sampleResponse = new SampleResponse(0, Utils.getTupleListString(results));
                 return Response.status(200)

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
@@ -60,7 +60,7 @@ public class QueryPlanResource {
                 List<ITuple> results = sink.collectAllTuples();
                 sink.close();
                 
-                SampleResponse sampleResponse = new SampleResponse(0, Utils.getTupleListJSON(results));
+                SampleResponse sampleResponse = new SampleResponse(0, Utils.getTupleListJSON(results).toString());
                 return Response.status(200)
                         .entity(objectMapper.writeValueAsString(sampleResponse))
                         .build();

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/QueryPlanResource.java
@@ -1,8 +1,16 @@
 package edu.uci.ics.textdb.web.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.uci.ics.textdb.api.common.ITuple;
+import edu.uci.ics.textdb.api.plan.Plan;
+import edu.uci.ics.textdb.common.utils.Utils;
+import edu.uci.ics.textdb.dataflow.sink.TupleStreamSink;
+import edu.uci.ics.textdb.engine.Engine;
 import edu.uci.ics.textdb.web.request.QueryPlanRequest;
 import edu.uci.ics.textdb.web.response.SampleResponse;
+
+import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
@@ -1,12 +1,17 @@
 package edu.uci.ics.textdb.web.resource;
 
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
 import edu.uci.ics.textdb.web.TextdbWebApplication;
 import edu.uci.ics.textdb.web.TextdbWebConfiguration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.message.internal.MediaTypes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -28,21 +33,20 @@ public class QueryPlanResourceTest {
     public static final String queryPlanRequestString = "{\n" +
             "    \"operators\": [{\n" +
             "        \"operator_id\": \"operator1\",\n" +
-            "        \"operator_type\": \"DictionaryMatcher\",\n" +
+            "        \"operator_type\": \"DictionarySource\",\n" +
             "        \"attributes\": \"attributes\",\n" +
             "        \"limit\": \"10\",\n" +
             "        \"offset\": \"100\",\n" +
+            "        \"data_source\": \"query_plan_resource_test_table\",\n" +
             "        \"dictionary\": \"dict1\",\n" +
             "        \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
             "    }, {\n" +
             "\n" +
             "        \"operator_id\": \"operator2\",\n" +
-            "        \"operator_type\": \"DictionaryMatcher\",\n" +
+            "        \"operator_type\": \"TupleStreamSink\",\n" +
             "        \"attributes\": \"attributes\",\n" +
             "        \"limit\": \"10\",\n" +
-            "        \"offset\": \"100\",\n" +
-            "        \"dictionary\": \"dict2\",\n" +
-            "        \"matching_type\": \"PHRASE_INDEXBASED\"\n" +
+            "        \"offset\": \"100\"\n" +
             "    }],\n" +
             "    \"links\": [{\n" +
             "        \"from\": \"operator1\",\n" +
@@ -72,6 +76,19 @@ public class QueryPlanResourceTest {
             "        \"to\": \"operator2\"    \n" +
             "    }]\n" +
             "}";
+    
+    public static final String TEST_TABLE = "query_plan_resource_test_table";
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        RelationManager.getRelationManager().createTable(TEST_TABLE, "../index/" + TEST_TABLE,
+                new Schema(new Attribute("attributes", FieldType.TEXT)), "standard");
+    }
+    
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        RelationManager.getRelationManager().deleteTable(TEST_TABLE);
+    }
 
     /**
      * Tests the query plan execution endpoint.


### PR DESCRIPTION
This PR uses the TupleStreamSink introduced in PR #361 to send the results back to front-end. 

The result tuples are converted to JSON format strings in the textdb-web layer and the front-end then properly displays it.