### PR TITLE
Fix a bug in Join that would cause multi-level join to fail

### DIFF
--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/IJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/IJoinPredicate.java
@@ -12,10 +12,10 @@ import edu.uci.ics.textdb.api.tuple.Tuple;
  */
 public interface IJoinPredicate {
 
-	Tuple joinTuples(Tuple outerTuple, Tuple innerTuple, Schema outputSchema)
+	Tuple joinTuples(Tuple innerTuple, Tuple outerTuple, Schema outputSchema)
 			throws Exception;
 	
-	Schema generateOutputSchema(Schema outerOperatorSchema, Schema innerOperatorSchema) throws DataFlowException;
+	Schema generateOutputSchema(Schema innerOperatorSchema, Schema outerOperatorSchema) throws DataFlowException;
 	
 	String getInnerAttributeName();
 	

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/common/JoinDistancePredicate.java
@@ -18,6 +18,7 @@ import edu.uci.ics.textdb.api.tuple.*;
 /**
  * 
  * @author sripadks
+ * @author Zuozhi Wang
  *
  */
 public class JoinDistancePredicate implements IJoinPredicate {
@@ -35,7 +36,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
      * JoinPredicate joinPre = new JoinPredicate(Attribute idAttr, Attribute
      * descriptionAttr, 10) <br>
      * will create a predicate that joins the spans of type descriptionAttr of
-     * outer and inner operators (that agree on the _id attributes) and
+     * inner and outer operators (that agree on the _id attributes) and
      * outputs tuples which satisfy the criteria of being within 10 characters
      * of each other.
      * </p>
@@ -97,8 +98,8 @@ public class JoinDistancePredicate implements IJoinPredicate {
         return this.threshold;
     }
     
-    public Schema generateOutputSchema(Schema outerOperatorSchema, Schema innerOperatorSchema) throws DataFlowException {
-        return generateIntersectionSchema(outerOperatorSchema, innerOperatorSchema);
+    public Schema generateOutputSchema(Schema innerOperatorSchema, Schema outerOperatorSchema) throws DataFlowException {
+        return generateIntersectionSchema(innerOperatorSchema, outerOperatorSchema);
     }
     
     /**
@@ -112,7 +113,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
      * 
      * @return outputSchema
      */
-    private Schema generateIntersectionSchema(Schema outerOperatorSchema, Schema innerOperatorSchema) throws DataFlowException {
+    private Schema generateIntersectionSchema(Schema innerOperatorSchema, Schema outerOperatorSchema) throws DataFlowException {
         List<Attribute> innerAttributes = innerOperatorSchema.getAttributes();
         List<Attribute> outerAttributes = outerOperatorSchema.getAttributes();
         
@@ -150,7 +151,8 @@ public class JoinDistancePredicate implements IJoinPredicate {
      * 
      * @return New Tuple containing the result of join operation.
      */
-	public Tuple joinTuples(Tuple outerTuple, Tuple innerTuple, Schema outputSchema) throws Exception {
+    @Override
+	public Tuple joinTuples(Tuple innerTuple, Tuple outerTuple, Schema outputSchema) throws Exception {
 	    List<Span> newJoinSpanList = new ArrayList<>();
 
 	    /*
@@ -210,8 +212,8 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	            Integer threshold = this.getThreshold();
 	            if (Math.abs(outerSpan.getStart() - innerSpan.getStart()) <= threshold
 	                    && Math.abs(outerSpan.getEnd() - innerSpan.getEnd()) <= threshold) {
-	                Integer newSpanStartIndex = Math.min(outerSpan.getStart(), innerSpan.getStart());
-	                Integer newSpanEndIndex = Math.max(outerSpan.getEnd(), innerSpan.getEnd());
+	                Integer newSpanStartIndex = Math.min(innerSpan.getStart(), outerSpan.getStart());
+	                Integer newSpanEndIndex = Math.max(innerSpan.getEnd(), outerSpan.getEnd());
 	                String attributeName = this.joinAttributeName;
 	                String fieldValue = (String) innerTuple.getField(attributeName).getValue();
 	                String newFieldValue = fieldValue.substring(newSpanStartIndex, newSpanEndIndex);
@@ -241,7 +243,7 @@ public class JoinDistancePredicate implements IJoinPredicate {
 	}
 
 	/**
-	 * Used to compare the value's of a field from the outer and inner tuples'.
+	 * Used to compare the value's of a field from the inner and outer tuples'.
 	 * 
 	 * @param innerTuple
 	 * @param outerTuple

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/Join.java
@@ -38,21 +38,19 @@ import edu.uci.ics.textdb.dataflow.common.IJoinPredicate;
  * then one of the values will be chosen to become the output value.
  * 
  * @author Sripad Kowshik Subramanyam (sripadks)
+ * @author Zuozhi Wang
  *
  */
 public class Join implements IOperator {
 
-    private IOperator outerOperator;
     private IOperator innerOperator;
+    private IOperator outerOperator;
     private IJoinPredicate joinPredicate;
-    // To indicate if next result from outer operator has to be obtained.
-    private boolean shouldIGetOuterOperatorNextTuple;
-    private Tuple outerTuple = null;
-    private Tuple innerTuple = null;
-    private List<Tuple> innerTupleList = new ArrayList<>();
-    // Cursor to maintain the position of tuple to be obtained from
-    // innerTupleList.
-    private Integer innerOperatorCursor = 0;
+    
+    private List<Tuple> innerTupleList = null;
+    // Cursor to maintain the position of tuple to be obtained from innerTupleList.
+    private Integer innerTupleListCursor = 0;
+    private Tuple currentOuterTuple;
     private Schema outputSchema;
 
     private int cursor = CLOSED;
@@ -87,25 +85,12 @@ public class Join implements IOperator {
         // generate output schema from schema of inner and outer operator
         innerOperator.open();
         Schema innerOperatorSchema = innerOperator.getOutputSchema();
-        innerOperator.close();
         
         outerOperator.open();
         Schema outerOperatorSchema = outerOperator.getOutputSchema();
-        outerOperator.close();
         
-        this.outputSchema = joinPredicate.generateOutputSchema(outerOperatorSchema, innerOperatorSchema);
-        
-        // load all tuples from inner operator into memory
-        innerOperator.open();
-        while ((innerTuple = innerOperator.getNextTuple()) != null) {
-            innerTupleList.add(innerTuple);
-        }
-        innerOperator.close();
+        this.outputSchema = joinPredicate.generateOutputSchema(innerOperatorSchema, outerOperatorSchema);
 
-        // open outer operator
-        outerOperator.open();
-
-        shouldIGetOuterOperatorNextTuple = true;
         cursor = OPENED;
     }
 
@@ -121,6 +106,25 @@ public class Join implements IOperator {
     	if (cursor == CLOSED) {
             throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
         }
+    	
+        // load all tuples from inner operator into memory in the first time
+    	if (innerTupleList == null) {
+    	    innerTupleList = new ArrayList<>();
+    	    Tuple tuple;
+            while ((tuple = innerOperator.getNextTuple()) != null) {
+                innerTupleList.add(tuple);
+            }
+    	}
+    	
+    	// load the first outer tuple
+    	currentOuterTuple = outerOperator.getNextTuple();
+    	
+    	// return null if either
+    	//   inner tuple list is empty, or
+    	//   all outer tuples have been consumed
+    	if (innerTupleList.isEmpty() || currentOuterTuple == null) {
+    	    return null;
+    	}
 
         if (resultCursor >= limit + offset - 1 || limit == 0){
             return null;
@@ -150,30 +154,28 @@ public class Join implements IOperator {
      * 
      * It returns null if there's no more tuples.
      */
-    protected  Tuple computeNextMatchingTuple() throws Exception {
+    private Tuple computeNextMatchingTuple() throws Exception {
         if (innerTupleList.isEmpty()) {
             return null;
         }
         
         Tuple nextTuple = null;
         while (nextTuple == null) {
-            if (shouldIGetOuterOperatorNextTuple == true) {
-                if ((outerTuple = outerOperator.getNextTuple()) == null) {
+            // if reach the end of inner tuple list
+            if (innerTupleListCursor >= innerTupleList.size()) {
+                // get next outer tuple
+                currentOuterTuple = outerOperator.getNextTuple();
+                if (currentOuterTuple == null) {
                     return null;
                 }
-                shouldIGetOuterOperatorNextTuple = false;
+                // reset cursor if outerTuple is not null
+                innerTupleListCursor = 0;
             }
-
-            if (innerOperatorCursor <= innerTupleList.size() - 1) {
-                innerTuple = innerTupleList.get(innerOperatorCursor);
-                innerOperatorCursor++;
-                if (innerOperatorCursor == innerTupleList.size()) {
-                    innerOperatorCursor = 0;
-                    shouldIGetOuterOperatorNextTuple = true;
-                }
-            }
-
-            nextTuple = joinPredicate.joinTuples(outerTuple, innerTuple, outputSchema);
+            // compute next tuple
+            nextTuple = joinPredicate.joinTuples(
+                    innerTupleList.get(innerTupleListCursor), currentOuterTuple, outputSchema);
+            // increment cursor
+            innerTupleListCursor++;
         }
         
     	return nextTuple;
@@ -186,15 +188,15 @@ public class Join implements IOperator {
         }
 
         try {
+            innerOperator.close();
             outerOperator.close();
-            // innerOperator.close(); already called in open()
-
         } catch (Exception e) {
-            e.printStackTrace();
             throw new DataFlowException(e.getMessage(), e);
         }
-        // Clear the inner tuple list from memory on close.
-        innerTupleList.clear();
+        
+        // Set the inner tuple list back to null on close.
+        innerTupleList = null;
+        innerTupleListCursor = 0;
         cursor = CLOSED;
     }
 

--- a/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-dataflow/src/main/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinPredicate.java
@@ -71,15 +71,15 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
         this(joinAttributeName, joinAttributeName, similarityThreshold);
     }
 
-    public SimilarityJoinPredicate(String outerJoinAttrName, String innerJoinAttrName, Double similarityThreshold) {
+    public SimilarityJoinPredicate(String innerJoinAttrName, String outerJoinAttrName, Double similarityThreshold) {
         if (similarityThreshold > 1) {
             similarityThreshold = 1.0;
         } else if (similarityThreshold < 0) {
             similarityThreshold = 0.0;
         }
         this.similarityThreshold = similarityThreshold;
-        this.outerJoinAttrName = outerJoinAttrName;
         this.innerJoinAttrName = innerJoinAttrName;
+        this.outerJoinAttrName = outerJoinAttrName;
         
         // initialize default similarity function to NormalizedLevenshtein
         // which is Levenshtein distance / length of longest string
@@ -88,7 +88,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
 
     
     @Override
-    public Schema generateOutputSchema(Schema outerOperatorSchema, Schema innerOperatorSchema) throws DataFlowException {
+    public Schema generateOutputSchema(Schema innerOperatorSchema, Schema outerOperatorSchema) throws DataFlowException {
         List<Attribute> outputAttributeList = new ArrayList<>();
         
         // add _ID field first
@@ -128,7 +128,7 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
     }
 
     @Override
-    public Tuple joinTuples(Tuple outerTuple, Tuple innerTuple, Schema outputSchema) throws DataFlowException {        
+    public Tuple joinTuples(Tuple innerTuple, Tuple outerTuple, Schema outputSchema) throws DataFlowException {        
         if (similarityThreshold == 0) {
             return null;
         }
@@ -177,11 +177,11 @@ public class SimilarityJoinPredicate implements IJoinPredicate {
             }
         }
                 
-        return mergeTuples(outerTuple, innerTuple, outputSchema, resultSpans);
+        return mergeTuples(innerTuple, outerTuple, outputSchema, resultSpans);
     }
     
     
-    private Tuple mergeTuples(Tuple outerTuple, Tuple innerTuple, Schema outputSchema, List<Span> mergeSpanList) {
+    private Tuple mergeTuples(Tuple innerTuple, Tuple outerTuple, Schema outputSchema, List<Span> mergeSpanList) {
         List<IField> resultFields = new ArrayList<>();
         for (String attrName : outputSchema.getAttributeNames()) {
             // generate a new _ID field for this tuple

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinDistanceTest.java
@@ -114,7 +114,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "writer", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
         
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -157,7 +157,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "topics", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
 
         Assert.assertEquals(0, resultList.size());
@@ -176,7 +176,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "book", conjunction);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
         
         Assert.assertEquals(0, resultList.size());
@@ -228,7 +228,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "takes a special kind of writer", phrase);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
         
         
@@ -274,7 +274,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "takes a special kind of writer", phrase);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 10), Integer.MAX_VALUE, 0);
         
         Assert.assertEquals(0, resultList.size());
@@ -307,7 +307,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "tract interesting", phrase);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
         
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -351,7 +351,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "special kind of writer", phrase);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 10), Integer.MAX_VALUE, 0);
 
         Assert.assertEquals(0, resultList.size());
@@ -377,7 +377,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "special", conjunction);
  
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 20), Integer.MAX_VALUE, 0);
         
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -424,7 +424,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "book", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 12), Integer.MAX_VALUE, 0);
 
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -494,7 +494,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "book", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 4), Integer.MAX_VALUE, 0);
         Assert.assertEquals(0, resultList.size());
     }
@@ -516,7 +516,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), Integer.MAX_VALUE, 0);
 
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -594,7 +594,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 3, 0);
 
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -671,7 +671,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 10, 0);
 
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -746,7 +746,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 0, 0);
 
         Assert.assertEquals(0, resultList.size());
@@ -769,7 +769,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 0, 2);
 
         Assert.assertEquals(0, resultList.size());
@@ -794,7 +794,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 1, 2);
 
         Schema resultSchema = Utils.createSpanSchema(JoinTestConstants.BOOK_SCHEMA);
@@ -841,7 +841,7 @@ public class JoinDistanceTest {
         KeywordMatcherSourceOperator keywordSourceInner = 
                 JoinTestHelper.getKeywordSource(BOOK_TABLE, "actually", conjunction);
         
-        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceOuter, keywordSourceInner, 
+        List<Tuple> resultList = JoinTestHelper.getJoinDistanceResults(keywordSourceInner, keywordSourceOuter, 
                 new JoinDistancePredicate(JoinTestConstants.REVIEW, 90), 1, 10);
 
         Assert.assertEquals(0, resultList.size());

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/JoinTestHelper.java
@@ -149,7 +149,7 @@ public class JoinTestHelper {
      * @return
      * @throws TextDBException
      */
-    public static List<Tuple> getJoinDistanceResults(IOperator outerOp, IOperator innerOp,
+    public static List<Tuple> getJoinDistanceResults(IOperator innerOp, IOperator outerOp,
             IJoinPredicate joinPredicate, int limit, int offset) throws TextDBException {
         Join join = new Join(joinPredicate);
         join.setInnerInputOperator(innerOp);

--- a/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinTest.java
+++ b/textdb/textdb-dataflow/src/test/java/edu/uci/ics/textdb/dataflow/join/SimilarityJoinTest.java
@@ -91,7 +91,7 @@ public class SimilarityJoinTest {
 
         SimilarityJoinPredicate similarityJoinPredicate = new SimilarityJoinPredicate(JoinTestConstants.NEWS_BODY, 0.8);
         List<Tuple> results = JoinTestHelper.getJoinDistanceResults(
-                regexMatcherOuter, regexMatcherInner, similarityJoinPredicate, Integer.MAX_VALUE, 0);
+                regexMatcherInner, regexMatcherOuter, similarityJoinPredicate, Integer.MAX_VALUE, 0);
 
         Schema joinInputSchema = Utils.addAttributeToSchema(JoinTestConstants.NEWS_SCHEMA, SchemaConstants.SPAN_LIST_ATTRIBUTE);
         Schema resultSchema = similarityJoinPredicate.generateOutputSchema(joinInputSchema, joinInputSchema);
@@ -144,7 +144,7 @@ public class SimilarityJoinTest {
 
         SimilarityJoinPredicate similarityJoinPredicate = new SimilarityJoinPredicate(JoinTestConstants.NEWS_BODY, 0.9);
         List<Tuple> results = JoinTestHelper.getJoinDistanceResults(
-                regexMatcherOuter, regexMatcherInner, similarityJoinPredicate, Integer.MAX_VALUE, 0);
+                regexMatcherInner, regexMatcherOuter, similarityJoinPredicate, Integer.MAX_VALUE, 0);
 
         Assert.assertTrue(results.isEmpty());
     }
@@ -170,7 +170,7 @@ public class SimilarityJoinTest {
 
         SimilarityJoinPredicate similarityJoinPredicate = new SimilarityJoinPredicate(JoinTestConstants.NEWS_BODY, 0.5);
         List<Tuple> results = JoinTestHelper.getJoinDistanceResults(
-                regexMatcherOuter, regexMatcherInner, similarityJoinPredicate, Integer.MAX_VALUE, 0);
+                regexMatcherInner, regexMatcherOuter, similarityJoinPredicate, Integer.MAX_VALUE, 0);
 
         Schema joinInputSchema = Utils.addAttributeToSchema(JoinTestConstants.NEWS_SCHEMA, SchemaConstants.SPAN_LIST_ATTRIBUTE);
         Schema resultSchema = similarityJoinPredicate.generateOutputSchema(joinInputSchema, joinInputSchema);
@@ -222,7 +222,7 @@ public class SimilarityJoinTest {
 
         SimilarityJoinPredicate similarityJoinPredicate = new SimilarityJoinPredicate(JoinTestConstants.NEWS_BODY, 0.8);
         List<Tuple> results = JoinTestHelper.getJoinDistanceResults(
-                regexMatcherOuter, regexMatcherInner, similarityJoinPredicate, Integer.MAX_VALUE, 0);
+                regexMatcherInner, regexMatcherOuter, similarityJoinPredicate, Integer.MAX_VALUE, 0);
 
         Assert.assertTrue(results.isEmpty());
     }


### PR DESCRIPTION
This PR fixes a bug in Join that causes multiples joins on top of each other to fail.

The problem is:
1. In Join's `open` function, the inner operator's tuples are fetched and loaded into an in-memory list called `InnerOperatorList`.  
2. Also in the same `open` function, the inner operator and outer operator are opened and closed multiple times.  
3. Therefore, when Join's inner operator is also a Join, opening Join multiple times will fetch the inner operator's tuples multiple times to `InnerOperatorList`, which will already cause a big overhead.  
4. If the inner operator's input operator is linked to a OneToNBroadcastConnector, the connector will maintain a cursor for each operator. If the cursor exceeds the total number of tuples, the connector will just return null.  
5. At this case, when Join's `open()` is called the second time, the innerOperator will only get null from the connector. The `innerOperatorList` is re-set to empty. Therefore, no result will be generated.

To fix this bug, this PR:
1. moves the loading innerTuples into `InnerOperatorList` logic to the first time that `getNextTuple` is called, instead of doing it in `open`
2. makes `open` of innerOperator and outerOperator only called once in Join's `open`
3. refines the logic of `computeNextTuple` and removes several unnecessary private variables to make the logic clearer  


This PR also does a minor aesthetic change:  
The order of `innerXxx` and `outerXxx` in function declarations was messy before. This PR changes them to all be `innerXxx` in the first, and `outerXxx` in the second.

