### PR TITLE
Refactor tuple.getField to make type generic

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
@@ -23,8 +23,14 @@ public class Tuple {
         this.fields = Arrays.asList(fields);
     }
 
-    public IField getField(int index) {
-        return fields.get(index);
+    public <T extends IField> T getField(int index) {
+        @SuppressWarnings("unchecked")
+        T field = (T) fields.get(index);
+        return field;
+    }
+    
+    public <T extends IField> T getField(int index, Class<T> fieldClass) {
+        return getField(index);
     }
 
     public IField getField(String fieldName) {

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
@@ -23,19 +23,21 @@ public class Tuple {
         this.fields = Arrays.asList(fields);
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends IField> T getField(int index) {
-        @SuppressWarnings("unchecked")
-        T field = (T) fields.get(index);
-        return field;
+        return (T) fields.get(index);
     }
     
     public <T extends IField> T getField(int index, Class<T> fieldClass) {
         return getField(index);
     }
 
-    public IField getField(String fieldName) {
-        int index = schema.getIndex(fieldName);
-        return getField(index);
+    public <T extends IField> T getField(String fieldName) {
+        return getField(schema.getIndex(fieldName));
+    }
+    
+    public <T extends IField> T getField(String fieldName, Class<T> fieldClass) {
+        return getField(schema.getIndex(fieldName));
     }
 
     public int hashCode() {

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -305,7 +305,8 @@ public class Utils {
         
         for (String attrName : tuple.getSchema().getAttributeNames()) {
             if (attrName.equalsIgnoreCase(SchemaConstants.SPAN_LIST)) {
-                List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+                ListField<Span> spanListField = tuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
                 jsonObject.put(attrName, getSpanListJSON(spanList));
             } else {
                 jsonObject.put(attrName, tuple.getField(attrName).getValue().toString());
@@ -359,7 +360,8 @@ public class Utils {
         Schema schema = tuple.getSchema();
         for (Attribute attribute : schema.getAttributes()) {
             if (attribute.getFieldName().equals(SchemaConstants.SPAN_LIST)) {
-                List<Span> spanList = ((ListField<Span>) tuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+                ListField<Span> spanListField = tuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
                 sb.append(getSpanListString(spanList));
                 sb.append("\n");
             } else {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -173,24 +173,18 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	     * Check using try/catch if both the tuples have span information.
 	     * If not return null; so we can process next tuple.
 	     */
-	    IField spanFieldOfInnerTuple = null;
-	    IField spanFieldOfOuterTuple = null;
-	    try {
-	        spanFieldOfInnerTuple = innerTuple.getField(SchemaConstants.SPAN_LIST);
-	        spanFieldOfOuterTuple = outerTuple.getField(SchemaConstants.SPAN_LIST);
-	    } catch (Exception e) {
-	        return null;
-	    }
+	    ListField<Span> spanFieldOfInnerTuple = innerTuple.getField(SchemaConstants.SPAN_LIST);
+	    ListField<Span> spanFieldOfOuterTuple = outerTuple.getField(SchemaConstants.SPAN_LIST);
 	
 	    List<Span> innerSpanList = null;
 	    List<Span> outerSpanList = null;
 	    // Check if both the fields obtained from the indexes are indeed of type
 	    // ListField
 	    if (spanFieldOfInnerTuple.getClass().equals(ListField.class)) {
-	        innerSpanList = (List<Span>) spanFieldOfInnerTuple.getValue();
+	        innerSpanList = spanFieldOfInnerTuple.getValue();
 	    }
 	    if (spanFieldOfOuterTuple.getClass().equals(ListField.class)) {
-	        outerSpanList = (List<Span>) spanFieldOfOuterTuple.getValue();
+	        outerSpanList = spanFieldOfOuterTuple.getValue();
 	    }
 	
 	    Iterator<Span> outerSpanIter = outerSpanList.iterator();
@@ -238,7 +232,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	            outputAttrList.stream()
 	            .filter(attr -> ! attr.equals(SchemaConstants.SPAN_LIST_ATTRIBUTE))
 	            .map(attr -> attr.getFieldName())
-	            .map(fieldName -> innerTuple.getField(fieldName))
+	            .map(fieldName -> innerTuple.getField(fieldName, IField.class))
 	            .collect(Collectors.toList());
 	    
 	    outputFields.add(new ListField<>(newJoinSpanList));

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -11,7 +11,7 @@ import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
  *
  * @author Adrian Seungjin Lee
  */
-public class ComparableMatcher<T extends Comparable> extends AbstractSingleInputOperator {
+public class ComparableMatcher<T extends Comparable<T>> extends AbstractSingleInputOperator {
     private ComparablePredicate<T> predicate;
 
     private Schema inputSchema;
@@ -48,7 +48,6 @@ public class ComparableMatcher<T extends Comparable> extends AbstractSingleInput
         Attribute attribute = predicate.getAttribute();
         DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
 
-        FieldType fieldType = attribute.getFieldType();
         String fieldName = attribute.getFieldName();
 
         T value;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -15,6 +15,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
@@ -268,7 +269,8 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
 
         return sourceTuple;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -11,6 +11,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -77,7 +78,8 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
 
     @Override
     public Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException {
-        List<Span> payload = (List<Span>) inputTuple.getField(SchemaConstants.PAYLOAD).getValue();
+        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchResults = new ArrayList<>();
 
@@ -110,7 +112,8 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) inputTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = inputTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchResults);
 
         return inputTuple;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -134,10 +134,13 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         }
         
         // get the span list only with the joinAttributeName
-        List<Span> innerRelevantSpanList = ((ListField<Span>) innerTuple.getField(SchemaConstants.SPAN_LIST))
-                .getValue().stream().filter(span -> span.getFieldName().equals(innerJoinAttrName)).collect(Collectors.toList());
-        List<Span> outerRelevantSpanList = ((ListField<Span>) outerTuple.getField(SchemaConstants.SPAN_LIST))
-                .getValue().stream().filter(span -> span.getFieldName().equals(outerJoinAttrName)).collect(Collectors.toList());
+        ListField<Span> innerSpanListField = innerTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> innerRelevantSpanList = innerSpanListField.getValue().stream()
+                .filter(span -> span.getFieldName().equals(innerJoinAttrName)).collect(Collectors.toList());
+        
+        ListField<Span> outerSpanListField = outerTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> outerRelevantSpanList = outerSpanListField.getValue().stream()
+                .filter(span -> span.getFieldName().equals(outerJoinAttrName)).collect(Collectors.toList());
         
         // get a set of span's values (since multiple spans may have the same value)
         Set<String> innerSpanValueSet = innerRelevantSpanList.stream()
@@ -190,8 +193,10 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
                 resultFields.add(new ListField<Span>(mergeSpanList));
             // put the payload of two tuples together
             } else if (attrName.equals(SchemaConstants.PAYLOAD)) {
-                List<Span> innerPayload = ((ListField<Span>) innerTuple.getField(SchemaConstants.PAYLOAD)).getValue();
-                List<Span> outerPayload = ((ListField<Span>) outerTuple.getField(SchemaConstants.PAYLOAD)).getValue();
+                ListField<Span> innerPayloadField = innerTuple.getField(SchemaConstants.PAYLOAD);
+                List<Span> innerPayload = innerPayloadField.getValue();      
+                ListField<Span> outerPayloadField = outerTuple.getField(SchemaConstants.PAYLOAD);
+                List<Span> outerPayload = outerPayloadField.getValue();
                 
                 List<Span> resultPayload = new ArrayList<>();
                 resultPayload.addAll(innerPayload.stream().map(span -> addFieldPrefix(span, INNER_PREFIX)).collect(Collectors.toList()));

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -16,6 +16,7 @@ import edu.uci.ics.textdb.common.constants.DataConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -91,7 +92,8 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     }
 
     private Tuple computeConjunctionMatchingResult(Tuple sourceTuple) throws DataFlowException {
-        List<Span> payload = (List<Span>) sourceTuple.getField(SchemaConstants.PAYLOAD).getValue();
+        ListField<Span> payloadField = sourceTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
@@ -129,14 +131,16 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
 
         return sourceTuple;
     }
 
     private Tuple computePhraseMatchingResult(Tuple sourceTuple) throws DataFlowException {
-        List<Span> payload = (List<Span>) sourceTuple.getField(SchemaConstants.PAYLOAD).getValue();
+        ListField<Span> payloadField = sourceTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
@@ -227,7 +231,8 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
 
         return sourceTuple;
@@ -269,7 +274,8 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) sourceTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
 
         return sourceTuple;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -14,6 +14,7 @@ import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -93,7 +94,8 @@ public class NlpExtractor extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) inputTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = inputTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
         return inputTuple;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -9,6 +9,7 @@ import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.common.field.ListField;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.common.AbstractSingleInputOperator;
@@ -145,7 +146,8 @@ public class RegexMatcher extends AbstractSingleInputOperator {
             return null;
         }
 
-        List<Span> spanList = (List<Span>) inputTuple.getField(SchemaConstants.SPAN_LIST).getValue();
+        ListField<Span> spanListField = inputTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);
 
         return inputTuple;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriterTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriterTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Tuple;
+import edu.uci.ics.textdb.common.field.ListField;
 
 /**
  * Created by kishorenarendran on 25/04/16. Testing QueryRewriter This test
@@ -93,15 +94,15 @@ public class QueryRewriterTest {
         QueryRewriter queryRewriter = new QueryRewriter(query);
         queryRewriter.open();
         Tuple resultItuple = queryRewriter.getNextTuple();
-        ArrayList<String> rewrittenStrings = new ArrayList<String>(
-                (List<String>) resultItuple.getField(QueryRewriter.QUERYLIST).getValue());
+        ListField<String> rewrittenStringsField = resultItuple.getField(QueryRewriter.QUERYLIST);
+        ArrayList<String> rewrittenStrings = new ArrayList<String>(rewrittenStringsField.getValue());
         queryRewriter.close();
 
         QueryRewriter allQueryRewriter = new QueryRewriter(query, true);
         allQueryRewriter.open();
         resultItuple = allQueryRewriter.getNextTuple();
-        ArrayList<String> allRewrittenStrings = new ArrayList<String>(
-                (List<String>) resultItuple.getField(QueryRewriter.QUERYLIST).getValue());
+        ListField<String> allRewrittenStringsField = resultItuple.getField(QueryRewriter.QUERYLIST);
+        ArrayList<String> allRewrittenStrings = new ArrayList<String>(allRewrittenStringsField.getValue());
         queryRewriter.close();
 
         return (rewrittenStrings.equals(expectedRewrittenStrings) 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -130,7 +130,8 @@ public class DictionaryMatcherPerformanceTest {
         Tuple nextTuple = null;
         int counter = 0;
         while ((nextTuple = dictionaryMatcher.getNextTuple()) != null) {
-            List<Span> spanList = ((ListField<Span>) nextTuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+            ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
+            List<Span> spanList = spanListField.getValue();
             counter += spanList.size();
         }
         dictionaryMatcher.close();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -127,7 +127,8 @@ public class FuzzyTokenMatcherPerformanceTest {
             int counter = 0;
             Tuple nextTuple = null;
             while ((nextTuple = fuzzyTokenSource.getNextTuple()) != null) {
-                List<Span> spanList = ((ListField<Span>) nextTuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+                ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
                 counter += spanList.size();
             }
             fuzzyTokenSource.close();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -151,7 +151,8 @@ public class KeywordMatcherPerformanceTest {
             int counter = 0;
             Tuple nextTuple = null;
             while ((nextTuple = keywordSource.getNextTuple()) != null) {
-                List<Span> spanList = ((ListField<Span>) nextTuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+                ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
                 counter += spanList.size();
             }
             keywordSource.close();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -106,7 +106,8 @@ public class NlpExtractorPerformanceTest {
         Tuple nextTuple = null;
         int counter = 0;
         while ((nextTuple = nlpExtractor.getNextTuple()) != null) {
-            List<Span> spanList = ((ListField<Span>) nextTuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+            ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
+            List<Span> spanList = spanListField.getValue();
             counter += spanList.size();
 
         }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -104,7 +104,8 @@ public class RegexMatcherPerformanceTest {
 	        int counter = 0;
 	        Tuple nextTuple = null;
 	        while ((nextTuple = regexSource.getNextTuple()) != null) {
-	            List<Span> spanList = ((ListField<Span>) nextTuple.getField(SchemaConstants.SPAN_LIST)).getValue();
+	            ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
+	            List<Span> spanList = spanListField.getValue();
 	            counter += spanList.size();
 	        }
 	        regexSource.close();

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/QueryPlanRequest.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/request/QueryPlanRequest.java
@@ -29,7 +29,8 @@ public class QueryPlanRequest {
     private LogicalPlan logicalPlan;
 
     public static final String GET_PROPERTIES_FUNCTION_NAME = "getOperatorProperties";
-    public static final HashMap<String, Class> OPERATOR_BEAN_MAP = new HashMap<String, Class>() {{
+    public static final HashMap<String, Class<? extends OperatorBean>> OPERATOR_BEAN_MAP = 
+            new HashMap<String, Class<? extends OperatorBean>>() {{
         put("DictionaryMatcher", DictionaryMatcherBean.class);
         put("DictionarySource", DictionarySourceBean.class);
         put("FileSink", FileSinkBean.class);
@@ -93,7 +94,7 @@ public class QueryPlanRequest {
         this.operatorProperties = new HashMap<>();
         for(Iterator<OperatorBean> iter = operatorBeans.iterator(); iter.hasNext(); ) {
             OperatorBean operatorBean = iter.next();
-            Class operatorBeanClassName =  OPERATOR_BEAN_MAP.get(operatorBean.getOperatorType());
+            Class<? extends OperatorBean> operatorBeanClassName =  OPERATOR_BEAN_MAP.get(operatorBean.getOperatorType());
             try {
                 Method method = operatorBeanClassName.getMethod(GET_PROPERTIES_FUNCTION_NAME);
                 HashMap<String, String> currentOperatorProperty = (HashMap<String, String>) method.invoke(operatorBean);


### PR DESCRIPTION
This PR modifies the `tuple.getField` return type to make it no longer necessary to do type casting in the code.

This PR also removes places that IDE warns type cast