### PR TITLE
[Issue #372] Refactoring Attribute's data members and the enum FieldType

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
@@ -1,11 +1,11 @@
 package edu.uci.ics.textdb.api.common;
 
 public class Attribute {
-    private final String fieldName;
+    private final String attributeName;
     private final FieldType fieldType;
 
-    public Attribute(String fieldName, FieldType type) {
-        this.fieldName = fieldName;
+    public Attribute(String attributeName, FieldType type) {
+        this.attributeName = attributeName;
         this.fieldType = type;
     }
 
@@ -13,13 +13,13 @@ public class Attribute {
         return fieldType;
     }
 
-    public String getFieldName() {
-        return fieldName;
+    public String getAttributeName() {
+        return attributeName;
     }
 
     @Override
     public String toString() {
-        return "Attribute [fieldName=" + fieldName + ", fieldType=" + fieldType + "]";
+        return "Attribute [attributeName=" + attributeName + ", fieldType=" + fieldType + "]";
     }
     
     @Override
@@ -36,18 +36,18 @@ public class Attribute {
         
         Attribute that = (Attribute) toCompare;
         
-        if (this.fieldName == null) {
-            return that.fieldName == null;
+        if (this.attributeName == null) {
+            return that.attributeName == null;
         }
         if (this.fieldType == null) {
             return that.fieldType == null;
         }
         
-        return this.fieldName.equals(that.fieldName) && this.fieldType.equals(that.fieldType);
+        return this.attributeName.equals(that.attributeName) && this.fieldType.equals(that.fieldType);
     }
     
     @Override
     public int hashCode() {
-        return this.fieldName.hashCode() + this.fieldType.toString().hashCode();
+        return this.attributeName.hashCode() + this.fieldType.toString().hashCode();
     }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
@@ -2,14 +2,14 @@ package edu.uci.ics.textdb.api.common;
 
 public class Attribute {
     private final String attributeName;
-    private final FieldType attributeType;
+    private final AttributeType attributeType;
 
-    public Attribute(String attributeName, FieldType type) {
+    public Attribute(String attributeName, AttributeType type) {
         this.attributeName = attributeName;
         this.attributeType = type;
     }
 
-    public FieldType getAttributeType() {
+    public AttributeType getAttributeType() {
         return attributeType;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Attribute.java
@@ -2,15 +2,15 @@ package edu.uci.ics.textdb.api.common;
 
 public class Attribute {
     private final String attributeName;
-    private final FieldType fieldType;
+    private final FieldType attributeType;
 
     public Attribute(String attributeName, FieldType type) {
         this.attributeName = attributeName;
-        this.fieldType = type;
+        this.attributeType = type;
     }
 
-    public FieldType getFieldType() {
-        return fieldType;
+    public FieldType getAttributeType() {
+        return attributeType;
     }
 
     public String getAttributeName() {
@@ -19,7 +19,7 @@ public class Attribute {
 
     @Override
     public String toString() {
-        return "Attribute [attributeName=" + attributeName + ", fieldType=" + fieldType + "]";
+        return "Attribute [attributeName=" + attributeName + ", attributeType=" + attributeType + "]";
     }
     
     @Override
@@ -39,15 +39,15 @@ public class Attribute {
         if (this.attributeName == null) {
             return that.attributeName == null;
         }
-        if (this.fieldType == null) {
-            return that.fieldType == null;
+        if (this.attributeType == null) {
+            return that.attributeType == null;
         }
         
-        return this.attributeName.equals(that.attributeName) && this.fieldType.equals(that.fieldType);
+        return this.attributeName.equals(that.attributeName) && this.attributeType.equals(that.attributeType);
     }
     
     @Override
     public int hashCode() {
-        return this.attributeName.hashCode() + this.fieldType.toString().hashCode();
+        return this.attributeName.hashCode() + this.attributeType.toString().hashCode();
     }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/AttributeType.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/AttributeType.java
@@ -1,6 +1,6 @@
 package edu.uci.ics.textdb.api.common;
 
-public enum FieldType {
+public enum AttributeType {
     // A field that is indexed but not tokenized: the entire String
     // value is indexed as a single token
     STRING, INTEGER, DOUBLE, DATE,

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -22,7 +22,7 @@ public class Schema {
     private void populateFieldNameVsIndexMap() {
         fieldNameVsIndex = new HashMap<String, Integer>();
         for (int count = 0; count < attributes.size(); count++) {
-            String fieldName = attributes.get(count).getFieldName();
+            String fieldName = attributes.get(count).getAttributeName();
             fieldNameVsIndex.put(fieldName.toLowerCase(), count);
         }
     }
@@ -32,7 +32,7 @@ public class Schema {
     }
     
     public List<String> getAttributeNames() {
-        return attributes.stream().map(attr -> attr.getFieldName()).collect(Collectors.toList());
+        return attributes.stream().map(attr -> attr.getAttributeName()).collect(Collectors.toList());
     }
 
     public Integer getIndex(String fieldName) {

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Schema.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 public class Schema {
     private List<Attribute> attributes;
-    private Map<String, Integer> fieldNameVsIndex;
+    private Map<String, Integer> attributeNameVsIndex;
 
     public Schema(Attribute... attributes) {
         // Converting to java.util.Arrays.ArrayList
@@ -16,14 +16,14 @@ public class Schema {
         // This makes List<Attribute> partially immutable.
         // Partial because we can still replace an element at particular index.
         this.attributes = Arrays.asList(attributes);
-        populateFieldNameVsIndexMap();
+        populateAttributeNameVsIndexMap();
     }
 
-    private void populateFieldNameVsIndexMap() {
-        fieldNameVsIndex = new HashMap<String, Integer>();
+    private void populateAttributeNameVsIndexMap() {
+        attributeNameVsIndex = new HashMap<String, Integer>();
         for (int count = 0; count < attributes.size(); count++) {
-            String fieldName = attributes.get(count).getAttributeName();
-            fieldNameVsIndex.put(fieldName.toLowerCase(), count);
+            String attributeName = attributes.get(count).getAttributeName();
+            attributeNameVsIndex.put(attributeName.toLowerCase(), count);
         }
     }
 
@@ -35,20 +35,20 @@ public class Schema {
         return attributes.stream().map(attr -> attr.getAttributeName()).collect(Collectors.toList());
     }
 
-    public Integer getIndex(String fieldName) {
-        return fieldNameVsIndex.get(fieldName.toLowerCase());
+    public Integer getIndex(String attributeName) {
+        return attributeNameVsIndex.get(attributeName.toLowerCase());
     }
     
-    public Attribute getAttribute(String fieldName) {
-        Integer attrIndex = getIndex(fieldName);
+    public Attribute getAttribute(String attributeName) {
+        Integer attrIndex = getIndex(attributeName);
         if (attrIndex == null) {
             return null;
         }
         return attributes.get(attrIndex);
     }
 
-    public boolean containsField(String fieldName) {
-        return fieldNameVsIndex.keySet().contains(fieldName.toLowerCase());
+    public boolean containsField(String attributeName) {
+        return attributeNameVsIndex.keySet().contains(attributeName.toLowerCase());
     }
 
     @Override
@@ -56,7 +56,7 @@ public class Schema {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
-        result = prime * result + ((fieldNameVsIndex == null) ? 0 : fieldNameVsIndex.hashCode());
+        result = prime * result + ((attributeNameVsIndex == null) ? 0 : attributeNameVsIndex.hashCode());
         return result;
     }
 
@@ -74,10 +74,10 @@ public class Schema {
                 return false;
         } else if (!attributes.equals(other.attributes))
             return false;
-        if (fieldNameVsIndex == null) {
-            if (other.fieldNameVsIndex != null)
+        if (attributeNameVsIndex == null) {
+            if (other.attributeNameVsIndex != null)
                 return false;
-        } else if (!fieldNameVsIndex.equals(other.fieldNameVsIndex))
+        } else if (!attributeNameVsIndex.equals(other.attributeNameVsIndex))
             return false;
         return true;
     }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/common/Tuple.java
@@ -32,12 +32,12 @@ public class Tuple {
         return getField(index);
     }
 
-    public <T extends IField> T getField(String fieldName) {
-        return getField(schema.getIndex(fieldName));
+    public <T extends IField> T getField(String attributeName) {
+        return getField(schema.getIndex(attributeName));
     }
     
-    public <T extends IField> T getField(String fieldName, Class<T> fieldClass) {
-        return getField(schema.getIndex(fieldName));
+    public <T extends IField> T getField(String attributeName, Class<T> fieldClass) {
+        return getField(schema.getIndex(attributeName));
     }
 
     public int hashCode() {

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
@@ -19,6 +19,6 @@ public class AttributeTest {
     @Test
     public void testGetterMethods() {
         Assert.assertEquals(fieldName, attribute.getAttributeName());
-        Assert.assertEquals(type, attribute.getFieldType());
+        Assert.assertEquals(type, attribute.getAttributeType());
     }
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
@@ -8,17 +8,17 @@ import org.junit.Test;
 public class AttributeTest {
 
     private Attribute attribute;
-    private String fieldName = "sampleFieldName";
+    private String attributeName = "sampleAttributeName";
     private AttributeType type = AttributeType.STRING;
 
     @Before
     public void setUp() {
-        attribute = new Attribute(fieldName, type);
+        attribute = new Attribute(attributeName, type);
     }
 
     @Test
     public void testGetterMethods() {
-        Assert.assertEquals(fieldName, attribute.getAttributeName());
+        Assert.assertEquals(attributeName, attribute.getAttributeName());
         Assert.assertEquals(type, attribute.getAttributeType());
     }
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
@@ -18,7 +18,7 @@ public class AttributeTest {
 
     @Test
     public void testGetterMethods() {
-        Assert.assertEquals(fieldName, attribute.getFieldName());
+        Assert.assertEquals(fieldName, attribute.getAttributeName());
         Assert.assertEquals(type, attribute.getFieldType());
     }
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/AttributeTest.java
@@ -9,7 +9,7 @@ public class AttributeTest {
 
     private Attribute attribute;
     private String fieldName = "sampleFieldName";
-    private FieldType type = FieldType.STRING;
+    private AttributeType type = AttributeType.STRING;
 
     @Before
     public void setUp() {

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -11,9 +11,9 @@ import org.junit.Test;
 public class SchemaTest {
     private Schema schema;
     private String fieldName1 = "sampleField_1";
-    private FieldType type1 = FieldType.STRING;
+    private AttributeType type1 = AttributeType.STRING;
     private String fieldName2 = "sampleField_2";
-    private FieldType type2 = FieldType.STRING;
+    private AttributeType type2 = AttributeType.STRING;
 
     private Attribute[] attributes = { new Attribute(fieldName1, type1), new Attribute(fieldName2, type2) };;
 
@@ -46,8 +46,8 @@ public class SchemaTest {
     @Test
     public void testGetAttribute() {
         
-        Attribute expectedAttribute1 = new Attribute("sampleField_1", FieldType.STRING);
-        Attribute expectedAttribute2 = new Attribute("sampleField_2", FieldType.STRING);
+        Attribute expectedAttribute1 = new Attribute("sampleField_1", AttributeType.STRING);
+        Attribute expectedAttribute2 = new Attribute("sampleField_2", AttributeType.STRING);
 
         Attribute retrievedAttribute1 = schema.getAttribute(fieldName1);
         Attribute retrievedAttribute2 = schema.getAttribute(fieldName2.toUpperCase());
@@ -75,7 +75,7 @@ public class SchemaTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testAddingNewAttribute() { // Should fail due to immutability
         List<Attribute> attributes = schema.getAttributes();
-        attributes.add(new Attribute("sampleField_3", FieldType.STRING));
+        attributes.add(new Attribute("sampleField_3", AttributeType.STRING));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -87,7 +87,7 @@ public class SchemaTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testAddingInBetween() { // Should fail due to immutability
         List<Attribute> attributes = schema.getAttributes();
-        attributes.add(0, new Attribute("sampleField_3", FieldType.STRING));
+        attributes.add(0, new Attribute("sampleField_3", AttributeType.STRING));
 
     }
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -46,8 +46,8 @@ public class SchemaTest {
     @Test
     public void testGetAttribute() {
         
-        Attribute expectedAttribute1 = new Attribute("sampleField_1", AttributeType.STRING);
-        Attribute expectedAttribute2 = new Attribute("sampleField_2", AttributeType.STRING);
+        Attribute expectedAttribute1 = new Attribute("sampleAttribute_1", AttributeType.STRING);
+        Attribute expectedAttribute2 = new Attribute("sampleAttribute_2", AttributeType.STRING);
 
         Attribute retrievedAttribute1 = schema.getAttribute(attributeName1);
         Attribute retrievedAttribute2 = schema.getAttribute(attributeName2.toUpperCase());
@@ -59,7 +59,7 @@ public class SchemaTest {
     
     @Test
     public void testGetAttributeNames() {
-        List<String> expectedAttrNames = Arrays.asList("sampleField_1", "sampleField_2");
+        List<String> expectedAttrNames = Arrays.asList("sampleAttribute_1", "sampleAttribute_2");
         List<String> actualAttrNames = schema.getAttributeNames();
         
         Assert.assertEquals(expectedAttrNames, actualAttrNames);

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -10,12 +10,12 @@ import org.junit.Test;
 
 public class SchemaTest {
     private Schema schema;
-    private String fieldName1 = "sampleField_1";
+    private String attributeName1 = "sampleAttribute_1";
     private AttributeType type1 = AttributeType.STRING;
-    private String fieldName2 = "sampleField_2";
+    private String attributeName2 = "sampleAttribute_2";
     private AttributeType type2 = AttributeType.STRING;
 
-    private Attribute[] attributes = { new Attribute(fieldName1, type1), new Attribute(fieldName2, type2) };;
+    private Attribute[] attributes = { new Attribute(attributeName1, type1), new Attribute(attributeName2, type2) };;
 
     @Before
     public void setUp() {
@@ -36,8 +36,8 @@ public class SchemaTest {
 
         int expectedIndex1 = 0;
         int expectedIndex2 = 1;
-        int retrievedIndex1 = schema.getIndex(fieldName1);
-        int retrievedIndex2 = schema.getIndex(fieldName2.toUpperCase());
+        int retrievedIndex1 = schema.getIndex(attributeName1);
+        int retrievedIndex2 = schema.getIndex(attributeName2.toUpperCase());
         Assert.assertEquals(expectedIndex1, retrievedIndex1);
         Assert.assertEquals(expectedIndex2, retrievedIndex2);
 
@@ -49,8 +49,8 @@ public class SchemaTest {
         Attribute expectedAttribute1 = new Attribute("sampleField_1", AttributeType.STRING);
         Attribute expectedAttribute2 = new Attribute("sampleField_2", AttributeType.STRING);
 
-        Attribute retrievedAttribute1 = schema.getAttribute(fieldName1);
-        Attribute retrievedAttribute2 = schema.getAttribute(fieldName2.toUpperCase());
+        Attribute retrievedAttribute1 = schema.getAttribute(attributeName1);
+        Attribute retrievedAttribute2 = schema.getAttribute(attributeName2.toUpperCase());
         
         Assert.assertEquals(expectedAttribute1, retrievedAttribute1);
         Assert.assertEquals(expectedAttribute2, retrievedAttribute2);

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/SchemaConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/SchemaConstants.java
@@ -4,7 +4,7 @@
 package edu.uci.ics.textdb.common.constants;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 
 /**
  * @author sandeepreddy602
@@ -12,11 +12,11 @@ import edu.uci.ics.textdb.api.common.FieldType;
  */
 public class SchemaConstants {
     public static final String PAYLOAD = "payload";
-    public static final Attribute PAYLOAD_ATTRIBUTE = new Attribute(PAYLOAD, FieldType.LIST);
+    public static final Attribute PAYLOAD_ATTRIBUTE = new Attribute(PAYLOAD, AttributeType.LIST);
 
     public static final String SPAN_LIST = "spanList";
-    public static final Attribute SPAN_LIST_ATTRIBUTE = new Attribute(SPAN_LIST, FieldType.LIST);
+    public static final Attribute SPAN_LIST_ATTRIBUTE = new Attribute(SPAN_LIST, AttributeType.LIST);
     
     public static final String _ID = "_id";
-    public static final Attribute _ID_ATTRIBUTE = new Attribute(_ID, FieldType._ID_TYPE);
+    public static final Attribute _ID_ATTRIBUTE = new Attribute(_ID, AttributeType._ID_TYPE);
 }

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/TestConstants.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/TestConstants.java
@@ -8,11 +8,8 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
 import edu.uci.ics.textdb.common.field.IntegerField;
@@ -33,12 +30,12 @@ public class TestConstants {
     public static final String DATE_OF_BIRTH = "dateOfBirth";
     public static final String DESCRIPTION = "description";
 
-    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, FieldType.STRING);
-    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, FieldType.STRING);
-    public static final Attribute AGE_ATTR = new Attribute(AGE, FieldType.INTEGER);
-    public static final Attribute HEIGHT_ATTR = new Attribute(HEIGHT, FieldType.DOUBLE);
-    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, FieldType.DATE);
-    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, FieldType.TEXT);
+    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, AttributeType.STRING);
+    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, AttributeType.STRING);
+    public static final Attribute AGE_ATTR = new Attribute(AGE, AttributeType.INTEGER);
+    public static final Attribute HEIGHT_ATTR = new Attribute(HEIGHT, AttributeType.DOUBLE);
+    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, AttributeType.DATE);
+    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, AttributeType.TEXT);
 
     // Sample Schema
     public static final Attribute[] ATTRIBUTES_PEOPLE = { FIRST_NAME_ATTR, LAST_NAME_ATTR, AGE_ATTR, HEIGHT_ATTR,

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/TestConstantsChinese.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/constants/TestConstantsChinese.java
@@ -5,11 +5,8 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
 import edu.uci.ics.textdb.common.field.IntegerField;
@@ -29,12 +26,12 @@ public class TestConstantsChinese {
     public static final String DATE_OF_BIRTH = "dateOfBirth";
     public static final String DESCRIPTION = "description";
 
-    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, FieldType.STRING);
-    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, FieldType.STRING);
-    public static final Attribute AGE_ATTR = new Attribute(AGE, FieldType.INTEGER);
-    public static final Attribute HEIGHT_ATTR = new Attribute(HEIGHT, FieldType.DOUBLE);
-    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, FieldType.DATE);
-    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, FieldType.TEXT);
+    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, AttributeType.STRING);
+    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, AttributeType.STRING);
+    public static final Attribute AGE_ATTR = new Attribute(AGE, AttributeType.INTEGER);
+    public static final Attribute HEIGHT_ATTR = new Attribute(HEIGHT, AttributeType.DOUBLE);
+    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, AttributeType.DATE);
+    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, AttributeType.TEXT);
 
     // Sample Schema
     public static final Attribute[] ATTRIBUTES_PEOPLE = { FIRST_NAME_ATTR, LAST_NAME_ATTR, AGE_ATTR, HEIGHT_ATTR,

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/field/Span.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/field/Span.java
@@ -2,7 +2,7 @@ package edu.uci.ics.textdb.common.field;
 
 public class Span {
     // The name of the field (in the tuple) where this span is present
-    private String fieldName;
+    private String attributeName;
     // The start position of the span, which is the offset of the gap before the
     // first character of the span.
     private int start;
@@ -25,8 +25,8 @@ public class Span {
 
     public static int INVALID_TOKEN_OFFSET = -1;
 
-    public Span(String fieldName, int start, int end, String key, String value) {
-        this.fieldName = fieldName;
+    public Span(String attributeName, int start, int end, String key, String value) {
+        this.attributeName = attributeName;
         this.start = start;
         this.end = end;
         this.key = key;
@@ -34,13 +34,13 @@ public class Span {
         this.tokenOffset = INVALID_TOKEN_OFFSET;
     }
 
-    public Span(String fieldName, int start, int end, String key, String value, int tokenOffset) {
-        this(fieldName, start, end, key, value);
+    public Span(String attributeName, int start, int end, String key, String value, int tokenOffset) {
+        this(attributeName, start, end, key, value);
         this.tokenOffset = tokenOffset;
     }
 
-    public String getFieldName() {
-        return fieldName;
+    public String getAttributeName() {
+        return attributeName;
     }
 
     public String getKey() {
@@ -68,7 +68,7 @@ public class Span {
         final int prime = 31;
         int result = 1;
         result = prime * result + end;
-        result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+        result = prime * result + ((attributeName == null) ? 0 : attributeName.hashCode());
         result = prime * result + ((key == null) ? 0 : key.hashCode());
         result = prime * result + start;
         result = prime * result + ((value == null) ? 0 : value.hashCode());
@@ -86,10 +86,10 @@ public class Span {
             return false;
         Span other = (Span) obj;
 
-        if (fieldName == null) {
-            if (other.fieldName != null)
+        if (attributeName == null) {
+            if (other.attributeName != null)
                 return false;
-        } else if (!fieldName.equals(other.fieldName))
+        } else if (!attributeName.equals(other.attributeName))
             return false;
 
         if (start != other.start)

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import edu.uci.ics.textdb.api.common.*;
 import edu.uci.ics.textdb.common.exception.StorageException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -28,11 +29,7 @@ import org.apache.lucene.index.IndexableField;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.field.DateField;
 import edu.uci.ics.textdb.common.field.DoubleField;
@@ -44,9 +41,9 @@ import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.field.TextField;
 
 public class Utils {
-    public static IField getField(FieldType fieldType, String fieldValue) throws ParseException {
+    public static IField getField(AttributeType attributeType, String fieldValue) throws ParseException {
         IField field = null;
-        switch (fieldType) {
+        switch (attributeType) {
         case _ID_TYPE:
             field = new IDField(fieldValue);
             break;
@@ -74,9 +71,9 @@ public class Utils {
         return field;
     }
 
-    public static IndexableField getLuceneField(FieldType fieldType, String fieldName, Object fieldValue) {
+    public static IndexableField getLuceneField(AttributeType attributeType, String fieldName, Object fieldValue) {
         IndexableField luceneField = null;
-        switch (fieldType) {
+        switch (attributeType) {
         // _ID_TYPE is currently same as STRING
         case _ID_TYPE:
         case STRING:
@@ -118,26 +115,26 @@ public class Utils {
     }
     
     /**
-     * Returns the FieldType of a field object.
+     * Returns the AttributeType of a field object.
      * 
      * @param field
      * @return
      */
-    public static FieldType getFieldType(IField field) {
+    public static AttributeType getFieldType(IField field) {
         if (field instanceof DateField) {
-            return FieldType.DATE;
+            return AttributeType.DATE;
         } else if (field instanceof DoubleField) {
-            return FieldType.DOUBLE;
+            return AttributeType.DOUBLE;
         } else if (field instanceof IDField) {
-            return FieldType._ID_TYPE;
+            return AttributeType._ID_TYPE;
         } else if (field instanceof IntegerField) {
-            return FieldType.INTEGER;
+            return AttributeType.INTEGER;
         } else if (field instanceof ListField) {
-            return FieldType.LIST;
+            return AttributeType.LIST;
         } else if (field instanceof StringField) {
-            return FieldType.STRING;
+            return AttributeType.STRING;
         } else if (field instanceof TextField) {
-            return FieldType.TEXT;
+            return AttributeType.TEXT;
         } else {
             throw new RuntimeException("no existing type mapping of this field object");
         }
@@ -453,7 +450,7 @@ public class Utils {
 
     public static List<Span> generatePayloadFromTuple(Tuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (attr.getAttributeType() == FieldType.TEXT)) // generate payload only for TEXT field
+                .filter(attr -> (attr.getAttributeType() == AttributeType.TEXT)) // generate payload only for TEXT field
                 .map(attr -> attr.getAttributeName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -163,7 +163,7 @@ public class Utils {
      */
     public static List<String> getAttributeNames(List<Attribute> attributeList) {
         return attributeList.stream()
-                .map(attr -> attr.getFieldName())
+                .map(attr -> attr.getAttributeName())
                 .collect(Collectors.toList());
     }
     
@@ -175,7 +175,7 @@ public class Utils {
      */
     public static List<String> getAttributeNames(Attribute... attributeList) {
         return Arrays.asList(attributeList).stream()
-                .map(attr -> attr.getFieldName())
+                .map(attr -> attr.getAttributeName())
                 .collect(Collectors.toList());
     }
     
@@ -215,7 +215,7 @@ public class Utils {
      * @return new schema
      */
     public static Schema addAttributeToSchema(Schema schema, Attribute attribute) {
-        if (schema.containsField(attribute.getFieldName())) {
+        if (schema.containsField(attribute.getAttributeName())) {
             return schema;
         }
         List<Attribute> attributes = new ArrayList<>(schema.getAttributes());
@@ -233,7 +233,7 @@ public class Utils {
      */
     public static Schema removeAttributeFromSchema(Schema schema, String... attributeName) {
         return new Schema(schema.getAttributes().stream()
-                .filter(attr -> (! Arrays.asList(attributeName).contains(attr.getFieldName())))
+                .filter(attr -> (! Arrays.asList(attributeName).contains(attr.getAttributeName())))
                 .toArray(Attribute[]::new));
     }
 
@@ -359,18 +359,18 @@ public class Utils {
 
         Schema schema = tuple.getSchema();
         for (Attribute attribute : schema.getAttributes()) {
-            if (attribute.getFieldName().equals(SchemaConstants.SPAN_LIST)) {
+            if (attribute.getAttributeName().equals(SchemaConstants.SPAN_LIST)) {
                 ListField<Span> spanListField = tuple.getField(SchemaConstants.SPAN_LIST);
                 List<Span> spanList = spanListField.getValue();
                 sb.append(getSpanListString(spanList));
                 sb.append("\n");
             } else {
-                sb.append(attribute.getFieldName());
+                sb.append(attribute.getAttributeName());
                 sb.append("(");
                 sb.append(attribute.getFieldType().toString());
                 sb.append(")");
                 sb.append(": ");
-                sb.append(tuple.getField(attribute.getFieldName()).getValue().toString());
+                sb.append(tuple.getField(attribute.getAttributeName()).getValue().toString());
                 sb.append("\n");
             }
         }
@@ -441,7 +441,7 @@ public class Utils {
                 .map(fieldName -> tuple.getSchema().getIndex(fieldName)).collect(Collectors.toList());
         
         Attribute[] newAttrs = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (! removeFieldList.contains(attr.getFieldName()))).toArray(Attribute[]::new);
+                .filter(attr -> (! removeFieldList.contains(attr.getAttributeName()))).toArray(Attribute[]::new);
         Schema newSchema = new Schema(newAttrs);
         
         IField[] newFields = IntStream.range(0, tuple.getSchema().getAttributes().size())
@@ -454,7 +454,7 @@ public class Utils {
     public static List<Span> generatePayloadFromTuple(Tuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
                 .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate payload only for TEXT field
-                .map(attr -> attr.getFieldName())
+                .map(attr -> attr.getAttributeName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))
                 .flatMap(payload -> payload.stream()) // flatten a list of lists to a list

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -367,7 +367,7 @@ public class Utils {
             } else {
                 sb.append(attribute.getAttributeName());
                 sb.append("(");
-                sb.append(attribute.getFieldType().toString());
+                sb.append(attribute.getAttributeType().toString());
                 sb.append(")");
                 sb.append(": ");
                 sb.append(tuple.getField(attribute.getAttributeName()).getValue().toString());
@@ -453,7 +453,7 @@ public class Utils {
 
     public static List<Span> generatePayloadFromTuple(Tuple tuple, Analyzer luceneAnalyzer) {
         List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
-                .filter(attr -> (attr.getFieldType() == FieldType.TEXT)) // generate payload only for TEXT field
+                .filter(attr -> (attr.getAttributeType() == FieldType.TEXT)) // generate payload only for TEXT field
                 .map(attr -> attr.getAttributeName())
                 .map(fieldName -> generatePayload(fieldName, tuple.getField(fieldName).getValue().toString(),
                         luceneAnalyzer))

--- a/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
+++ b/textdb/textdb-common/src/main/java/edu/uci/ics/textdb/common/utils/Utils.java
@@ -120,7 +120,7 @@ public class Utils {
      * @param field
      * @return
      */
-    public static AttributeType getFieldType(IField field) {
+    public static AttributeType getAttributeType(IField field) {
         if (field instanceof DateField) {
             return AttributeType.DATE;
         } else if (field instanceof DoubleField) {

--- a/textdb/textdb-common/src/test/java/edu/uci/ics/textdb/common/field/SpanTest.java
+++ b/textdb/textdb-common/src/test/java/edu/uci/ics/textdb/common/field/SpanTest.java
@@ -16,16 +16,16 @@ public class SpanTest {
 
     @Test
     public void testGetters() {
-        String fieldName = "description";
+        String attributeName = "description";
         int start = 10;
         int end = 20;
         String key = "location";
         String value = "new york";
-        span = new Span(fieldName, start, end, key, value);
+        span = new Span(attributeName, start, end, key, value);
         Assert.assertEquals(start, span.getStart());
         Assert.assertEquals(end, span.getEnd());
         Assert.assertEquals(key, span.getKey());
         Assert.assertEquals(value, span.getValue());
-        Assert.assertEquals(fieldName, span.getFieldName());
+        Assert.assertEquals(attributeName, span.getAttributeName());
     }
 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -231,7 +231,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	    List<IField> outputFields = 
 	            outputAttrList.stream()
 	            .filter(attr -> ! attr.equals(SchemaConstants.SPAN_LIST_ATTRIBUTE))
-	            .map(attr -> attr.getFieldName())
+	            .map(attr -> attr.getAttributeName())
 	            .map(fieldName -> innerTuple.getField(fieldName, IField.class))
 	            .collect(Collectors.toList());
 	    

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -5,11 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.ListField;
@@ -135,8 +132,8 @@ public class JoinDistancePredicate implements IJoinPredicate {
         }
         
         // check if join attribute is TEXT or STRING
-        FieldType joinAttrType = intersectionSchema.getAttribute(this.joinAttributeName).getAttributeType();
-        if (joinAttrType != FieldType.TEXT && joinAttrType != FieldType.STRING) {
+        AttributeType joinAttrType = intersectionSchema.getAttribute(this.joinAttributeName).getAttributeType();
+        if (joinAttrType != AttributeType.TEXT && joinAttrType != AttributeType.STRING) {
             throw new DataFlowException(
                     String.format("Join attribute %s must be either TEXT or STRING.", this.joinAttributeName));
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -135,7 +135,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
         }
         
         // check if join attribute is TEXT or STRING
-        FieldType joinAttrType = intersectionSchema.getAttribute(this.joinAttributeName).getFieldType();
+        FieldType joinAttrType = intersectionSchema.getAttribute(this.joinAttributeName).getAttributeType();
         if (joinAttrType != FieldType.TEXT && joinAttrType != FieldType.STRING) {
             throw new DataFlowException(
                     String.format("Join attribute %s must be either TEXT or STRING.", this.joinAttributeName));

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -195,13 +195,13 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	        Span outerSpan = outerSpanIter.next();
 	        // Check if the field matches the filed over which we want to join.
 	        // If not return null.
-	        if (!outerSpan.getFieldName().equals(this.joinAttributeName)) {
+	        if (!outerSpan.getAttributeName().equals(this.joinAttributeName)) {
 	            continue;
 	        }
 	        Iterator<Span> innerSpanIter = innerSpanList.iterator();
 	        while (innerSpanIter.hasNext()) {
 	            Span innerSpan = innerSpanIter.next();
-	            if (!innerSpan.getFieldName().equals(this.joinAttributeName)) {
+	            if (!innerSpan.getAttributeName().equals(this.joinAttributeName)) {
 	                continue;
 	            }
 	            Integer threshold = this.getThreshold();
@@ -209,11 +209,11 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	                    && Math.abs(outerSpan.getEnd() - innerSpan.getEnd()) <= threshold) {
 	                Integer newSpanStartIndex = Math.min(outerSpan.getStart(), innerSpan.getStart());
 	                Integer newSpanEndIndex = Math.max(outerSpan.getEnd(), innerSpan.getEnd());
-	                String fieldName = this.joinAttributeName;
-	                String fieldValue = (String) innerTuple.getField(fieldName).getValue();
+	                String attributeName = this.joinAttributeName;
+	                String fieldValue = (String) innerTuple.getField(attributeName).getValue();
 	                String newFieldValue = fieldValue.substring(newSpanStartIndex, newSpanEndIndex);
 	                String spanKey = outerSpan.getKey() + "_" + innerSpan.getKey();
-	                Span newSpan = new Span(fieldName, newSpanStartIndex, newSpanEndIndex, spanKey, newFieldValue);
+	                Span newSpan = new Span(attributeName, newSpanStartIndex, newSpanEndIndex, spanKey, newFieldValue);
 	                newJoinSpanList.add(newSpan);
 	            }
 	        }
@@ -229,7 +229,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	            outputAttrList.stream()
 	            .filter(attr -> ! attr.equals(SchemaConstants.SPAN_LIST_ATTRIBUTE))
 	            .map(attr -> attr.getAttributeName())
-	            .map(fieldName -> innerTuple.getField(fieldName, IField.class))
+	            .map(attributeName -> innerTuple.getField(attributeName, IField.class))
 	            .collect(Collectors.toList());
 	    
 	    outputFields.add(new ListField<>(newJoinSpanList));
@@ -242,12 +242,12 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	 * 
 	 * @param innerTuple
 	 * @param outerTuple
-	 * @param fieldName
+	 * @param attributeName
 	 * @return True if both the tuples have the field and the values are equal.
 	 */
-	private boolean compareField(Tuple innerTuple, Tuple outerTuple, String fieldName) {  
-	    IField innerField = innerTuple.getField(fieldName);
-	    IField outerField = outerTuple.getField(fieldName);
+	private boolean compareField(Tuple innerTuple, Tuple outerTuple, String attributeName) {
+	    IField innerField = innerTuple.getField(attributeName);
+	    IField outerField = outerTuple.getField(attributeName);
 	    
 	    if (innerField == null ||  outerField == null) {
 	        return false;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -48,12 +48,12 @@ public class ComparableMatcher<T extends Comparable<T>> extends AbstractSingleIn
         Attribute attribute = predicate.getAttribute();
         DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
 
-        String fieldName = attribute.getAttributeName();
+        String attributeName = attribute.getAttributeName();
 
         T value;
         T threshold;
         try {
-            value = (T) inputTuple.getField(fieldName).getValue();
+            value = (T) inputTuple.getField(attributeName).getValue();
             threshold = (T) predicate.getThreshold();
         } catch (ClassCastException e) {
             return null;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/comparablematcher/ComparableMatcher.java
@@ -48,7 +48,7 @@ public class ComparableMatcher<T extends Comparable<T>> extends AbstractSingleIn
         Attribute attribute = predicate.getAttribute();
         DataConstants.NumberMatchingType operatorType = predicate.getMatchingType();
 
-        String fieldName = attribute.getFieldName();
+        String fieldName = attribute.getAttributeName();
 
         T value;
         T threshold;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -239,7 +239,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
         for (String fieldName : attributeNames) {
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
-            FieldType fieldType = inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = inputSchema.getAttribute(fieldName).getAttributeType();
 
             // if attribute type is not TEXT, then key needs to match the
             // fieldValue exactly

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -237,15 +237,15 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
         List<String> attributeNames = predicate.getAttributeNames();
         List<Span> matchingResults = new ArrayList<>();
 
-        for (String fieldName : attributeNames) {
-            String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
-            AttributeType attributeType = inputSchema.getAttribute(fieldName).getAttributeType();
+        for (String attributeName : attributeNames) {
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
+            AttributeType attributeType = inputSchema.getAttribute(attributeName).getAttributeType();
 
             // if attribute type is not TEXT, then key needs to match the
             // fieldValue exactly
             if (attributeType != AttributeType.TEXT) {
                 if (fieldValue.equals(key)) {
-                    matchingResults.add(new Span(fieldName, 0, fieldValue.length(), key, fieldValue));
+                    matchingResults.add(new Span(attributeName, 0, fieldValue.length(), key, fieldValue));
                 }
             }
             // if attribute type is TEXT, then key can match a substring of
@@ -258,7 +258,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                     int start = matcher.start();
                     int end = matcher.end();
 
-                    matchingResults.add(new Span(fieldName, start, end, key, fieldValue.substring(start, end)));
+                    matchingResults.add(new Span(attributeName, start, end, key, fieldValue.substring(start, end)));
                 }
             }
         }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
@@ -239,11 +239,11 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
         for (String fieldName : attributeNames) {
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
-            FieldType fieldType = inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = inputSchema.getAttribute(fieldName).getAttributeType();
 
             // if attribute type is not TEXT, then key needs to match the
             // fieldValue exactly
-            if (fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.TEXT) {
                 if (fieldValue.equals(key)) {
                     matchingResults.add(new Span(fieldName, 0, fieldValue.length(), key, fieldValue));
                 }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -90,7 +90,7 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
          * returned is 15. So we need to filter those 5 spans for attribute B.
          */
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();   
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             
             // types other than TEXT and STRING: throw Exception for now
             if (fieldType != FieldType.TEXT && fieldType != FieldType.STRING) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -89,8 +89,8 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
          * 5 matching tokens, and we set threshold to 10, the number of spans
          * returned is 15. So we need to filter those 5 spans for attribute B.
          */
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
             
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.TEXT && attributeType != AttributeType.STRING) {
@@ -99,7 +99,7 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
             
             List<Span> fieldSpans = 
                     relevantSpans.stream()
-                    .filter(span -> span.getFieldName().equals(fieldName))
+                    .filter(span -> span.getAttributeName().equals(attributeName))
                     .filter(span -> queryTokens.contains(span.getKey()))
                     .collect(Collectors.toList());
             

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/fuzzytokenmatcher/FuzzyTokenMatcher.java
@@ -5,7 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -90,10 +90,10 @@ public class FuzzyTokenMatcher extends AbstractSingleInputOperator {
          * returned is 15. So we need to filter those 5 spans for attribute B.
          */
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.TEXT && fieldType != FieldType.STRING) {
+            if (attributeType != AttributeType.TEXT && attributeType != AttributeType.STRING) {
                 throw new DataFlowException("FuzzyTokenMatcher: Fields other than TEXT or STRING are not supported");
             }
             

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -133,11 +133,11 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         // get the span list only with the joinAttributeName
         ListField<Span> innerSpanListField = innerTuple.getField(SchemaConstants.SPAN_LIST);
         List<Span> innerRelevantSpanList = innerSpanListField.getValue().stream()
-                .filter(span -> span.getFieldName().equals(innerJoinAttrName)).collect(Collectors.toList());
+                .filter(span -> span.getAttributeName().equals(innerJoinAttrName)).collect(Collectors.toList());
         
         ListField<Span> outerSpanListField = outerTuple.getField(SchemaConstants.SPAN_LIST);
         List<Span> outerRelevantSpanList = outerSpanListField.getValue().stream()
-                .filter(span -> span.getFieldName().equals(outerJoinAttrName)).collect(Collectors.toList());
+                .filter(span -> span.getAttributeName().equals(outerJoinAttrName)).collect(Collectors.toList());
         
         // get a set of span's values (since multiple spans may have the same value)
         Set<String> innerSpanValueSet = innerRelevantSpanList.stream()
@@ -211,7 +211,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
     }
     
     private Span addFieldPrefix(Span span, String prefix) {
-        return new Span(prefix+span.getFieldName(), 
+        return new Span(prefix+span.getAttributeName(),
                 span.getStart(), span.getEnd(), span.getKey(), span.getValue(), span.getTokenOffset());
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -96,7 +96,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         
         for (Attribute attr : innerOperatorSchema.getAttributes()) {
             String attrName = attr.getAttributeName();
-            FieldType attrType = attr.getFieldType();
+            FieldType attrType = attr.getAttributeType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 
                     || attrName.equals(SchemaConstants.PAYLOAD)) {
@@ -106,7 +106,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         }
         for (Attribute attr : outerOperatorSchema.getAttributes()) {
             String attrName = attr.getAttributeName();
-            FieldType attrType = attr.getFieldType();
+            FieldType attrType = attr.getAttributeType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 
                     || attrName.equals(SchemaConstants.PAYLOAD)) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -3,11 +3,8 @@ package edu.uci.ics.textdb.dataflow.join;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.field.IDField;
@@ -96,7 +93,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         
         for (Attribute attr : innerOperatorSchema.getAttributes()) {
             String attrName = attr.getAttributeName();
-            FieldType attrType = attr.getAttributeType();
+            AttributeType attrType = attr.getAttributeType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 
                     || attrName.equals(SchemaConstants.PAYLOAD)) {
@@ -106,7 +103,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         }
         for (Attribute attr : outerOperatorSchema.getAttributes()) {
             String attrName = attr.getAttributeName();
-            FieldType attrType = attr.getAttributeType();
+            AttributeType attrType = attr.getAttributeType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 
                     || attrName.equals(SchemaConstants.PAYLOAD)) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -95,7 +95,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         outputAttributeList.add(SchemaConstants._ID_ATTRIBUTE);
         
         for (Attribute attr : innerOperatorSchema.getAttributes()) {
-            String attrName = attr.getFieldName();
+            String attrName = attr.getAttributeName();
             FieldType attrType = attr.getFieldType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 
@@ -105,7 +105,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
             outputAttributeList.add(new Attribute(INNER_PREFIX + attrName, attrType));
         }
         for (Attribute attr : outerOperatorSchema.getAttributes()) {
-            String attrName = attr.getFieldName();
+            String attrName = attr.getAttributeName();
             FieldType attrType = attr.getFieldType();
             // ignore _id, spanList, and payload
             if (attrName.equals(SchemaConstants._ID) || attrName.equals(SchemaConstants.SPAN_LIST) 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -98,7 +98,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
@@ -145,7 +145,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
@@ -242,7 +242,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -9,7 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.DataConstants;
@@ -98,16 +98,16 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
             }
 
             // for STRING type, the query should match the fieldValue completely
-            if (fieldType == FieldType.STRING) {
+            if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
                     Span span = new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
                     matchingResults.add(span);
@@ -116,7 +116,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
 
             // for TEXT type, every token in the query should be present in span
             // list for this field
-            if (fieldType == FieldType.TEXT) {
+            if (attributeType == AttributeType.TEXT) {
                 List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getFieldName().equals(fieldName))
                         .collect(Collectors.toList());
 
@@ -145,16 +145,16 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
             }
 
             // for STRING type, the query should match the fieldValue completely
-            if (fieldType == FieldType.STRING) {
+            if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
                     matchingResults.add(new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
                 }
@@ -162,7 +162,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
 
             // for TEXT type, spans need to be reconstructed according to the
             // phrase query
-            if (fieldType == FieldType.TEXT) {
+            if (attributeType == AttributeType.TEXT) {
                 List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getFieldName().equals(fieldName))
                         .collect(Collectors.toList());
 
@@ -242,22 +242,22 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
             }
 
             // for STRING type, the query should match the fieldValue completely
-            if (fieldType == FieldType.STRING) {
+            if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
                     matchingResults.add(new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
                 }
             }
 
-            if (fieldType == FieldType.TEXT) {
+            if (attributeType == AttributeType.TEXT) {
                 String regex = predicate.getQuery().toLowerCase();
                 Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
                 Matcher matcher = pattern.matcher(fieldValue.toLowerCase());

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcher.java
@@ -97,9 +97,9 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
-            String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -109,7 +109,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             // for STRING type, the query should match the fieldValue completely
             if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
-                    Span span = new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
+                    Span span = new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
                     matchingResults.add(span);
                 }
             }
@@ -117,7 +117,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             // for TEXT type, every token in the query should be present in span
             // list for this field
             if (attributeType == AttributeType.TEXT) {
-                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getFieldName().equals(fieldName))
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
                         .collect(Collectors.toList());
 
                 if (isAllQueryTokensPresent(fieldSpanList, predicate.getQueryTokenSet())) {
@@ -144,9 +144,9 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
         List<Span> relevantSpans = filterRelevantSpans(payload);
         List<Span> matchingResults = new ArrayList<>();
 
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
-            String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -156,14 +156,14 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             // for STRING type, the query should match the fieldValue completely
             if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
-                    matchingResults.add(new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
                 }
             }
 
             // for TEXT type, spans need to be reconstructed according to the
             // phrase query
             if (attributeType == AttributeType.TEXT) {
-                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getFieldName().equals(fieldName))
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
                         .collect(Collectors.toList());
 
                 if (!isAllQueryTokensPresent(fieldSpanList, predicate.getQueryTokenSet())) {
@@ -219,7 +219,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
                     int combinedSpanStartIndex = fieldSpanList.get(iter).getStart();
                     int combinedSpanEndIndex = fieldSpanList.get(iter + queryTokenList.size() - 1).getEnd();
 
-                    Span combinedSpan = new Span(fieldName, combinedSpanStartIndex, combinedSpanEndIndex, predicate.getQuery(),
+                    Span combinedSpan = new Span(attributeName, combinedSpanStartIndex, combinedSpanEndIndex, predicate.getQuery(),
                             fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
                     matchingResults.add(combinedSpan);
                     iter = iter + queryTokenList.size();
@@ -241,9 +241,9 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     private Tuple computeSubstringMatchingResult(Tuple sourceTuple) throws DataFlowException {
         List<Span> matchingResults = new ArrayList<>();
 
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
-            String fieldValue = sourceTuple.getField(fieldName).getValue().toString();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -253,7 +253,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             // for STRING type, the query should match the fieldValue completely
             if (attributeType == AttributeType.STRING) {
                 if (fieldValue.equals(predicate.getQuery())) {
-                    matchingResults.add(new Span(fieldName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
                 }
             }
 
@@ -265,7 +265,7 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
                     int start = matcher.start();
                     int end = matcher.end();
 
-                    matchingResults.add(new Span(fieldName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
+                    matchingResults.add(new Span(attributeName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
                 }
             }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -134,8 +134,8 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     private Query buildConjunctionQuery() throws DataFlowException {
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -144,13 +144,13 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
             }
 
             if (attributeType == AttributeType.STRING) {
-                Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery));
+                Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery));
                 booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
             }
             if (attributeType == AttributeType.TEXT) {
                 BooleanQuery.Builder fieldQueryBuilder = new BooleanQuery.Builder();
                 for (String token : this.predicate.getQueryTokenSet()) {
-                    Query termQuery = new TermQuery(new Term(fieldName, token.toLowerCase()));
+                    Query termQuery = new TermQuery(new Term(attributeName, token.toLowerCase()));
                     fieldQueryBuilder.add(termQuery, BooleanClause.Occur.MUST);
                 }
                 booleanQueryBuilder.add(fieldQueryBuilder.build(), BooleanClause.Occur.SHOULD);
@@ -164,8 +164,8 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     private Query buildPhraseQuery() throws DataFlowException {
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -174,19 +174,19 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
             }
 
             if (attributeType == AttributeType.STRING) {
-                Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery));
+                Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery));
                 booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
             }
             if (attributeType == AttributeType.TEXT) {
                 if (this.predicate.getQueryTokenList().size() == 1) {
-                    Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery.toLowerCase()));
+                    Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery.toLowerCase()));
                     booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
                 } else {
                     PhraseQuery.Builder phraseQueryBuilder = new PhraseQuery.Builder();
                     for (int i = 0; i < this.predicate.getQueryTokensWithStopwords().size(); i++) {
                         if (!StandardAnalyzer.STOP_WORDS_SET
                                 .contains(this.predicate.getQueryTokensWithStopwords().get(i))) {
-                            phraseQueryBuilder.add(new Term(fieldName,
+                            phraseQueryBuilder.add(new Term(attributeName,
                                     this.predicate.getQueryTokensWithStopwords().get(i).toLowerCase()), i);
                         }
                     }
@@ -201,8 +201,8 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
     }
 
     private Query buildScanQuery() throws DataFlowException {
-        for (String fieldName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -135,7 +135,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
@@ -165,7 +165,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
@@ -202,7 +202,7 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
 
     private Query buildScanQuery() throws DataFlowException {
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
             if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/keywordmatch/KeywordMatcherSourceOperator.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.dataflow.keywordmatch;
 
+import edu.uci.ics.textdb.api.common.AttributeType;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -10,7 +11,6 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
@@ -135,19 +135,19 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException(
                         "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
             }
 
-            if (fieldType == FieldType.STRING) {
+            if (attributeType == AttributeType.STRING) {
                 Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery));
                 booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
             }
-            if (fieldType == FieldType.TEXT) {
+            if (attributeType == AttributeType.TEXT) {
                 BooleanQuery.Builder fieldQueryBuilder = new BooleanQuery.Builder();
                 for (String token : this.predicate.getQueryTokenSet()) {
                     Query termQuery = new TermQuery(new Term(fieldName, token.toLowerCase()));
@@ -165,19 +165,19 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException(
                         "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
             }
 
-            if (fieldType == FieldType.STRING) {
+            if (attributeType == AttributeType.STRING) {
                 Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery));
                 booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
             }
-            if (fieldType == FieldType.TEXT) {
+            if (attributeType == AttributeType.TEXT) {
                 if (this.predicate.getQueryTokenList().size() == 1) {
                     Query termQuery = new TermQuery(new Term(fieldName, this.keywordQuery.toLowerCase()));
                     booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
@@ -202,10 +202,10 @@ public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator im
 
     private Query buildScanQuery() throws DataFlowException {
         for (String fieldName : this.predicate.getAttributeNames()) {
-            FieldType fieldType = this.inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = this.inputSchema.getAttribute(fieldName).getAttributeType();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException(
                         "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
             }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/nlpextrator/NlpExtractor.java
@@ -102,7 +102,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
     
     /**
      * @param iField
-     * @param fieldName
+     * @param attributeName
      * @return
      * @about This function takes an IField(TextField) and a String (the field's
      *        name) as input and uses the Stanford NLP package to process the
@@ -137,7 +137,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
      *           <p>
      *           For Example: With TextField value: "Microsoft, Google and
      *           Facebook are organizations while Donald Trump and Barack Obama
-     *           are persons", with fieldName: Sentence1 and inputTokenType is
+     *           are persons", with attributeName: Sentence1 and inputTokenType is
      *           Organization. Since the inputTokenType require us to use
      *           NamedEntity Annotator in the Stanford NLP package, the
      *           nlpTypeIndicator would be set to "NE". The pipeline would set
@@ -151,7 +151,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
      *           to the returned list. In this case, token "Microsoft" would be
      *           span: ["Sentence1", 0, 9, Organization, "Microsoft"]
      */
-    private List<Span> extractNlpSpans(IField iField, String fieldName) {
+    private List<Span> extractNlpSpans(IField iField, String attributeName) {
         List<Span> spanList = new ArrayList<>();
         String text = (String) iField.getValue();
         Properties props = new Properties();
@@ -195,10 +195,10 @@ public class NlpExtractor extends AbstractSingleInputOperator {
                     int end = token.get(CoreAnnotations.CharacterOffsetEndAnnotation.class);
                     String word = token.get(CoreAnnotations.TextAnnotation.class);
 
-                    Span span = new Span(fieldName, start, end, thisNlpTokenType.toString(), word);
+                    Span span = new Span(attributeName, start, end, thisNlpTokenType.toString(), word);
                     if (spanList.size() >= 1 && (predicate.getNlpTypeIndicator().equals("NE_ALL"))) {
                         Span previousSpan = spanList.get(spanList.size() - 1);
-                        if (previousSpan.getFieldName().equals(span.getFieldName())
+                        if (previousSpan.getAttributeName().equals(span.getAttributeName())
                                 && (span.getStart() - previousSpan.getEnd() <= 1)
                                 && previousSpan.getKey().equals(span.getKey())) {
                             Span newSpan = mergeTwoSpans(previousSpan, span);
@@ -220,7 +220,7 @@ public class NlpExtractor extends AbstractSingleInputOperator {
      * @about This function takes two spans as input and merges them as a new
      *        span
      *        <p>
-     *        Two spans with fieldName, start, end, key, value: previousSpan:
+     *        Two spans with attributeName, start, end, key, value: previousSpan:
      *        "Doc1", 10, 13, "Location", "New" currentSpan : "Doc1", 14, 18,
      *        "Location", "York"
      *        <p>
@@ -228,12 +228,12 @@ public class NlpExtractor extends AbstractSingleInputOperator {
      *        <p>
      *        The caller needs to make sure: 1. The two spans are adjacent. 2.
      *        The two spans are in the same field. They should have the same
-     *        fieldName. 3. The two spans have the same key (Organization,
+     *        attributeName. 3. The two spans have the same key (Organization,
      *        Person,... etc)
      */
     private Span mergeTwoSpans(Span previousSpan, Span currentSpan) {
         String newWord = previousSpan.getValue() + " " + currentSpan.getValue();
-        return new Span(previousSpan.getFieldName(), previousSpan.getStart(), currentSpan.getEnd(),
+        return new Span(previousSpan.getAttributeName(), previousSpan.getStart(), currentSpan.getEnd(),
                 previousSpan.getKey(), newWord);
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/projection/ProjectionOperator.java
@@ -27,7 +27,7 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
         List<Attribute> outputAttributes = 
                 inputSchema.getAttributes()
                 .stream()
-                .filter(attr -> predicate.getProjectionFields().contains(attr.getFieldName().toLowerCase()))
+                .filter(attr -> predicate.getProjectionFields().contains(attr.getAttributeName().toLowerCase()))
                 .collect(Collectors.toList());
         
         if (outputAttributes.size() != predicate.getProjectionFields().size()) {
@@ -51,7 +51,7 @@ public class ProjectionOperator extends AbstractSingleInputOperator {
         IField[] outputFields =
                 outputSchema.getAttributes()
                         .stream()
-                        .map(attr -> inputTuple.getField(attr.getFieldName()))
+                        .map(attr -> inputTuple.getField(attr.getAttributeName()))
                         .toArray(IField[]::new);
 
         return new Tuple(outputSchema, outputFields);

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/queryrewriter/QueryRewriter.java
@@ -3,7 +3,7 @@ package edu.uci.ics.textdb.dataflow.queryrewriter;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -30,7 +30,7 @@ public class QueryRewriter implements IOperator {
     private boolean allSegmentations = false;
 
     public static final String QUERYLIST = "querylist";
-    public static final Attribute QUERYLIST_ATTR = new Attribute(QUERYLIST, FieldType.LIST);
+    public static final Attribute QUERYLIST_ATTR = new Attribute(QUERYLIST, AttributeType.LIST);
     public static final Schema SCHEMA_QUERY_LIST = new Schema(QUERYLIST_ATTR);
 
     private Tuple sourceTuple;

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -3,7 +3,7 @@ package edu.uci.ics.textdb.dataflow.regexmatch;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
@@ -124,11 +124,11 @@ public class RegexMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : attributeNames) {
-            FieldType fieldType = inputSchema.getAttribute(fieldName).getAttributeType();
+            AttributeType attributeType = inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = inputTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
-            if (fieldType != FieldType.STRING && fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
                 throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
             }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -123,9 +123,9 @@ public class RegexMatcher extends AbstractSingleInputOperator {
 
         List<Span> matchingResults = new ArrayList<>();
 
-        for (String fieldName : attributeNames) {
-            AttributeType attributeType = inputSchema.getAttribute(fieldName).getAttributeType();
-            String fieldValue = inputTuple.getField(fieldName).getValue().toString();
+        for (String attributeName : attributeNames) {
+            AttributeType attributeType = inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now
             if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
@@ -134,10 +134,10 @@ public class RegexMatcher extends AbstractSingleInputOperator {
 
             switch (regexEngine) {
             case JavaRegex:
-                matchingResults.addAll(javaRegexMatch(fieldValue, fieldName));
+                matchingResults.addAll(javaRegexMatch(fieldValue, attributeName));
                 break;
             case RE2J:
-                matchingResults.addAll(re2jRegexMatch(fieldValue, fieldName));
+                matchingResults.addAll(re2jRegexMatch(fieldValue, attributeName));
                 break;
             }
         }
@@ -153,26 +153,26 @@ public class RegexMatcher extends AbstractSingleInputOperator {
         return inputTuple;
     }
 
-    private List<Span> javaRegexMatch(String fieldValue, String fieldName) {
+    private List<Span> javaRegexMatch(String fieldValue, String attributeName) {
         List<Span> matchingResults = new ArrayList<>();
         java.util.regex.Matcher javaMatcher = this.javaPattern.matcher(fieldValue);
         while (javaMatcher.find()) {
             int start = javaMatcher.start();
             int end = javaMatcher.end();
             matchingResults.add(
-                    new Span(fieldName, start, end, this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
+                    new Span(attributeName, start, end, this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
         }
         return matchingResults;
     }
 
-    private List<Span> re2jRegexMatch(String fieldValue, String fieldName) {
+    private List<Span> re2jRegexMatch(String fieldValue, String attributeName) {
         List<Span> matchingResults = new ArrayList<>();
         com.google.re2j.Matcher re2jMatcher = this.re2jPattern.matcher(fieldValue);
         while (re2jMatcher.find()) {
             int start = re2jMatcher.start();
             int end = re2jMatcher.end();
             matchingResults.add(
-                    new Span(fieldName, start, end, this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
+                    new Span(attributeName, start, end, this.regexPredicate.getRegex(), fieldValue.substring(start, end)));
         }
         return matchingResults;
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexMatcher.java
@@ -124,7 +124,7 @@ public class RegexMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         for (String fieldName : attributeNames) {
-            FieldType fieldType = inputSchema.getAttribute(fieldName).getFieldType();
+            FieldType fieldType = inputSchema.getAttribute(fieldName).getAttributeType();
             String fieldValue = inputTuple.getField(fieldName).getValue().toString();
 
             // types other than TEXT and STRING: throw Exception for now

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/PlanGenUtils.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/plangen/PlanGenUtils.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.plangen.operatorbuilder.DictionaryMatcherBuilder;
@@ -78,18 +78,18 @@ public class PlanGenUtils {
      * @return true if the string is an attribute type
      */
     public static boolean isValidAttributeType(String attributeType) {
-        return Stream.of(FieldType.values()).anyMatch(type -> type.toString().toLowerCase().equals(attributeType.toLowerCase()));
+        return Stream.of(AttributeType.values()).anyMatch(type -> type.toString().toLowerCase().equals(attributeType.toLowerCase()));
     }
     
     /**
-     * This function converts a attributeTypeString to FieldType (case insensitive). 
+     * This function converts a attributeTypeString to AttributeType (case insensitive).
      * It returns null if string is not a valid type.
      * 
      * @param attributeTypeStr
-     * @return FieldType, null if attributeTypeStr is not a valid type.
+     * @return AttributeType, null if attributeTypeStr is not a valid type.
      */
-    public static FieldType convertAttributeType(String attributeTypeStr) {
-        return Stream.of(FieldType.values())
+    public static AttributeType convertAttributeType(String attributeTypeStr) {
+        return Stream.of(AttributeType.values())
                 .filter(typeStr -> typeStr.toString().toLowerCase().equals(attributeTypeStr.toLowerCase()))
                 .findAny().orElse(null);
     }

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/planstore/PlanStoreConstants.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/planstore/PlanStoreConstants.java
@@ -1,7 +1,7 @@
 package edu.uci.ics.textdb.planstore;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Schema;
 
 import java.util.regex.Pattern;
@@ -23,9 +23,9 @@ public class PlanStoreConstants {
     public static final String DESCRIPTION = "desc";
     public static final String LOGICAL_PLAN_JSON = "planJson";
 
-    public static final Attribute NAME_ATTR = new Attribute(NAME, FieldType.STRING);
-    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, FieldType.STRING);
-    public static final Attribute LOGICAL_PLAN_JSON_ATTR = new Attribute(LOGICAL_PLAN_JSON, FieldType.STRING);
+    public static final Attribute NAME_ATTR = new Attribute(NAME, AttributeType.STRING);
+    public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, AttributeType.STRING);
+    public static final Attribute LOGICAL_PLAN_JSON_ATTR = new Attribute(LOGICAL_PLAN_JSON, AttributeType.STRING);
 
     public static final Attribute[] ATTRIBUTES_PLAN = {NAME_ATTR, DESCRIPTION_ATTR, LOGICAL_PLAN_JSON_ATTR};
     public static final Schema SCHEMA_PLAN = new Schema(ATTRIBUTES_PLAN);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
@@ -195,7 +195,7 @@ public class JoinDistanceTest {
         String fuzzyTokenQuery = "this writer writes well";
         double thresholdRatio = 0.25;
         List<String> textAttributeNames = JoinTestConstants.BOOK_SCHEMA.getAttributes().stream()
-                .filter(attr -> attr.getFieldType() != FieldType.TEXT)
+                .filter(attr -> attr.getAttributeType() != FieldType.TEXT)
                 .map(Attribute::getAttributeName).collect(Collectors.toList());
         FuzzyTokenPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(fuzzyTokenQuery, textAttributeNames,
                 LuceneAnalyzerConstants.getStandardAnalyzer(), thresholdRatio);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
@@ -10,7 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -195,7 +195,7 @@ public class JoinDistanceTest {
         String fuzzyTokenQuery = "this writer writes well";
         double thresholdRatio = 0.25;
         List<String> textAttributeNames = JoinTestConstants.BOOK_SCHEMA.getAttributes().stream()
-                .filter(attr -> attr.getAttributeType() != FieldType.TEXT)
+                .filter(attr -> attr.getAttributeType() != AttributeType.TEXT)
                 .map(Attribute::getAttributeName).collect(Collectors.toList());
         FuzzyTokenPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(fuzzyTokenQuery, textAttributeNames,
                 LuceneAnalyzerConstants.getStandardAnalyzer(), thresholdRatio);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
@@ -196,7 +196,7 @@ public class JoinDistanceTest {
         double thresholdRatio = 0.25;
         List<String> textAttributeNames = JoinTestConstants.BOOK_SCHEMA.getAttributes().stream()
                 .filter(attr -> attr.getFieldType() != FieldType.TEXT)
-                .map(Attribute::getFieldName).collect(Collectors.toList());
+                .map(Attribute::getAttributeName).collect(Collectors.toList());
         FuzzyTokenPredicate fuzzyPredicateInner = new FuzzyTokenPredicate(fuzzyTokenQuery, textAttributeNames,
                 LuceneAnalyzerConstants.getStandardAnalyzer(), thresholdRatio);
         FuzzyTokenMatcherSourceOperator fuzzyMatcherInner = new FuzzyTokenMatcherSourceOperator(fuzzyPredicateInner, BOOK_TABLE);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestConstants.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestConstants.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.field.IntegerField;
@@ -19,11 +19,11 @@ public class JoinTestConstants {
     public static final String PAGES = "numberOfPages";
     public static final String REVIEW = "reviewOfBook";
     
-    public static final Attribute ID_ATTR = new Attribute(ID, FieldType.INTEGER);
-    public static final Attribute AUTHOR_ATTR = new Attribute(AUTHOR, FieldType.STRING);
-    public static final Attribute TITLE_ATTR = new Attribute(TITLE, FieldType.STRING);
-    public static final Attribute PAGES_ATTR = new Attribute(PAGES, FieldType.INTEGER);
-    public static final Attribute REVIEW_ATTR = new Attribute(REVIEW, FieldType.TEXT);
+    public static final Attribute ID_ATTR = new Attribute(ID, AttributeType.INTEGER);
+    public static final Attribute AUTHOR_ATTR = new Attribute(AUTHOR, AttributeType.STRING);
+    public static final Attribute TITLE_ATTR = new Attribute(TITLE, AttributeType.STRING);
+    public static final Attribute PAGES_ATTR = new Attribute(PAGES, AttributeType.INTEGER);
+    public static final Attribute REVIEW_ATTR = new Attribute(REVIEW, AttributeType.TEXT);
     
     public static final Schema BOOK_SCHEMA = new Schema(ID_ATTR, AUTHOR_ATTR, TITLE_ATTR, PAGES_ATTR, REVIEW_ATTR);
        
@@ -107,9 +107,9 @@ public class JoinTestConstants {
     public static final String NEWS_TITLE = "news_title";
     public static final String NEWS_BODY = "news_body";
     
-    public static final Attribute NEWS_NUM_ATTR = new Attribute(NEWS_NUMBER, FieldType.INTEGER);
-    public static final Attribute NEWS_TITLE_ATTR = new Attribute(NEWS_TITLE, FieldType.TEXT);
-    public static final Attribute NEWS_BODY_ATTR = new Attribute(NEWS_BODY, FieldType.TEXT);
+    public static final Attribute NEWS_NUM_ATTR = new Attribute(NEWS_NUMBER, AttributeType.INTEGER);
+    public static final Attribute NEWS_TITLE_ATTR = new Attribute(NEWS_TITLE, AttributeType.TEXT);
+    public static final Attribute NEWS_BODY_ATTR = new Attribute(NEWS_BODY, AttributeType.TEXT);
     
     public static final Schema NEWS_SCHEMA = new Schema(NEWS_NUM_ATTR, NEWS_TITLE_ATTR, NEWS_BODY_ATTR);
     

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
@@ -182,7 +182,7 @@ public class JoinTestHelper {
         List<IField> newFields = new ArrayList<>();
         for (int i = 0; i < originalAttributes.size(); i++) {
             if (i == fieldIndex) {
-                newAttributes.add(new Attribute(originalAttributes.get(i).getFieldName(), 
+                newAttributes.add(new Attribute(originalAttributes.get(i).getAttributeName(),
                         Utils.getFieldType(newField)));
                 newFields.add(newField);
             } else {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
@@ -183,7 +183,7 @@ public class JoinTestHelper {
         for (int i = 0; i < originalAttributes.size(); i++) {
             if (i == fieldIndex) {
                 newAttributes.add(new Attribute(originalAttributes.get(i).getAttributeName(),
-                        Utils.getFieldType(newField)));
+                        Utils.getAttributeType(newField)));
                 newFields.add(newField);
             } else {
                 newAttributes.add(originalAttributes.get(i));

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/keywordTestConstants.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/keywordmatch/keywordTestConstants.java
@@ -3,11 +3,8 @@ package edu.uci.ics.textdb.dataflow.keywordmatch;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.DoubleField;
 import edu.uci.ics.textdb.common.field.IntegerField;
 import edu.uci.ics.textdb.common.field.StringField;
@@ -25,16 +22,16 @@ public class keywordTestConstants {
     public static final String ABSTRACT = "abstract";
     public static final String ZIPF_SCORE = "zipf_score";
 
-    public static final Attribute PMID_ATTR = new Attribute(PMID, FieldType.INTEGER);
-    public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, FieldType.TEXT);
-    public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, FieldType.TEXT);
-    public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, FieldType.TEXT);
-    public static final Attribute JOURNAL_ISSUE_ATTR = new Attribute(JOURNAL_ISSUE, FieldType.STRING);
-    public static final Attribute JOURNAL_TITLE_ATTR = new Attribute(JOURNAL_TITLE, FieldType.TEXT);
-    public static final Attribute KEYWORDS_ATTR = new Attribute(KEYWORDS, FieldType.TEXT);
-    public static final Attribute MESH_HEADINGS_ATTR = new Attribute(MESH_HEADINGS, FieldType.TEXT);
-    public static final Attribute ABSTRACT_ATTR = new Attribute(ABSTRACT, FieldType.TEXT);
-    public static final Attribute ZIPF_SCORE_ATTR = new Attribute(ZIPF_SCORE, FieldType.DOUBLE);
+    public static final Attribute PMID_ATTR = new Attribute(PMID, AttributeType.INTEGER);
+    public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, AttributeType.TEXT);
+    public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, AttributeType.TEXT);
+    public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, AttributeType.TEXT);
+    public static final Attribute JOURNAL_ISSUE_ATTR = new Attribute(JOURNAL_ISSUE, AttributeType.STRING);
+    public static final Attribute JOURNAL_TITLE_ATTR = new Attribute(JOURNAL_TITLE, AttributeType.TEXT);
+    public static final Attribute KEYWORDS_ATTR = new Attribute(KEYWORDS, AttributeType.TEXT);
+    public static final Attribute MESH_HEADINGS_ATTR = new Attribute(MESH_HEADINGS, AttributeType.TEXT);
+    public static final Attribute ABSTRACT_ATTR = new Attribute(ABSTRACT, AttributeType.TEXT);
+    public static final Attribute ZIPF_SCORE_ATTR = new Attribute(ZIPF_SCORE, AttributeType.DOUBLE);
 
     public static final Attribute[] ATTRIBUTES_MEDLINE = { PMID_ATTR, AFFILIATION_ATTR, ARTICLE_TITLE_ATTR,
             AUTHORS_ATTR, JOURNAL_ISSUE_ATTR, JOURNAL_TITLE_ATTR, KEYWORDS_ATTR, MESH_HEADINGS_ATTR, ABSTRACT_ATTR,

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTestConstants.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/nlpextractor/NlpExtractorTestConstants.java
@@ -5,11 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.Span;
 import edu.uci.ics.textdb.common.field.TextField;
 import edu.uci.ics.textdb.common.utils.Utils;
@@ -23,9 +20,9 @@ public class NlpExtractorTestConstants {
     public static final String SENTENCE_ONE = "sentence_one";
     public static final String SENTENCE_TWO = "sentence_two";
 
-    public static final Attribute SENTENCE_ONE_ATTR = new Attribute(SENTENCE_ONE, FieldType.TEXT);
+    public static final Attribute SENTENCE_ONE_ATTR = new Attribute(SENTENCE_ONE, AttributeType.TEXT);
 
-    public static final Attribute SENTENCE_TWO_ATTR = new Attribute(SENTENCE_TWO, FieldType.TEXT);
+    public static final Attribute SENTENCE_TWO_ATTR = new Attribute(SENTENCE_TWO, AttributeType.TEXT);
 
     public static final List<Attribute> ATTRIBUTES_ONE_SENTENCE = Arrays.asList(SENTENCE_ONE_ATTR);
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantStaff.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantStaff.java
@@ -3,11 +3,8 @@ package edu.uci.ics.textdb.dataflow.regexmatch;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.StringField;
 
 /**
@@ -23,10 +20,10 @@ public class RegexTestConstantStaff {
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";
 
-    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, FieldType.STRING);
-    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, FieldType.STRING);
-    public static final Attribute EMAIL_ATTR = new Attribute(EMAIL, FieldType.STRING);
-    public static final Attribute PHONE_ATTR = new Attribute(PHONE, FieldType.STRING);
+    public static final Attribute FIRST_NAME_ATTR = new Attribute(FIRST_NAME, AttributeType.STRING);
+    public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, AttributeType.STRING);
+    public static final Attribute EMAIL_ATTR = new Attribute(EMAIL, AttributeType.STRING);
+    public static final Attribute PHONE_ATTR = new Attribute(PHONE, AttributeType.STRING);
 
     public static final Attribute[] ATTRIBUTES_STAFF = { FIRST_NAME_ATTR, LAST_NAME_ATTR, EMAIL_ATTR, PHONE_ATTR };
     public static final Schema SCHEMA_STAFF = new Schema(ATTRIBUTES_STAFF);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantsCorp.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantsCorp.java
@@ -3,11 +3,8 @@ package edu.uci.ics.textdb.dataflow.regexmatch;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.*;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.field.StringField;
 
 /**
@@ -22,9 +19,9 @@ public class RegexTestConstantsCorp {
     public static final String URL = "url";
     public static final String IP_ADDRESS = "ip";
 
-    public static final Attribute CORP_NAME_ATTR = new Attribute(CORP_NAME, FieldType.STRING);
-    public static final Attribute URL_ATTR = new Attribute(URL, FieldType.STRING);
-    public static final Attribute IP_ADDRESS_ATTR = new Attribute(IP_ADDRESS, FieldType.STRING);
+    public static final Attribute CORP_NAME_ATTR = new Attribute(CORP_NAME, AttributeType.STRING);
+    public static final Attribute URL_ATTR = new Attribute(URL, AttributeType.STRING);
+    public static final Attribute IP_ADDRESS_ATTR = new Attribute(IP_ADDRESS, AttributeType.STRING);
 
     public static final Attribute[] ATTRIBUTES_CORP = { CORP_NAME_ATTR, URL_ATTR, IP_ADDRESS_ATTR };
     public static final Schema SCHEMA_CORP = new Schema(ATTRIBUTES_CORP);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantsText.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/regexmatch/RegexTestConstantsText.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -19,7 +19,7 @@ public class RegexTestConstantsText {
     // Sample test data of some random text
     public static final String CONTENT = "content";
 
-    public static final Attribute CONTENT_ATTR = new Attribute(CONTENT, FieldType.TEXT);
+    public static final Attribute CONTENT_ATTR = new Attribute(CONTENT, AttributeType.TEXT);
 
     public static final Attribute[] ATTRIBUTES_TEXT = { CONTENT_ATTR };
     public static final Schema SCHEMA_TEXT = new Schema(ATTRIBUTES_TEXT);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/TupleStreamSinkTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/sink/TupleStreamSinkTest.java
@@ -2,13 +2,13 @@ package edu.uci.ics.textdb.dataflow.sink;
 
 import java.io.FileNotFoundException;
 
+import edu.uci.ics.textdb.api.common.AttributeType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
@@ -20,7 +20,7 @@ public class TupleStreamSinkTest {
     private TupleStreamSink tupleStreamSink;
     private IOperator inputOperator;
     private Schema inputSchema = new Schema(
-            SchemaConstants._ID_ATTRIBUTE, new Attribute("content", FieldType.TEXT), SchemaConstants.PAYLOAD_ATTRIBUTE);
+            SchemaConstants._ID_ATTRIBUTE, new Attribute("content", AttributeType.TEXT), SchemaConstants.PAYLOAD_ATTRIBUTE);
 
     @Before
     public void setUp() throws FileNotFoundException {
@@ -41,7 +41,7 @@ public class TupleStreamSinkTest {
         // verify that inputOperator called open() method
         Mockito.verify(inputOperator).open();
         // assert that the tuple stream sink removes the _ID and PAYLOAD attribute
-        Assert.assertEquals(new Schema(new Attribute("content", FieldType.TEXT)), tupleStreamSink.getOutputSchema());
+        Assert.assertEquals(new Schema(new Attribute("content", AttributeType.TEXT)), tupleStreamSink.getOutputSchema());
     }
 
     @Test

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/source/IndexBasedSourceOperatorTest.java
@@ -54,8 +54,8 @@ public class IndexBasedSourceOperatorTest {
         relationManager.deleteTable(PEOPLE_TABLE);
     }
 
-    public List<Tuple> getQueryResults(String fieldName, String query) throws TextDBException, ParseException {
-        return getQueryResults(new TermQuery(new Term(fieldName, query)));
+    public List<Tuple> getQueryResults(String attributeName, String query) throws TextDBException, ParseException {
+        return getQueryResults(new TermQuery(new Term(attributeName, query)));
     }
     
     public List<Tuple> getQueryResults(Query query) throws TextDBException, ParseException {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/LogicalPlanTest.java
@@ -3,13 +3,13 @@ package edu.uci.ics.textdb.plangen;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import edu.uci.ics.textdb.api.common.AttributeType;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.ISink;
@@ -41,8 +41,8 @@ public class LogicalPlanTest {
     public static final String TEST_TABLE = "logical_plan_test_table";
     
     public static final Schema TEST_SCHEMA = new Schema(
-            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
-            new Attribute("content", FieldType.TEXT));
+            new Attribute("city", AttributeType.STRING), new Attribute("location", AttributeType.STRING),
+            new Attribute("content", AttributeType.TEXT));
     
     @BeforeClass
     public static void setUp() throws StorageException {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/DictionarySourceBuilderTest.java
@@ -10,7 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
@@ -24,8 +24,8 @@ public class DictionarySourceBuilderTest {
     public static final String TEST_TABLE = "dictionary_source_buidler_test_table";
     
     public static final Schema TEST_SCHEMA = new Schema(
-            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
-            new Attribute("content", FieldType.TEXT));
+            new Attribute("city", AttributeType.STRING), new Attribute("location", AttributeType.STRING),
+            new Attribute("content", AttributeType.TEXT));
     
     @BeforeClass
     public static void setUp() throws StorageException {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/FuzzyTokenMatcherBuilderTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcher;

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordMatcherBuilderTest.java
@@ -6,12 +6,9 @@ import java.util.List;
 
 import org.junit.Test;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
-import edu.uci.ics.textdb.common.utils.Utils;
 import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcher;
 import junit.framework.Assert;
 

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/KeywordSourceBuilderTest.java
@@ -3,12 +3,12 @@ package edu.uci.ics.textdb.plangen.operatorbuilder;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import edu.uci.ics.textdb.api.common.AttributeType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
@@ -22,8 +22,8 @@ public class KeywordSourceBuilderTest {
     public static final String TEST_TABLE = "keyword_source_buidler_test_table";
     
     public static final Schema TEST_SCHEMA = new Schema(
-            new Attribute("city", FieldType.STRING), new Attribute("location", FieldType.STRING),
-            new Attribute("content", FieldType.TEXT));
+            new Attribute("city", AttributeType.STRING), new Attribute("location", AttributeType.STRING),
+            new Attribute("content", AttributeType.TEXT));
     
     @BeforeClass
     public static void setUp() throws StorageException {

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilderTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/plangen/operatorbuilder/RegexMatcherBuilderTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
 import edu.uci.ics.textdb.common.exception.PlanGenException;
 import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -62,7 +62,7 @@ public class MedlineIndexWriter {
         JSONObject json = new JSONObject(record);
         ArrayList<IField> fieldList = new ArrayList<IField>();
         for (Attribute attr : ATTRIBUTES_MEDLINE) {
-            fieldList.add(Utils.getField(attr.getFieldType(), json.get(attr.getAttributeName()).toString()));
+            fieldList.add(Utils.getField(attr.getAttributeType(), json.get(attr.getAttributeName()).toString()));
         }
         IField[] fieldArray = new IField[fieldList.size()];
         Tuple tuple = new Tuple(SCHEMA_MEDLINE, fieldList.toArray(fieldArray));

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -7,7 +7,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -41,16 +41,16 @@ public class MedlineIndexWriter {
     public static final String ABSTRACT = "abstract";
     public static final String ZIPF_SCORE = "zipf_score";
 
-    public static final Attribute PMID_ATTR = new Attribute(PMID, FieldType.INTEGER);
-    public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, FieldType.TEXT);
-    public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, FieldType.TEXT);
-    public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, FieldType.TEXT);
-    public static final Attribute JOURNAL_ISSUE_ATTR = new Attribute(JOURNAL_ISSUE, FieldType.STRING);
-    public static final Attribute JOURNAL_TITLE_ATTR = new Attribute(JOURNAL_TITLE, FieldType.TEXT);
-    public static final Attribute KEYWORDS_ATTR = new Attribute(KEYWORDS, FieldType.TEXT);
-    public static final Attribute MESH_HEADINGS_ATTR = new Attribute(MESH_HEADINGS, FieldType.TEXT);
-    public static final Attribute ABSTRACT_ATTR = new Attribute(ABSTRACT, FieldType.TEXT);
-    public static final Attribute ZIPF_SCORE_ATTR = new Attribute(ZIPF_SCORE, FieldType.DOUBLE);
+    public static final Attribute PMID_ATTR = new Attribute(PMID, AttributeType.INTEGER);
+    public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, AttributeType.TEXT);
+    public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, AttributeType.TEXT);
+    public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, AttributeType.TEXT);
+    public static final Attribute JOURNAL_ISSUE_ATTR = new Attribute(JOURNAL_ISSUE, AttributeType.STRING);
+    public static final Attribute JOURNAL_TITLE_ATTR = new Attribute(JOURNAL_TITLE, AttributeType.TEXT);
+    public static final Attribute KEYWORDS_ATTR = new Attribute(KEYWORDS, AttributeType.TEXT);
+    public static final Attribute MESH_HEADINGS_ATTR = new Attribute(MESH_HEADINGS, AttributeType.TEXT);
+    public static final Attribute ABSTRACT_ATTR = new Attribute(ABSTRACT, AttributeType.TEXT);
+    public static final Attribute ZIPF_SCORE_ATTR = new Attribute(ZIPF_SCORE, AttributeType.DOUBLE);
 
     public static final Attribute[] ATTRIBUTES_MEDLINE = { PMID_ATTR, AFFILIATION_ATTR, ARTICLE_TITLE_ATTR,
             AUTHORS_ATTR, JOURNAL_ISSUE_ATTR, JOURNAL_TITLE_ATTR, KEYWORDS_ATTR, MESH_HEADINGS_ATTR, ABSTRACT_ATTR,

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -62,7 +62,7 @@ public class MedlineIndexWriter {
         JSONObject json = new JSONObject(record);
         ArrayList<IField> fieldList = new ArrayList<IField>();
         for (Attribute attr : ATTRIBUTES_MEDLINE) {
-            fieldList.add(Utils.getField(attr.getFieldType(), json.get(attr.getFieldName()).toString()));
+            fieldList.add(Utils.getField(attr.getFieldType(), json.get(attr.getAttributeName()).toString()));
         }
         IField[] fieldArray = new IField[fieldList.size()];
         Tuple tuple = new Tuple(SCHEMA_MEDLINE, fieldList.toArray(fieldArray));

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/promed/PromedSchema.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/promed/PromedSchema.java
@@ -1,7 +1,7 @@
 package edu.uci.ics.textdb.perftest.promed;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Schema;
 
 public class PromedSchema {
@@ -9,8 +9,8 @@ public class PromedSchema {
     public static final String ID = "id";
     public static final String CONTENT = "content";
     
-    public static final Attribute ID_ATTR = new Attribute(ID, FieldType.STRING);
-    public static final Attribute CONTENT_ATTR = new Attribute(CONTENT, FieldType.TEXT);
+    public static final Attribute ID_ATTR = new Attribute(ID, AttributeType.STRING);
+    public static final Attribute CONTENT_ATTR = new Attribute(CONTENT, AttributeType.TEXT);
     
     public static final Schema PROMED_SCHEMA = new Schema(ID_ATTR, CONTENT_ATTR);
 

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.exception.StorageException;
@@ -58,10 +58,10 @@ public class CatalogConstants {
     public static final String TABLE_DIRECTORY = "tableDirectory";
     public static final String TABLE_LUCENE_ANALYZER = "luceneAnalyzer";
 
-    public static final Attribute TABLE_NAME_ATTR = new Attribute(TABLE_NAME, FieldType.STRING);
-    public static final Attribute TABLE_DIRECTORY_ATTR = new Attribute(TABLE_DIRECTORY, FieldType.STRING);
+    public static final Attribute TABLE_NAME_ATTR = new Attribute(TABLE_NAME, AttributeType.STRING);
+    public static final Attribute TABLE_DIRECTORY_ATTR = new Attribute(TABLE_DIRECTORY, AttributeType.STRING);
     public static final Attribute TABLE_LUCENE_ANALYZER_ATTR = new Attribute(TABLE_LUCENE_ANALYZER,
-            FieldType.STRING);
+            AttributeType.STRING);
 
     public static final Schema TABLE_CATALOG_SCHEMA = new Schema(TABLE_NAME_ATTR, TABLE_DIRECTORY_ATTR,
             TABLE_LUCENE_ANALYZER_ATTR);
@@ -72,9 +72,9 @@ public class CatalogConstants {
     public static final String ATTR_TYPE = "attributeType";
     public static final String ATTR_POSITION = "attributePosition";
 
-    public static final Attribute ATTR_NAME_ATTR = new Attribute(ATTR_NAME, FieldType.STRING);
-    public static final Attribute ATTR_TYPE_ATTR = new Attribute(ATTR_TYPE, FieldType.STRING);
-    public static final Attribute ATTR_POSITION_ATTR = new Attribute(ATTR_POSITION, FieldType.INTEGER);
+    public static final Attribute ATTR_NAME_ATTR = new Attribute(ATTR_NAME, AttributeType.STRING);
+    public static final Attribute ATTR_TYPE_ATTR = new Attribute(ATTR_TYPE, AttributeType.STRING);
+    public static final Attribute ATTR_POSITION_ATTR = new Attribute(ATTR_POSITION, AttributeType.INTEGER);
 
     public static final Schema SCHEMA_CATALOG_SCHEMA = new Schema(TABLE_NAME_ATTR, ATTR_NAME_ATTR, ATTR_TYPE_ATTR,
             ATTR_POSITION_ATTR);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
@@ -127,7 +127,7 @@ public class CatalogConstants {
             Tuple schemaTuple = new Tuple(SCHEMA_CATALOG_SCHEMA, 
                     new StringField(tableName),
                     new StringField(attr.getAttributeName()),
-                    new StringField(attr.getFieldType().toString().toLowerCase()),
+                    new StringField(attr.getAttributeType().toString().toLowerCase()),
                     new IntegerField(i));
             schemaCatalogTuples.add(schemaTuple);
         }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
@@ -126,7 +126,7 @@ public class CatalogConstants {
             Attribute attr = tableSchema.getAttributes().get(i);
             Tuple schemaTuple = new Tuple(SCHEMA_CATALOG_SCHEMA, 
                     new StringField(tableName),
-                    new StringField(attr.getFieldName()),
+                    new StringField(attr.getAttributeName()),
                     new StringField(attr.getFieldType().toString().toLowerCase()),
                     new IntegerField(i));
             schemaCatalogTuples.add(schemaTuple);

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
@@ -165,7 +165,7 @@ public class DataReader implements IOperator {
     private ArrayList<IField> documentToFields(Document luceneDocument) throws ParseException {
         ArrayList<IField> fields = new ArrayList<>();
         for (Attribute attr : inputSchema.getAttributes()) {
-            FieldType fieldType = attr.getFieldType();
+            FieldType fieldType = attr.getAttributeType();
             String fieldValue = luceneDocument.get(attr.getAttributeName());
             fields.add(Utils.getField(fieldType, fieldValue));
         }
@@ -177,7 +177,7 @@ public class DataReader implements IOperator {
 
         for (Attribute attr : inputSchema.getAttributes()) {
             String fieldName = attr.getAttributeName();
-            FieldType fieldType = attr.getFieldType();
+            FieldType fieldType = attr.getAttributeType();
 
             // We only store positional information for TEXT fields into
             // payload.

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
@@ -173,7 +173,7 @@ public class DataReader implements IOperator {
         ArrayList<Span> payloadSpanList = new ArrayList<>();
 
         for (Attribute attr : inputSchema.getAttributes()) {
-            String fieldName = attr.getAttributeName();
+            String attributeName = attr.getAttributeName();
             AttributeType attributeType = attr.getAttributeType();
 
             // We only store positional information for TEXT fields into
@@ -182,9 +182,9 @@ public class DataReader implements IOperator {
                 continue;
             }
 
-            String fieldValue = fields.get(inputSchema.getIndex(fieldName)).getValue().toString();
+            String fieldValue = fields.get(inputSchema.getIndex(attributeName)).getValue().toString();
 
-            Terms termVector = luceneIndexReader.getTermVector(docID, fieldName);
+            Terms termVector = luceneIndexReader.getTermVector(docID, attributeName);
             if (termVector == null) {
                 continue;
             }
@@ -205,7 +205,7 @@ public class DataReader implements IOperator {
                     String analyzedTermStr = termsEnum.term().utf8ToString();
                     String originalTermStr = fieldValue.substring(charStart, charEnd);
 
-                    Span span = new Span(fieldName, charStart, charEnd, analyzedTermStr, originalTermStr,
+                    Span span = new Span(attributeName, charStart, charEnd, analyzedTermStr, originalTermStr,
                             tokenPosition);
                     payloadSpanList.add(span);
                 }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
@@ -166,7 +166,7 @@ public class DataReader implements IOperator {
         ArrayList<IField> fields = new ArrayList<>();
         for (Attribute attr : inputSchema.getAttributes()) {
             FieldType fieldType = attr.getFieldType();
-            String fieldValue = luceneDocument.get(attr.getFieldName());
+            String fieldValue = luceneDocument.get(attr.getAttributeName());
             fields.add(Utils.getField(fieldType, fieldValue));
         }
         return fields;
@@ -176,7 +176,7 @@ public class DataReader implements IOperator {
         ArrayList<Span> payloadSpanList = new ArrayList<>();
 
         for (Attribute attr : inputSchema.getAttributes()) {
-            String fieldName = attr.getFieldName();
+            String fieldName = attr.getAttributeName();
             FieldType fieldType = attr.getFieldType();
 
             // We only store positional information for TEXT fields into

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataReader.java
@@ -6,6 +6,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.uci.ics.textdb.api.common.*;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -20,12 +21,8 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
-import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.ErrorMessages;
 import edu.uci.ics.textdb.common.exception.StorageException;
@@ -165,9 +162,9 @@ public class DataReader implements IOperator {
     private ArrayList<IField> documentToFields(Document luceneDocument) throws ParseException {
         ArrayList<IField> fields = new ArrayList<>();
         for (Attribute attr : inputSchema.getAttributes()) {
-            FieldType fieldType = attr.getAttributeType();
+            AttributeType attributeType = attr.getAttributeType();
             String fieldValue = luceneDocument.get(attr.getAttributeName());
-            fields.add(Utils.getField(fieldType, fieldValue));
+            fields.add(Utils.getField(attributeType, fieldValue));
         }
         return fields;
     }
@@ -177,11 +174,11 @@ public class DataReader implements IOperator {
 
         for (Attribute attr : inputSchema.getAttributes()) {
             String fieldName = attr.getAttributeName();
-            FieldType fieldType = attr.getAttributeType();
+            AttributeType attributeType = attr.getAttributeType();
 
             // We only store positional information for TEXT fields into
             // payload.
-            if (fieldType != FieldType.TEXT) {
+            if (attributeType != AttributeType.TEXT) {
                 continue;
             }
 

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
@@ -221,7 +221,7 @@ public class DataWriter {
             IField field = fields.get(count);
             Attribute attr = attributes.get(count);
             FieldType fieldType = attr.getFieldType();
-            doc.add(Utils.getLuceneField(fieldType, attr.getFieldName(), field.getValue()));
+            doc.add(Utils.getLuceneField(fieldType, attr.getAttributeName(), field.getValue()));
         }
         return doc;
     }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
@@ -16,7 +16,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.IField;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
@@ -220,8 +220,8 @@ public class DataWriter {
         for (int count = 0; count < fields.size(); count++) {
             IField field = fields.get(count);
             Attribute attr = attributes.get(count);
-            FieldType fieldType = attr.getAttributeType();
-            doc.add(Utils.getLuceneField(fieldType, attr.getAttributeName(), field.getValue()));
+            AttributeType attributeType = attr.getAttributeType();
+            doc.add(Utils.getLuceneField(attributeType, attr.getAttributeName(), field.getValue()));
         }
         return doc;
     }

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/DataWriter.java
@@ -220,7 +220,7 @@ public class DataWriter {
         for (int count = 0; count < fields.size(); count++) {
             IField field = fields.get(count);
             Attribute attr = attributes.get(count);
-            FieldType fieldType = attr.getFieldType();
+            FieldType fieldType = attr.getAttributeType();
             doc.add(Utils.getLuceneField(fieldType, attr.getAttributeName(), field.getValue()));
         }
         return doc;

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
@@ -5,16 +5,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import edu.uci.ics.textdb.api.common.*;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
-import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
-import edu.uci.ics.textdb.api.common.IField;
-import edu.uci.ics.textdb.api.common.Tuple;
-import edu.uci.ics.textdb.api.common.Schema;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.common.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.common.constants.SchemaConstants;
 import edu.uci.ics.textdb.common.exception.DataFlowException;
@@ -377,12 +374,12 @@ public class RelationManager {
     
     
     /*
-     * Converts a attributeTypeString to FieldType (case insensitive). 
+     * Converts a attributeTypeString to AttributeType (case insensitive).
      * It returns null if string is not a valid type.
      * 
      */
-    private static FieldType convertAttributeType(String attributeTypeStr) {
-        return Stream.of(FieldType.values())
+    private static AttributeType convertAttributeType(String attributeTypeStr) {
+        return Stream.of(AttributeType.values())
                 .filter(typeStr -> typeStr.toString().toLowerCase().equals(attributeTypeStr.toLowerCase()))
                 .findAny().orElse(null);
     }

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/RelationManagerTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/RelationManagerTest.java
@@ -2,6 +2,7 @@ package edu.uci.ics.textdb.storage;
 
 import java.io.File;
 
+import edu.uci.ics.textdb.api.common.AttributeType;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
@@ -12,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
 import edu.uci.ics.textdb.api.common.Tuple;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.api.exception.TextDBException;
@@ -21,7 +21,6 @@ import edu.uci.ics.textdb.common.exception.StorageException;
 import edu.uci.ics.textdb.common.field.IDField;
 import edu.uci.ics.textdb.common.field.StringField;
 import edu.uci.ics.textdb.common.utils.Utils;
-import edu.uci.ics.textdb.storage.RelationManager;
 
 public class RelationManagerTest {
     
@@ -77,9 +76,9 @@ public class RelationManagerTest {
         String tableName = "relation_manager_test_table_1";
         String tableDirectory = "./index/test_table_1/";
         Schema tableSchema = new Schema(
-                new Attribute("city", FieldType.STRING),
-                new Attribute("description", FieldType.TEXT), new Attribute("tax rate", FieldType.DOUBLE),
-                new Attribute("population", FieldType.INTEGER), new Attribute("record time", FieldType.DATE));
+                new Attribute("city", AttributeType.STRING),
+                new Attribute("description", AttributeType.TEXT), new Attribute("tax rate", AttributeType.DOUBLE),
+                new Attribute("population", AttributeType.INTEGER), new Attribute("record time", AttributeType.DATE));
         String tableLuceneAnalyzerString = LuceneAnalyzerConstants.standardAnalyzerString();
         Analyzer tableLuceneAnalyzer = LuceneAnalyzerConstants.getLuceneAnalyzer(tableLuceneAnalyzerString);
         
@@ -134,9 +133,9 @@ public class RelationManagerTest {
         String tableName = "relation_manager_test_table";
         String tableDirectory = "./index/test_table";
         Schema tableSchema = new Schema(
-                new Attribute("city", FieldType.STRING),
-                new Attribute("description", FieldType.TEXT), new Attribute("tax rate", FieldType.DOUBLE),
-                new Attribute("population", FieldType.INTEGER), new Attribute("record time", FieldType.DATE));
+                new Attribute("city", AttributeType.STRING),
+                new Attribute("description", AttributeType.TEXT), new Attribute("tax rate", AttributeType.DOUBLE),
+                new Attribute("population", AttributeType.INTEGER), new Attribute("record time", AttributeType.DATE));
         
         int NUM_OF_LOOPS = 10;
         RelationManager relationManager = RelationManager.getRelationManager();
@@ -182,7 +181,7 @@ public class RelationManagerTest {
         String tableName = "relation_manager_test_table";
         String tableDirectory = "./index/test_table";
         Schema tableSchema = new Schema(
-                new Attribute("content", FieldType.STRING));
+                new Attribute("content", AttributeType.STRING));
         
         RelationManager relationManager = RelationManager.getRelationManager();
         
@@ -220,7 +219,7 @@ public class RelationManagerTest {
         String tableName = "relation_manager_test_table";
         String tableDirectory = "./index/test_table";
         Schema tableSchema = new Schema(
-                new Attribute("content", FieldType.STRING));
+                new Attribute("content", AttributeType.STRING));
         
         RelationManager relationManager = RelationManager.getRelationManager();
         
@@ -268,7 +267,7 @@ public class RelationManagerTest {
         String tableName = "relation_manager_test_table";
         String tableDirectory = "./index/test_table";
         Schema tableSchema = new Schema(
-                new Attribute("content", FieldType.STRING), new Attribute("number", FieldType.STRING));
+                new Attribute("content", AttributeType.STRING), new Attribute("number", AttributeType.STRING));
         
         RelationManager relationManager = RelationManager.getRelationManager();
         

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
@@ -1,7 +1,7 @@
 package edu.uci.ics.textdb.web.resource;
 
 import edu.uci.ics.textdb.api.common.Attribute;
-import edu.uci.ics.textdb.api.common.FieldType;
+import edu.uci.ics.textdb.api.common.AttributeType;
 import edu.uci.ics.textdb.api.common.Schema;
 import edu.uci.ics.textdb.storage.RelationManager;
 import edu.uci.ics.textdb.web.TextdbWebApplication;
@@ -82,7 +82,7 @@ public class QueryPlanResourceTest {
     @BeforeClass
     public static void setUp() throws Exception {
         RelationManager.getRelationManager().createTable(TEST_TABLE, "../index/" + TEST_TABLE,
-                new Schema(new Attribute("attributes", FieldType.TEXT)), "standard");
+                new Schema(new Attribute("attributes", AttributeType.TEXT)), "standard");
     }
     
     @AfterClass


### PR DESCRIPTION
* Refactors the Enum `FieldType` to `AttributeType`
* Refactors the data member `fieldType` in `Attribute` to `attributeType`
* Refactors the data member `fieldName` in `Attribute` to `attributeName`
* Refactors variable names from `fieldName` to `attributeName`
* Refactors variable names from `fieldType` to `attributeType`

This PR has been opened to address Issue #372 