### PR TITLE
[Issue #289] TextQL - Rename getOperatorBean to generateOperatorBean

### DIFF
--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/SelectExtractStatement.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/SelectExtractStatement.java
@@ -196,13 +196,13 @@ public class SelectExtractStatement extends Statement {
         if(this.selectPredicate==null){
             operators.add(new PassThroughBean(getSelectionNodeID(), "PassThrough"));
         }else{
-            operators.add(this.selectPredicate.getOperatorBean(getSelectionNodeID()));
+            operators.add(this.selectPredicate.generateOperatorBean(getSelectionNodeID()));
         }
         // Build and append bean for Extraction predicate
         if(this.extractPredicate==null){
             operators.add(new PassThroughBean(getExtractionNodeID(), "PassThrough"));
         }else{
-            operators.add(this.extractPredicate.getOperatorBean(getExtractionNodeID()));
+            operators.add(this.extractPredicate.generateOperatorBean(getExtractionNodeID()));
         }
         // Build and append bean for the Source
         operators.add(new PassThroughBean(getInputNodeID(), "PassThrough"));

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/ExtractPredicate.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/ExtractPredicate.java
@@ -18,6 +18,6 @@ public interface ExtractPredicate {
      * @param extractionOperatorId The ID of the OperatorBean to be created.
      * @return The bean operator representation of this { @code ExtractPredicate }.
      */
-    public OperatorBean getOperatorBean(String extractionOperatorId);
+    public OperatorBean generateOperatorBean(String extractionOperatorId);
     
 }

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/KeywordExtractPredicate.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/KeywordExtractPredicate.java
@@ -106,7 +106,7 @@ public class KeywordExtractPredicate implements ExtractPredicate {
      * @return this operator converted to a KeywordMatcherBean.
      */
     @Override
-    public KeywordMatcherBean getOperatorBean(String extractionOperatorId) {
+    public KeywordMatcherBean generateOperatorBean(String extractionOperatorId) {
         String matchingFieldsAsString = String.join(",", this.matchingFields);
         return new KeywordMatcherBean(extractionOperatorId, "KeywordMatcher", matchingFieldsAsString,
                     null, null, this.keywords, this.matchingType);

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectAllFieldsPredicate.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectAllFieldsPredicate.java
@@ -15,7 +15,7 @@ public class SelectAllFieldsPredicate implements SelectPredicate {
      * Return this operator converted to an { @code OperatorBean }.
      * @param selectOperatorId The ID of the OperatorBean to be created.
      */
-    public OperatorBean getOperatorBean(String selectOperatorId) {
+    public OperatorBean generateOperatorBean(String selectOperatorId) {
         return new PassThroughBean(selectOperatorId, "PassThrough");
     }
     

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectPredicate.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectPredicate.java
@@ -17,6 +17,6 @@ public interface SelectPredicate {
      * Return this operator converted to an { @code OperatorBean }.
      * @param selectOperatorId The ID of the OperatorBean to be created.
      */
-    public OperatorBean getOperatorBean(String selectOperatorId);
+    public OperatorBean generateOperatorBean(String selectOperatorId);
     
 }

--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectSomeFieldsPredicate.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/statements/predicates/SelectSomeFieldsPredicate.java
@@ -51,7 +51,7 @@ public class SelectSomeFieldsPredicate implements SelectPredicate {
      * Return this operator converted to an { @code OperatorBean }.
      * @param selectOperatorId The ID of the OperatorBean to be created.
      */
-    public OperatorBean getOperatorBean(String selectOperatorId) {
+    public OperatorBean generateOperatorBean(String selectOperatorId) {
         ProjectionBean projectionBean = new ProjectionBean();
         projectionBean.setOperatorID(selectOperatorId);
         projectionBean.setOperatorType("Projection");

--- a/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/KeywordExtractPredicateTest.java
+++ b/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/KeywordExtractPredicateTest.java
@@ -13,7 +13,7 @@ import edu.uci.ics.textdb.web.request.beans.OperatorBean;
 
 /**
  * This class contains test cases for the KeywordExtractPredicate class.
- * The constructor, getters, setters and the getOperatorBean methods are
+ * The constructor, getters, setters and the generateOperatorBean methods are
  * tested.
  * 
  * @author Flavio Bayer
@@ -97,20 +97,20 @@ public class KeywordExtractPredicateTest {
     }
 
     /**
-     * Test the getOperatorBean method.
-     * Build a KeywordExtractPredicate, invoke the getOperatorBean and
+     * Test the generateOperatorBean method.
+     * Build a KeywordExtractPredicate, invoke the generateOperatorBean and
      * check whether a KeywordMatcherBean with the right attributes is returned.
      * An empty list is used as the list of fields to perform the match.
      */
     @Test
-    public void testGetOperatorBean00() {
+    public void testGenerateOperatorBean00() {
         String operatorId = "xxx";
         List<String> matchingFields = Collections.emptyList();
         String keywords = "keyword";
         String matchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED.toString();
         KeywordExtractPredicate keywordExtractPredicate = new KeywordExtractPredicate(matchingFields, keywords, matchingType);
         
-        OperatorBean computedProjectionBean = keywordExtractPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = keywordExtractPredicate.generateOperatorBean(operatorId);
         String matchingFieldsAsString = String.join(",", matchingFields);
         OperatorBean expectedProjectionBean = new KeywordMatcherBean(operatorId, "KeywordMatcher", matchingFieldsAsString,
                             null, null, keywords, matchingType);
@@ -119,20 +119,20 @@ public class KeywordExtractPredicateTest {
     }
     
     /**
-     * Test the getOperatorBean method.
-     * Build a KeywordExtractPredicate, invoke the getOperatorBean and
+     * Test the generateOperatorBean method.
+     * Build a KeywordExtractPredicate, invoke the generateOperatorBean and
      * check whether a KeywordMatcherBean with the right attributes is returned.
      * A list with one field is used as the list of fields to perform the match.
      */
     @Test
-    public void testGetOperatorBean01() {
+    public void testGenerateOperatorBean01() {
         String operatorId = "operator";
         List<String> matchingFields = Arrays.asList("fieldOne");
         String keywords = "keyword(s)";
         String matchingType = KeywordMatchingType.PHRASE_INDEXBASED.toString();
         KeywordExtractPredicate keywordExtractPredicate = new KeywordExtractPredicate(matchingFields, keywords, matchingType);
         
-        OperatorBean computedProjectionBean = keywordExtractPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = keywordExtractPredicate.generateOperatorBean(operatorId);
         String matchingFieldsAsString = String.join(",", matchingFields);
         OperatorBean expectedProjectionBean = new KeywordMatcherBean(operatorId, "KeywordMatcher", matchingFieldsAsString,
                             null, null, keywords, matchingType);
@@ -141,20 +141,20 @@ public class KeywordExtractPredicateTest {
     }
     
     /**
-     * Test the getOperatorBean method.
-     * Build a KeywordExtractPredicate, invoke the getOperatorBean and
+     * Test the generateOperatorBean method.
+     * Build a KeywordExtractPredicate, invoke the generateOperatorBean and
      * check whether a KeywordMatcherBean with the right attributes is returned.
      * A list with some fields is used as the list of fields to perform the match.
      */
     @Test
-    public void testGetOperatorBean02() {
+    public void testGenerateOperatorBean02() {
         String operatorId = "keywordExtract00";
         List<String> matchingFields = Arrays.asList("field0", "field1");
         String keywords = "xxx";
         String matchingType = KeywordMatchingType.SUBSTRING_SCANBASED.toString();
         KeywordExtractPredicate keywordExtractPredicate = new KeywordExtractPredicate(matchingFields, keywords, matchingType);
         
-        OperatorBean computedProjectionBean = keywordExtractPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = keywordExtractPredicate.generateOperatorBean(operatorId);
         String matchingFieldsAsString = String.join(",", matchingFields);
         OperatorBean expectedProjectionBean = new KeywordMatcherBean(operatorId, "KeywordMatcher",
                             matchingFieldsAsString, null, null, keywords, matchingType);

--- a/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/SelectAllFieldsPredicateTest.java
+++ b/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/SelectAllFieldsPredicateTest.java
@@ -8,7 +8,7 @@ import edu.uci.ics.textdb.web.request.beans.OperatorBean;
 
 /**
  * This class contains test cases for the SelectAllFieldsPredicate class.
- * The getOperatorBean method is tested.
+ * The generateOperatorBean method is tested.
  * There are no constructors, getters nor setters to test. 
  * 
  * @author Flavio Bayer
@@ -17,22 +17,22 @@ import edu.uci.ics.textdb.web.request.beans.OperatorBean;
 public class SelectAllFieldsPredicateTest {
 
     /**
-     * Test the getOperatorBean method.
-     * Build a SelectAllFieldsPredicate, invoke the getOperatorBean and check
+     * Test the generateOperatorBean method.
+     * Build a SelectAllFieldsPredicate, invoke the generateOperatorBean and check
      * whether a PassThroughBean with the right attributes is returned.
      */
     @Test
-    public void testGetOperatorBean() {
+    public void testGenerateOperatorBean() {
         SelectAllFieldsPredicate selectAllFieldsPredicate = new SelectAllFieldsPredicate();
         OperatorBean projectionBean;
         String operatorId;
         
         operatorId = "xxx";
-        projectionBean = selectAllFieldsPredicate.getOperatorBean(operatorId);
+        projectionBean = selectAllFieldsPredicate.generateOperatorBean(operatorId);
         Assert.assertEquals(projectionBean, new PassThroughBean(operatorId, "PassThrough"));
 
         operatorId = "y0a9";
-        projectionBean = selectAllFieldsPredicate.getOperatorBean(operatorId);
+        projectionBean = selectAllFieldsPredicate.generateOperatorBean(operatorId);
         Assert.assertEquals(projectionBean, new PassThroughBean(operatorId, "PassThrough"));
     }
     

--- a/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/SelectSomeFieldsPredicateTest.java
+++ b/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/statements/predicates/SelectSomeFieldsPredicateTest.java
@@ -13,7 +13,7 @@ import edu.uci.ics.textdb.web.request.beans.ProjectionBean;
 
 /**
  * This class contains test cases for the SelectSomeFieldsPredicate class.
- * The constructor, getters, setters and the getOperatorBean methods are
+ * The constructor, getters, setters and the generateOperatorBean methods are
  * tested.
  * 
  * @author Flavio Bayer
@@ -66,54 +66,54 @@ public class SelectSomeFieldsPredicateTest {
     }
 
     /**
-     * Test the getOperatorBean method.
-     * Build a SelectSomeFieldsPredicate, invoke the getOperatorBean and check
+     * Test the generateOperatorBean method.
+     * Build a SelectSomeFieldsPredicate, invoke the generateOperatorBean and check
      * whether a ProjectionBean with the right attributes is returned.
      * An empty list is used as the list of projected fields.
      */
     @Test
-    public void testGetOperatorBean00() {
+    public void testGenerateOperatorBean00() {
         String operatorId = "xxx";
         List<String> projectedFields = Collections.emptyList();
         SelectSomeFieldsPredicate selectSomeFieldsPredicate = new SelectSomeFieldsPredicate(projectedFields);
         
-        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.generateOperatorBean(operatorId);
         OperatorBean expectedProjectionBean = new ProjectionBean(operatorId, "Projection", "", null, null);
         
         Assert.assertEquals(expectedProjectionBean, computedProjectionBean);
     }
     
     /**
-     * Test the getOperatorBean method.
-     * Build a SelectSomeFieldsPredicate, invoke the getOperatorBean and check
+     * Test the generateOperatorBean method.
+     * Build a SelectSomeFieldsPredicate, invoke the generateOperatorBean and check
      * whether a ProjectionBean with the right attributes is returned.
      * A list with some field names is used as the list of projected fields.
      */
     @Test
-    public void testGetOperatorBean01() {
+    public void testGenerateOperatorBean01() {
         String operatorId = "zwx";
         List<String> projectedFields = Arrays.asList("field0", "field1");
         SelectSomeFieldsPredicate selectSomeFieldsPredicate = new SelectSomeFieldsPredicate(projectedFields);
         
-        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.generateOperatorBean(operatorId);
         OperatorBean expectedProjectionBean = new ProjectionBean(operatorId, "Projection", "field0,field1", null, null);
 
         Assert.assertEquals(expectedProjectionBean, computedProjectionBean);        
     }
 
     /**
-     * Test the getOperatorBean method.
-     * Build a SelectSomeFieldsPredicate, invoke the getOperatorBean and check
+     * Test the generateOperatorBean method.
+     * Build a SelectSomeFieldsPredicate, invoke the generateOperatorBean and check
      * whether a ProjectionBean with the right attributes is returned.
      * A list with some unordered field names is used as the list of projected fields.
      */
     @Test
-    public void testGetOperatorBean02() {
+    public void testGenerateOperatorBean02() {
         String operatorId = "op00";
         List<String> projectedFields = Arrays.asList("c", "a", "b");
         SelectSomeFieldsPredicate selectSomeFieldsPredicate = new SelectSomeFieldsPredicate(projectedFields);
         
-        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.getOperatorBean(operatorId);
+        OperatorBean computedProjectionBean = selectSomeFieldsPredicate.generateOperatorBean(operatorId);
         OperatorBean expectedProjectionBean = new ProjectionBean(operatorId, "Projection", "c,a,b", null, null);
         
         Assert.assertEquals(expectedProjectionBean, computedProjectionBean);   


### PR DESCRIPTION
As discussed in the comments of PR #370 (https://github.com/TextDB/textdb/pull/370#issuecomment-276221383), the use of the name ´getOperatorBean´ is not intuitive because the function is not a getter.
All the implementations and references in comments to the ´getOperatorBean´ have been replaced with ´generateOutputBean´ in order to make clear that a new OperatorBean is being generated.