### PR TITLE
[Issue 289] TextQL - Implement Scope

### DIFF
--- a/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/scope/Scope.java
+++ b/textdb/textdb-textql/src/main/java/edu/uci/ics/textdb/textql/scope/Scope.java
@@ -1,0 +1,198 @@
+package edu.uci.ics.textdb.textql.scope;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.exception.StorageException;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
+import edu.uci.ics.textdb.textql.statements.Statement;
+
+/**
+ * Scope to be used by the TextQL Language Parser. The scope is capable of
+ * store declared schemas and statements (including its generated schemas).
+ * A RelationManager can be used as an alternative persistent source of Schemas.
+ * 
+ * @author Flavio Bayer
+ *
+ */
+public class Scope {
+
+    /**
+     * The Relation Manager used to fetch table schemas.
+     */
+    private final RelationManager relationManager;
+
+    /**
+     * Collection for all declared schemas in the Scope. The key of the map is
+     * the name of the schema and the value is the schema itself. 
+     */
+    private final LinkedHashMap<String, Schema> schemasByName;
+
+    /**
+     * Collection for declared statements. The key of the map is the id of the
+     * statement (that is, the value returned by the getId method of the
+     * Statement) and the value is the statement itself. 
+     */
+    private final LinkedHashMap<String, Statement> statementById;
+
+    /**
+     * Initialize the scope without the use of a RelationManager.
+     */
+    public Scope() {
+        this(null);
+    }
+
+    /**
+     * Initialize the Scope with the given RelationManager.
+     * 
+     * @param relationManager
+     *            The RelationManager to be used in the scope.
+     */
+    public Scope(RelationManager relationManager) {
+        this.relationManager = relationManager;
+        this.statementById = new LinkedHashMap<>();
+        this.schemasByName = new LinkedHashMap<>();
+    }
+
+    /**
+     * Return the RelationManager being used by the Scope.
+     * 
+     * @return The RelationManager currently being used.
+     */
+    public RelationManager getRealationManager() {
+        return relationManager;
+    }
+
+    /**
+     * Add a Schema to the scope.
+     * 
+     * @param schemaName The name of the schema to be added (must be unique).
+     * @param schema The schema to be added.
+     * @throws TextDBException If the schema cannot be added.
+     */
+    public void addSchema(String schemaName, Schema schema) throws TextDBException {
+        // Assert the name of the schema is valid and it is not yet associated
+        scopeAssert(schemaName != null, "The name of the schema is mandatory");
+        scopeAssert(!schemaName.isEmpty(), "The name of the schema is mandatory");
+        scopeAssert(getSchema(schemaName) == null, "Schema for '" + schemaName + "' is already defined");
+
+        // Add the schema into the Scope
+        schemasByName.put(schemaName, schema);
+    }
+
+    /**
+     * Get the schema associated with the given schemaName. The schema is
+     * consecutively looked into the Collection of declared schemas and the
+     * RelationManager until it is found. If the schema can be found in the
+     * RelationManager, it is added to the Collection of declared Schemas.
+     * If the scope cannot find the schema with the given name, then null is
+     * returned.
+     * 
+     * @param schemaName The name of the schema to look for.
+     * @return The schema associated with the given name.
+     * @throws StorageException
+     *             If an error occur in the RelationManager.
+     */
+    public Schema getSchema(String schemaName) throws StorageException {
+        Schema schema = null;
+        if (schemasByName.containsKey(schemaName)) {
+            // Look for the schema in the Map of declared schemas
+            schema = schemasByName.get(schemaName);
+        } else if (relationManager != null && relationManager.checkTableExistence(schemaName)) {
+            // Look for the schema as a table in the RelationManager and add it to the scope
+            schema = relationManager.getTableSchema(schemaName);
+            schemasByName.put(schemaName, schema);
+        }
+        // Return the schema found, null otherwise
+        return schema;
+    }
+
+    /**
+     * Get a map containing the schemas inserted in the scope. The Entry of the
+     * map is in the format <SchemaName,Schema>. Schemas inserted in the scope
+     * by the addition of statements are also returned. The returned Map can be
+     * iterated in the same order in which the Schemas were added.
+     * 
+     * @return An unmodifiable Map containing all the inserted schemas by name.
+     */
+    public Map<String, Schema> getSchemas() {
+        return Collections.unmodifiableMap(schemasByName);
+    }
+
+    /**
+     * Add a new Statement and its generated output Schema to the scope.
+     * 
+     * @param statement The statement to be added to the scope (the Id of the
+     *            statement must be unique).
+     * @throws StorageException If an error occur while trying to fetch a 
+     *            table schema.
+     * @throws TextDBException If an error occur when a statement is generating
+     *            the output schema.
+     */
+    public void addStatement(Statement statement) throws StorageException, TextDBException {
+        // Assert the id of the statement is valid and it is not yet associated
+        scopeAssert(statement.getId() != null, "The ID attribute is mandatory for a statement");
+        scopeAssert(!statement.getId().isEmpty(), "The ID attribute is mandatory for a statement");
+        scopeAssert(!statementById.containsKey(statement.getId()),
+                "View with name '" + statement.getId() + "' is already declared");
+        scopeAssert(getSchema(statement.getId()) == null, "Schema for '" + statement.getId() + "' is already defined");
+
+        // Compute the output schema of the statement
+        List<String> inputViews = statement.getInputViews();
+        List<Schema> inputSchemas = new ArrayList<>(inputViews.size());
+        for (String inputViewName : inputViews) {
+            Schema inputSchema = getSchema(inputViewName);
+            scopeAssert(inputSchema != null, "Unable to find required schema '" + inputViewName + "' for statement");
+            inputSchemas.add(inputSchema);
+        }
+        Schema outputSchema = statement.generateOutputSchema(inputSchemas.stream().toArray(Schema[]::new));
+
+        // Add the statement and the generated Schema into the Scope
+        statementById.put(statement.getId(), statement);
+        schemasByName.put(statement.getId(), outputSchema);
+    }
+
+    /**
+     * Get a statement with Id equals to the given statementId. Null is returned
+     * if no statement is found with the given Id.
+     * 
+     * @param statementId The Id of the statement to search for.
+     * @return The statement associated with the given id, or null if no statement is
+     *         found.
+     */
+    public Statement getStatement(String statementId) {
+        return statementById.get(statementId);
+    }
+
+    /**
+     * Return a collection containing all the valid statements added to this
+     * scope. The returned collection can be iterated in the same order in which
+     * the statements were added.
+     * 
+     * @return A collection with valid declared statements.
+     */
+    public Collection<Statement> getStatements() {
+        return statementById.values();
+    }
+
+    /**
+     * Assert the value of assertBoolean is true or throw a TextDBException.
+     * 
+     * @param assertBoolean If a TextDBException should not be thrown.
+     * @param errorMessage The error message to describe a TextDBException
+     *            if it is thrown.
+     * @throws TextDBException If the value of assertBoolean is false.
+     */
+    private static void scopeAssert(boolean assertBoolean, String errorMessage) throws TextDBException {
+        if (!assertBoolean) {
+            throw new TextDBException(errorMessage);
+        }
+    }
+
+}

--- a/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/scope/ScopeTest.java
+++ b/textdb/textdb-textql/src/test/java/edu/uci/ics/textdb/textql/scope/ScopeTest.java
@@ -1,0 +1,665 @@
+package edu.uci.ics.textdb.textql.scope;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.common.Attribute;
+import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
+import edu.uci.ics.textdb.common.constants.TestConstants;
+import edu.uci.ics.textdb.common.exception.StorageException;
+import edu.uci.ics.textdb.common.utils.Utils;
+import edu.uci.ics.textdb.storage.relation.RelationManager;
+import edu.uci.ics.textdb.textql.statements.CreateViewStatement;
+import edu.uci.ics.textdb.textql.statements.SelectExtractStatement;
+import edu.uci.ics.textdb.textql.statements.Statement;
+import edu.uci.ics.textdb.textql.statements.StatementTestUtils;
+import edu.uci.ics.textdb.textql.statements.predicates.SelectAllFieldsPredicate;
+import edu.uci.ics.textdb.textql.statements.predicates.SelectPredicate;
+import junit.framework.Assert;
+
+public class ScopeTest {
+
+    /**
+     * RelationManager used in the tests 
+     */
+    private static RelationManager relationManager;
+    
+    /**
+     * Sample tables used in the tests
+     */
+    private static final String PEOPLE_TABLE = "people";
+    private static final Schema PEOPLE_SCHEMA = TestConstants.SCHEMA_PEOPLE;
+
+    private static final String ALL_FIELD_TYPES_TABLE = "allFieldTypes";
+    private static final Schema ALL_FIELD_TYPES_SCHEMA = StatementTestUtils.ALL_FIELD_TYPES_SCHEMA;
+    
+    private static final String SAMPLE_TABLE0 = "schema00";
+    private static final Schema SAMPLE_SCHEMA0 = new Schema(
+            new Attribute("X", FieldType.INTEGER),
+            new Attribute("Y", FieldType.INTEGER),
+            new Attribute("Z", FieldType.STRING)
+        );
+    
+    private static final String SAMPLE_TABLE1 = "schema01";
+    private static final Schema SAMPLE_SCHEMA1 = new Schema(
+            new Attribute("attr1", FieldType.DATE),
+            new Attribute("attr2", FieldType.DOUBLE),
+            new Attribute("attr3", FieldType.INTEGER),
+            new Attribute("attr4", FieldType.LIST),
+            new Attribute("attr5", FieldType.STRING),
+            new Attribute("attr6", FieldType.TEXT)
+        );
+    
+    private static final Map<String,Schema> TEST_TABLES = new HashMap<>();
+    static {
+        TEST_TABLES.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        TEST_TABLES.put(ALL_FIELD_TYPES_TABLE, ALL_FIELD_TYPES_SCHEMA);
+        TEST_TABLES.put(SAMPLE_TABLE0, SAMPLE_SCHEMA0);
+        TEST_TABLES.put(SAMPLE_TABLE1, SAMPLE_SCHEMA1);
+    }
+    
+    /**
+     * Delete all the test tables from the Relation Manager.
+     * @throws StorageException If an error occur in the Relation Manager while deleting a table.
+     */
+    private static void dropTestTables() throws StorageException {
+        for(String tableName : TEST_TABLES.keySet()){
+            relationManager.deleteTable(tableName);
+        }
+    }
+    
+    /**
+     * Delete all the test tables from the Relation Manager and insert new test tables.
+     * @param tableNames The name of the test tables to be added to the Relation Manager.
+     * @throws StorageException If an error occur in the Relation Manager while deleting or creating a table. 
+     */
+    private static void initTestTables(String... tableNames) throws StorageException {
+        dropTestTables();
+        String indexesDirectory = "../index/test_tables/";
+        for(String tableName : tableNames) {
+            String indexDirectory =  indexesDirectory + tableName;
+            Schema tableSchema = TEST_TABLES.get(tableName);
+            String luceneAnalyzer = LuceneAnalyzerConstants.standardAnalyzerString();
+            relationManager.createTable(tableName, indexDirectory, tableSchema, luceneAnalyzer);
+        }
+    }
+    
+    
+    /**
+     * Initialize the Relation Manager.
+     * @throws StorageException If an error occur while initializing the Relation Manager.
+     */
+    @Before
+    public void setUp() throws StorageException {
+        relationManager = RelationManager.getRelationManager();
+    }
+    
+    /**
+     * Delete all the test tables added to the Relation Manager during the tests.
+     * @throws StorageException If an error occur while deleting the test tables.
+     */
+    @After
+    public void cleanUp() throws StorageException {
+        dropTestTables();
+    }
+    
+
+    /**
+     * Test the Scope by adding a schema and retrieving it.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithoutRelationManager00() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add a schema into the scope
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        
+        // Assert the value of the relation manager
+        Assert.assertEquals(null, scope.getRealationManager());
+        // Assert the values of the added Schema
+        Assert.assertEquals(PEOPLE_SCHEMA, scope.getSchema(PEOPLE_TABLE));
+        Assert.assertEquals(Collections.singletonMap(PEOPLE_TABLE, PEOPLE_SCHEMA), scope.getSchemas());
+    }
+
+    /**
+     * Test the Scope by adding multiple schemas and retrieving them.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithoutRelationManager01() throws TextDBException, StorageException {
+        // Build a map of data to be inserted
+        Map<String,Schema> schemaById = new HashMap<>();
+        schemaById.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        schemaById.put(ALL_FIELD_TYPES_TABLE, ALL_FIELD_TYPES_SCHEMA);
+        schemaById.put(SAMPLE_TABLE0, SAMPLE_SCHEMA0);
+        schemaById.put(SAMPLE_TABLE1, SAMPLE_SCHEMA1);
+        
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add schemas into the scope
+        for(Map.Entry<String,Schema> schemaByIdEntry : schemaById.entrySet()){
+            scope.addSchema(schemaByIdEntry.getKey(), schemaByIdEntry.getValue());
+        }
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(null, scope.getRealationManager());
+        // Assert the values of the added Schemas (in an order different than they have been inserted)
+        ArrayList<Map.Entry<String,Schema>> shuffledSchemaByIdEntries = new ArrayList<>(schemaById.entrySet());
+        Collections.shuffle(shuffledSchemaByIdEntries, new Random(0x59));
+        for(Map.Entry<String,Schema> schemaByIdEntry : shuffledSchemaByIdEntries){
+            Assert.assertEquals(schemaByIdEntry.getValue(), scope.getSchema(schemaByIdEntry.getKey()));
+        }
+        Assert.assertEquals(schemaById, scope.getSchemas());
+    }
+    
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * non existing schema is requested (null should be returned).
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithoutRelationManager02() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Assert the returned value of a schema that has not been added
+        Assert.assertEquals(null, scope.getSchema(ALL_FIELD_TYPES_TABLE));
+    }
+
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Schema with an invalid name (null) is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddSchemaWithoutRelationManager03() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add a schema with a null name
+        scope.addSchema(null, PEOPLE_SCHEMA);
+    }
+
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Schema with an invalid name (empty) is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddSchemaWithoutRelationManager04() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add a schema with an empty("") name
+        scope.addSchema("", PEOPLE_SCHEMA);
+    }
+
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Schema with an already associated name is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddSchemaWithoutRelationManager05() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add schemas into the scope (PEOPLE_TABLE is added twice)
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+    }
+    
+    /**
+     * Test the Scope with a RelationManager by adding a schema, retrieving 
+     * the added schema and retrieving a schema from the relation manager.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithRelationManager00() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(SAMPLE_TABLE0);
+        Scope scope = new Scope(relationManager);
+        
+        // Add a schema into the scope
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        // Assert added Schemas
+        Assert.assertEquals(PEOPLE_SCHEMA, scope.getSchema(PEOPLE_TABLE));
+        Map<String,Schema> declaredSchemas = new HashMap<>();
+        declaredSchemas.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        Assert.assertEquals(declaredSchemas, scope.getSchemas());
+        // Assert added Schemas after a test table is requested
+        Assert.assertEquals(Utils.getSchemaWithID(SAMPLE_SCHEMA0), scope.getSchema(SAMPLE_TABLE0));
+        declaredSchemas.put(SAMPLE_TABLE0, Utils.getSchemaWithID(SAMPLE_SCHEMA0));
+        Assert.assertEquals(declaredSchemas, scope.getSchemas());
+    }
+    
+    /**
+     * Test the Scope with a RelationManager by adding multiple schemas,
+     * retrieving them and retrieving multiple schemas from the relation manager.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithRelationManager01() throws TextDBException, StorageException {
+        // Build a map of data to be inserted
+        Map<String,Schema> schemaById = new HashMap<>();
+        schemaById.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        schemaById.put(ALL_FIELD_TYPES_TABLE, ALL_FIELD_TYPES_SCHEMA);
+
+        // Scope and Tables Initialization
+        initTestTables(SAMPLE_TABLE0, SAMPLE_TABLE1);
+        Scope scope = new Scope(relationManager);
+
+        // Add a schema into the scope
+        for(Map.Entry<String,Schema> schemaByIdEntry : schemaById.entrySet()){
+            scope.addSchema(schemaByIdEntry.getKey(), schemaByIdEntry.getValue());
+        }
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        // Assert the values of the added Schemas (in an order different than they have been inserted)
+        ArrayList<Map.Entry<String,Schema>> shuffledSchemaByIdEntries = new ArrayList<>(schemaById.entrySet());
+        Collections.shuffle(shuffledSchemaByIdEntries, new Random(0x59));
+        for(Map.Entry<String,Schema> schemaByIdEntry : shuffledSchemaByIdEntries){
+            Assert.assertEquals(schemaByIdEntry.getValue(), scope.getSchema(schemaByIdEntry.getKey()));
+        }
+        Assert.assertEquals(new HashSet<>(shuffledSchemaByIdEntries), new HashSet<>(scope.getSchemas().entrySet()));
+        // Assert the values of the added Schemas after a test table is requested
+        Assert.assertEquals(Utils.getSchemaWithID(SAMPLE_SCHEMA1), scope.getSchema(SAMPLE_TABLE1));
+        schemaById.put(SAMPLE_TABLE1, Utils.getSchemaWithID(SAMPLE_SCHEMA1));
+        Assert.assertEquals(Utils.getSchemaWithID(SAMPLE_SCHEMA0), scope.getSchema(SAMPLE_TABLE0));
+        schemaById.put(SAMPLE_TABLE0, Utils.getSchemaWithID(SAMPLE_SCHEMA0));
+        Assert.assertEquals(schemaById, scope.getSchemas());
+    }
+    
+    /**
+     * Test the behavior of the Scope with a RelationManager when a Schema
+     * with the same name of a table in the RelationManager is added (when 
+     * the table information has not been retrieved by the Scope yet). A
+     * TextDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddSchemaWithRelationManager02() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+        
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        
+        // Add a schema into the scope with the same name as a table
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+    }
+    
+    /**
+     * Test the behavior of the Scope with a RelationManager when a Schema
+     * with the same name of a table in the RelationManager is added (when 
+     * the table information has already been retrieved by the Scope). A 
+     * TextDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddSchemaWithRelationManager03() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+        
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        
+        // Make the Scope fetch a table schema and keep it in the collection of schemas 
+        Assert.assertEquals(Utils.getSchemaWithID(PEOPLE_SCHEMA), scope.getSchema(PEOPLE_TABLE));
+        
+        // Add a schema into the scope with the same name as a table
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+    }
+    
+    /**
+     * Test the behavior of the Scope with a RelationManager when a 
+     * non existing schema or table is requested (null should be returned).
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddSchemaWithRelationManager04() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Assert the returned value of a schema that has not been added
+        Assert.assertEquals(null, scope.getSchema(ALL_FIELD_TYPES_TABLE));
+    }   
+    
+    /**
+     * Test the Scope by adding a Statement, retrieving it and retrieving 
+     * its generated Schema.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddStatementWithoutRelationManager00() throws TextDBException, StorageException {
+        /*
+         * TODO: All implemented statements (CreateViewStatement and SelectExtractStatement), at the moment, have
+         * another statement as dependency, thus no values can be added into the scope with only Statements.
+         * This test Must be implemented in the future when a Statement can generate a schema by itself. 
+         */
+    }
+    
+    /**
+     * Test the Scope by adding a Statement that require an added Schema,
+     * retrieving it and retrieve its generated Schema.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddStatementWithoutRelationManager01() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add a schema into the scope
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        // Build and add a statement into the scope
+        String statementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        Schema selectExtractStatementOutputSchema = selectExtractStatement.generateOutputSchema(PEOPLE_SCHEMA);
+        scope.addStatement(selectExtractStatement);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(null, scope.getRealationManager());
+        // Assert added Schemas
+        Assert.assertEquals(PEOPLE_SCHEMA, scope.getSchema(PEOPLE_TABLE));
+        Assert.assertEquals(selectExtractStatementOutputSchema, scope.getSchema(statementId));
+        Map<String,Schema> declaredSchemas = new HashMap<>();
+        declaredSchemas.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        declaredSchemas.put(statementId, selectExtractStatementOutputSchema);
+        Assert.assertEquals(declaredSchemas, scope.getSchemas());
+        // Assert added Statements
+        Set<Statement> declaredStatements = Collections.singleton(selectExtractStatement);
+        Assert.assertEquals(declaredStatements, new HashSet<>(scope.getStatements()));
+    }
+    
+    /**
+     * Test the Scope by adding a Statement that require an added Statement,
+     * retrieving it and retrieve its generated Schema.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddStatementWithoutRelationManager02() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Add schemas into the scope
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        scope.addSchema(SAMPLE_TABLE0, SAMPLE_SCHEMA0);
+        // Build and add statements into the scope
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        String statmentId0 = "_sid0";
+        SelectExtractStatement selectExtractStatement0 = new SelectExtractStatement(statmentId0, selectPredicate, null, PEOPLE_TABLE, null, null);
+        Schema selectExtractStatement0OutputSchema = selectExtractStatement0.generateOutputSchema(PEOPLE_SCHEMA);
+        String statmentId1 = "_sid1";
+        SelectExtractStatement selectExtractStatement1 = new SelectExtractStatement(statmentId1, selectPredicate, null, statmentId0, null, null);
+        Schema selectExtractStatement1OutputSchema = selectExtractStatement1.generateOutputSchema(selectExtractStatement0OutputSchema);
+        scope.addStatement(selectExtractStatement0);
+        scope.addStatement(selectExtractStatement1);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(null, scope.getRealationManager());
+        // Assert added Schemas
+        Assert.assertEquals(PEOPLE_SCHEMA, scope.getSchema(PEOPLE_TABLE));
+        Assert.assertEquals(SAMPLE_SCHEMA0, scope.getSchema(SAMPLE_TABLE0));
+        Map<String,Schema> declaredSchemas = new HashMap<>();
+        declaredSchemas.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        declaredSchemas.put(SAMPLE_TABLE0, SAMPLE_SCHEMA0);
+        declaredSchemas.put(statmentId0, selectExtractStatement0OutputSchema);
+        declaredSchemas.put(statmentId1, selectExtractStatement1OutputSchema);
+        Assert.assertEquals(declaredSchemas, scope.getSchemas());
+        // Assert added Statements
+        Set<Statement> declaredStatements = new HashSet<>();
+        declaredStatements.add(selectExtractStatement0);
+        declaredStatements.add(selectExtractStatement1);
+        Assert.assertEquals(declaredStatements, new HashSet<>(scope.getStatements()));
+    }
+
+    /**
+     * Test the Scope by adding a Statement that require an non existing 
+     * Schema. A TextDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithoutRelationManager03() throws TextDBException, StorageException {
+        // Scope Initialization
+        Scope scope = new Scope();
+        
+        // Build and add a statement into the scope
+        String statementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+    }
+    
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Statement with an invalid Id (null) is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithoutRelationManager04() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Build and add a statement into the scope
+        String statementId = null;
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, null, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+    }
+
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Statement with an invalid Id (empty) is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithoutRelationManager05() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Build and add a statement into the scope
+        String statementId = "";
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, null, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+    }
+    
+    /**
+     * Test the behavior of the Scope (without using a RelationManager) when a
+     * Statement with an already associated Id is inserted. A TextDBException
+     * exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithoutRelationManager06() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+
+        // Build and add a statement into the scope
+        String statementId = ALL_FIELD_TYPES_TABLE;
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+        scope.addStatement(selectExtractStatement);
+    }    
+    
+    /**
+     * Test the Scope with a RelationManager by adding a Statement,
+     * retrieving it and retrieve its generated Schema.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddStatementWithRelationManager00() throws TextDBException, StorageException {
+        /*
+         * TODO: All implemented statements (CreateViewStatement and SelectExtractStatement), at the moment, have
+         * another statement as dependency, thus no values can be added into the scope with only Statements.
+         * This test Must be implemented in the future when a Statement can generate a schema by itself. 
+         */
+    }
+    
+    /**
+     * Test the Scope with a RelationManager by adding a Statement that
+     * require an added Schema, retrieving it and retrieving its generated
+     * Schema.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test
+    public void testAddStatementhWitRelationManager01() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(SAMPLE_TABLE0);
+        Scope scope = new Scope(relationManager);
+        
+        // Add a schema into the scope
+        scope.addSchema(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        // Build and add a statement into the scope
+        String statementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        Schema selectExtractStatementOutputSchema = selectExtractStatement.generateOutputSchema(PEOPLE_SCHEMA);
+        scope.addStatement(selectExtractStatement);
+        
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        
+        // Assert added Schemas
+        Assert.assertEquals(PEOPLE_SCHEMA, scope.getSchema(PEOPLE_TABLE));
+        Assert.assertEquals(selectExtractStatementOutputSchema, scope.getSchema(statementId));
+        Map<String,Schema> declaredSchemas = new HashMap<>();
+        declaredSchemas.put(PEOPLE_TABLE, PEOPLE_SCHEMA);
+        declaredSchemas.put(statementId, selectExtractStatementOutputSchema);
+        Assert.assertEquals(declaredSchemas, scope.getSchemas());
+        // Assert added Statements
+        Set<Statement> declaredStatements = Collections.singleton(selectExtractStatement);
+        Assert.assertEquals(declaredStatements, new HashSet<>(scope.getStatements()));
+    }
+        
+    /**
+     * Test the behavior of the Scope with a RelationManager when a Statement
+     * is added with the same name of an existing table in the RelationManager
+     * (when the table information has not yet been retrieved for). A 
+     * extDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithRelationManager02() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE, ALL_FIELD_TYPES_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+
+        // Build and add statements into the scope
+        String selectExtractStatementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(selectExtractStatementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+        String createviewStatementId = PEOPLE_TABLE;
+        CreateViewStatement createviewStatement = new CreateViewStatement(createviewStatementId, selectExtractStatement);
+        scope.addStatement(createviewStatement);
+    }
+    
+    /**
+     * Test the behavior of the Scope with a RelationManager when a Statement
+     * is added with the same name of an existing table in the RelationManager
+     * (when the table information has already been retrieved for). A
+     * TextDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithRelationManager03() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables(PEOPLE_TABLE, ALL_FIELD_TYPES_TABLE);
+        Scope scope = new Scope(relationManager);
+
+        // Assert the value of the relation manager
+        Assert.assertEquals(relationManager, scope.getRealationManager());
+        
+        // Make the Scope fetch a table schema and keep it in the collection of schemas 
+        Assert.assertEquals(Utils.getSchemaWithID(ALL_FIELD_TYPES_SCHEMA), scope.getSchema(ALL_FIELD_TYPES_TABLE));
+        
+        // Build and add statements into the scope
+        String selectExtractStatementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(selectExtractStatementId, selectPredicate, null, PEOPLE_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+        String createviewStatementId = PEOPLE_TABLE;
+        CreateViewStatement createviewStatement = new CreateViewStatement(createviewStatementId, selectExtractStatement);
+        scope.addStatement(createviewStatement);
+    }
+
+    /**
+     * Test the behavior of the Scope with a RelationManager when a 
+     * Statement require a non existing schema or table. 
+     * A TextDBException exception is expected to be thrown.
+     * @throws TextDBException If a TextDBException is thrown by the Scope.
+     * @throws StorageException If an error occur in the RelationManager.
+     */
+    @Test(expected = TextDBException.class)
+    public void testAddStatementWithRelationManager04() throws TextDBException, StorageException {
+        // Scope and Tables Initialization
+        initTestTables();
+        Scope scope = new Scope(relationManager);
+
+        // Build and add a statement into the scope
+        String statementId = "_sid0";
+        SelectPredicate selectPredicate = new SelectAllFieldsPredicate();
+        SelectExtractStatement selectExtractStatement = new SelectExtractStatement(statementId, selectPredicate, null, ALL_FIELD_TYPES_TABLE, null, null);
+        scope.addStatement(selectExtractStatement);
+    }
+    
+}


### PR DESCRIPTION
Implementation of the Scope object used in TextQL.
This object is part of the semantic analysis of TextQL. Is responsable for maintaining, adding and fetching statements (from the parser) and schemas (from statements or from the RelationManager), which allows for error checking like test wether all requered fields in a view actually exist.

PR #374 is required to be done by this PR