### PR TITLE
[Issue #395] Copy KeywordMatcher related classes to experiment folder

### DIFF
--- a/textdb/textdb-exp/pom.xml
+++ b/textdb/textdb-exp/pom.xml
@@ -29,6 +29,16 @@
             <artifactId>textdb-storage</artifactId>
             <version>${textdb.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160810</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/AbstractSingleInputOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/AbstractSingleInputOperator.java
@@ -1,0 +1,144 @@
+package edu.uci.ics.textdb.exp.common;
+
+import edu.uci.ics.textdb.api.constants.ErrorMessages;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+/**
+ * AbstractSingleInputOperator is an abstract class that can be used by many operators.
+ * This class implements logic such as open and close the input operator, manage the cursor, manage its
+ * limit and offset, etc. An operator that extends this class must implement:
+ * 
+ * setUp(): It is called in open(). 
+ *          Its purpose is to initialize resources, and build the output schema.
+ * computeNextMatchingTuple(): It is called in getNextTuple().
+ *          It returns the next available matching tuple, null if there's no more match.
+ * cleanUp(). It is called in close(). 
+ *          Its purpose is to deallocates resources.
+
+ * @author Zuozhi Wang (zuozhiw)
+ *
+ */
+public abstract class AbstractSingleInputOperator implements IOperator {
+    
+    protected IOperator inputOperator;
+    protected Schema outputSchema;
+    
+    protected int cursor = CLOSED;
+    
+    protected int resultCursor = -1;
+    protected int limit = Integer.MAX_VALUE;
+    protected int offset = 0;
+    
+    @Override
+    public void open() throws TextDBException {
+        if (cursor != CLOSED) {
+            return;
+        }
+        try {
+            if (this.inputOperator == null) {
+                throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+            }
+            inputOperator.open();
+            setUp();
+            
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+        cursor = OPENED;
+    }
+    
+    /**
+     * setUp necessary resources, variables in this function.
+     * outputSchema MUST be initialized in setUP().
+     * @throws TextDBException
+     */
+    protected abstract void setUp() throws TextDBException;
+
+    @Override
+    public Tuple getNextTuple() throws TextDBException {
+        if (cursor == CLOSED) {
+            throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
+        }
+        if (resultCursor >= limit + offset - 1){
+            return null;
+        }
+        try {
+            Tuple resultTuple = null;
+            while (true) {
+                resultTuple = computeNextMatchingTuple();
+                if (resultTuple == null) {
+                    break;
+                }
+                resultCursor++;
+                if (resultCursor >= offset) {
+                    break;
+                }
+            }
+            return resultTuple;
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Give the input tuples, compute the next matching tuple. Return null if there's no more matching tuple.
+     * 
+     * @return next matching tuple, null if there's no more matching tuple.
+     * @throws TextDBException
+     */
+    protected abstract Tuple computeNextMatchingTuple() throws TextDBException;
+
+    public abstract Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException;
+
+    @Override
+    public void close() throws TextDBException {
+        if (cursor == CLOSED) {
+            return;
+        }
+        try {
+            if (inputOperator != null) {
+                inputOperator.close();
+            }
+            cleanUp();
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+        cursor = CLOSED;
+    }
+    
+    protected abstract void cleanUp() throws TextDBException;
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
+    
+    public void setInputOperator(IOperator inputOperator) {
+        this.inputOperator = inputOperator;
+    }
+    
+    public IOperator getInputOperator() {
+        return inputOperator;
+    }
+    
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+    
+    public int getLimit() {
+        return limit;
+    }
+    
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+    
+    public int getOffset() {
+        return offset;
+    }
+    
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/KeywordMatchingType.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/KeywordMatchingType.java
@@ -1,0 +1,57 @@
+package edu.uci.ics.textdb.exp.common;
+
+/**
+ * KeywordMatchingType: the type of keyword matching to perform. <br>
+ * Currently we have 3 types of keyword matching: <br>
+ * 
+ * SUBSTRING_SCANBASED: <br>
+ * Performs simple substring matching of the query. SubString matching is
+ * case insensitive. Source tuples are provided by ScanSourceOperator. <br>
+ * 
+ * CONJUNCTION_INDEXBASED: <br>
+ * Performs search of conjunction of query tokens. The query is tokenized
+ * into keywords, with each token treated as a separate keyword. The order
+ * of tokens doesn't matter in the source tuple. <br>
+ * 
+ * For example: <br>
+ * query "book appointment" <br>
+ * matches: "book appointment with the doctor" <br>
+ * also matches: "an appointment to pick up a book" <br>
+ * <br>
+ * 
+ * 
+ * PHRASE_INDEXBASED: <br>
+ * Performs a phrase search. The query is tokenized into keywords, with
+ * stopwords treated as placeholders. The order of tokens matters in the
+ * source tuple. A stopword matches an arbitary token. <br>
+ * 
+ * For example: <br>
+ * query "book appointment" <br>
+ * matches: "book appointment with the doctor" <br>
+ * doesn't match: "an appointment to pick up book" <br>
+ * 
+ * Example of stopword as placeholders: <br>
+ * query "nice a a person": matches "nice and beautiful person" <br>
+ * matches "nice gentle honest person" <br>
+ * doesn't match "nice person" <br>
+ * doesn't match "nice gentle person" <br>
+ * <br>
+ * 
+ * Default list of stopwords: in
+ * org.apache.lucene.analysis.standard.StandardAnalyzer: <br>
+ * StandardAnalyzer.STOP_WORDS_SET which includes:
+ * 
+ * but, be, with, such, then, for, no, will, not, are, and, their, if, this,
+ * on, into, a, or, there, in, that, they, was, is, it, an, the, as, at,
+ * these, by, to, of
+ * 
+ * @author Zuozhi Wang
+ * 
+ */
+public enum KeywordMatchingType {
+    SUBSTRING_SCANBASED,
+
+    CONJUNCTION_INDEXBASED,
+
+    PHRASE_INDEXBASED
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcher.java
@@ -1,0 +1,306 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import edu.uci.ics.textdb.api.constants.DataConstants;
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.Utils;
+import edu.uci.ics.textdb.exp.common.AbstractSingleInputOperator;
+import edu.uci.ics.textdb.exp.utils.DataflowUtils;
+
+public class KeywordMatcher extends AbstractSingleInputOperator {
+
+    private KeywordPredicate predicate;
+
+    private Schema inputSchema;
+
+    public KeywordMatcher(KeywordPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected void setUp() throws TextDBException {
+        inputSchema = inputOperator.getOutputSchema();
+        outputSchema = inputSchema;
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            outputSchema = Utils.addAttributeToSchema(outputSchema, SchemaConstants.PAYLOAD_ATTRIBUTE);
+        }
+        if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+            outputSchema = Utils.addAttributeToSchema(outputSchema, SchemaConstants.SPAN_LIST_ATTRIBUTE);
+        }
+    }
+
+    @Override
+    protected Tuple computeNextMatchingTuple() throws TextDBException {
+        Tuple inputTuple = null;
+        Tuple resultTuple = null;
+
+        while ((inputTuple = inputOperator.getNextTuple()) != null) {
+            resultTuple = processOneInputTuple(inputTuple);
+
+            if (resultTuple != null) {
+                break;
+            }
+        }
+        return resultTuple;
+    }
+
+    @Override
+    public Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException {
+        Tuple resultTuple = null;
+
+        // There's an implicit assumption that, in open() method, PAYLOAD is
+        // checked before SPAN_LIST.
+        // Therefore, PAYLOAD needs to be checked and added first
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            inputTuple = DataflowUtils.getSpanTuple(inputTuple.getFields(),
+                    DataflowUtils.generatePayloadFromTuple(inputTuple, predicate.getLuceneAnalyzer()), outputSchema);
+        }
+        if (!inputSchema.containsField(SchemaConstants.SPAN_LIST)) {
+            inputTuple = DataflowUtils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
+        }
+
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+            resultTuple = computeConjunctionMatchingResult(inputTuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.PHRASE_INDEXBASED) {
+            resultTuple = computePhraseMatchingResult(inputTuple);
+        }
+        if (this.predicate.getOperatorType() == DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED) {
+            resultTuple = computeSubstringMatchingResult(inputTuple);
+        }
+
+        return resultTuple;
+    }
+
+    @Override
+    protected void cleanUp() {
+    }
+
+    private Tuple computeConjunctionMatchingResult(Tuple sourceTuple) throws DataFlowException {
+        ListField<Span> payloadField = sourceTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
+        List<Span> relevantSpans = filterRelevantSpans(payload);
+        List<Span> matchingResults = new ArrayList<>();
+
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(predicate.getQuery())) {
+                    Span span = new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
+                    matchingResults.add(span);
+                }
+            }
+
+            // for TEXT type, every token in the query should be present in span
+            // list for this field
+            if (attributeType == AttributeType.TEXT) {
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+                        .collect(Collectors.toList());
+
+                if (isAllQueryTokensPresent(fieldSpanList, predicate.getQueryTokenSet())) {
+                    matchingResults.addAll(fieldSpanList);
+                }
+            }
+
+        }
+
+        if (matchingResults.isEmpty()) {
+            return null;
+        }
+
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
+        spanList.addAll(matchingResults);
+
+        return sourceTuple;
+    }
+
+    private Tuple computePhraseMatchingResult(Tuple sourceTuple) throws DataFlowException {
+        ListField<Span> payloadField = sourceTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
+        List<Span> relevantSpans = filterRelevantSpans(payload);
+        List<Span> matchingResults = new ArrayList<>();
+
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(predicate.getQuery())) {
+                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+                }
+            }
+
+            // for TEXT type, spans need to be reconstructed according to the
+            // phrase query
+            if (attributeType == AttributeType.TEXT) {
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+                        .collect(Collectors.toList());
+
+                if (!isAllQueryTokensPresent(fieldSpanList, predicate.getQueryTokenSet())) {
+                    // move on to next field if not all query tokens are present
+                    // in the spans
+                    continue;
+                }
+
+                // Sort current field's span list by token offset for later use
+                Collections.sort(fieldSpanList, (span1, span2) -> span1.getTokenOffset() - span2.getTokenOffset());
+
+                List<String> queryTokenList = predicate.getQueryTokenList();
+                List<Integer> queryTokenOffset = new ArrayList<>();
+                List<String> queryTokensWithStopwords = predicate.getQueryTokensWithStopwords();
+
+                for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
+                    if (queryTokenList.contains(queryTokensWithStopwords.get(i))) {
+                        queryTokenOffset.add(i);
+                    }
+                }
+
+                int iter = 0; // maintains position of term being checked in
+                              // spanForThisField list
+                while (iter < fieldSpanList.size()) {
+                    if (iter > fieldSpanList.size() - queryTokenList.size()) {
+                        break;
+                    }
+
+                    // Verify if span in the spanForThisField correspond to our
+                    // phrase query, ie relative position offsets should be
+                    // similar
+                    // and the value should be same.
+                    boolean isMismatchInSpan = false;// flag to check if a
+                                                     // mismatch in spans occurs
+
+                    // To check all the terms in query are verified
+                    for (int i = 0; i < queryTokenList.size() - 1; i++) {
+                        Span first = fieldSpanList.get(iter + i);
+                        Span second = fieldSpanList.get(iter + i + 1);
+                        if (!(second.getTokenOffset() - first.getTokenOffset() == queryTokenOffset.get(i + 1)
+                                - queryTokenOffset.get(i) && first.getValue().equalsIgnoreCase(queryTokenList.get(i))
+                                && second.getValue().equalsIgnoreCase(queryTokenList.get(i + 1)))) {
+                            iter++;
+                            isMismatchInSpan = true;
+                            break;
+                        }
+                    }
+
+                    if (isMismatchInSpan) {
+                        continue;
+                    }
+
+                    int combinedSpanStartIndex = fieldSpanList.get(iter).getStart();
+                    int combinedSpanEndIndex = fieldSpanList.get(iter + queryTokenList.size() - 1).getEnd();
+
+                    Span combinedSpan = new Span(attributeName, combinedSpanStartIndex, combinedSpanEndIndex, predicate.getQuery(),
+                            fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
+                    matchingResults.add(combinedSpan);
+                    iter = iter + queryTokenList.size();
+                }
+            }
+        }
+
+        if (matchingResults.isEmpty()) {
+            return null;
+        }
+
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
+        spanList.addAll(matchingResults);
+
+        return sourceTuple;
+    }
+
+    private Tuple computeSubstringMatchingResult(Tuple sourceTuple) throws DataFlowException {
+        List<Span> matchingResults = new ArrayList<>();
+
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(predicate.getQuery())) {
+                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+                }
+            }
+
+            if (attributeType == AttributeType.TEXT) {
+                String regex = predicate.getQuery().toLowerCase();
+                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
+                while (matcher.find()) {
+                    int start = matcher.start();
+                    int end = matcher.end();
+
+                    matchingResults.add(new Span(attributeName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
+                }
+            }
+
+        }
+        if (matchingResults.isEmpty()) {
+            return null;
+        }
+
+        ListField<Span> spanListField = sourceTuple.getField(SchemaConstants.SPAN_LIST);
+        List<Span> spanList = spanListField.getValue();
+        spanList.addAll(matchingResults);
+
+        return sourceTuple;
+    }
+
+    private boolean isAllQueryTokensPresent(List<Span> fieldSpanList, Set<String> queryTokenSet) {
+        Set<String> fieldSpanKeys = fieldSpanList.stream().map(span -> span.getKey()).collect(Collectors.toSet());
+
+        return fieldSpanKeys.equals(queryTokenSet);
+    }
+
+    private List<Span> filterRelevantSpans(List<Span> spanList) {
+        List<Span> relevantSpans = new ArrayList<>();
+        Iterator<Span> iterator = spanList.iterator();
+        while (iterator.hasNext()) {
+            Span span = iterator.next();
+            if (predicate.getQueryTokenSet().contains(span.getKey())) {
+                relevantSpans.add(span);
+            }
+        }
+        return relevantSpans;
+    }
+
+    public KeywordPredicate getPredicate() {
+        return this.predicate;
+    }
+
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcherSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcherSourceOperator.java
@@ -1,0 +1,217 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.StorageException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.exp.common.AbstractSingleInputOperator;
+import edu.uci.ics.textdb.storage.DataReader;
+import edu.uci.ics.textdb.storage.RelationManager;
+
+/**
+ * KeywordMatcherSourceOperator is a source operator with a keyword query.
+ * 
+ * @author Zuozhi Wang
+ * @author Zhenfeng Qi
+ *
+ */
+public class KeywordMatcherSourceOperator extends AbstractSingleInputOperator implements ISourceOperator {
+
+    private KeywordPredicate predicate;
+    private String tableName;
+
+    private String keywordQuery;
+
+    private DataReader dataReader;
+    private KeywordMatcher keywordMatcher;
+    
+    private Schema inputSchema;
+
+    public KeywordMatcherSourceOperator(KeywordPredicate predicate, String tableName) 
+            throws DataFlowException, StorageException {
+        this.predicate = predicate;
+        this.tableName = tableName;
+        
+        this.keywordQuery = predicate.getQuery();
+        
+        // input schema must be specified before creating query
+        this.inputSchema = RelationManager.getRelationManager().getTableDataStore(tableName).getSchema();
+        
+        // generate dataReader
+        Query luceneQuery = createLuceneQueryObject();
+
+        this.dataReader = RelationManager.getRelationManager().getTableDataReader(tableName, luceneQuery);
+        this.dataReader.setPayloadAdded(true);
+        
+        // generate KeywordMatcher
+        keywordMatcher = new KeywordMatcher(predicate);
+        keywordMatcher.setInputOperator(dataReader);
+        
+        this.inputOperator = this.keywordMatcher;
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        return this.outputSchema;
+    }
+
+    @Override
+    protected void setUp() throws DataFlowException {
+        this.outputSchema = keywordMatcher.getOutputSchema();
+    }
+
+    @Override
+    protected Tuple computeNextMatchingTuple() throws TextDBException {
+        return this.keywordMatcher.getNextTuple();
+    }
+
+    @Override
+    public Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException {
+        return this.keywordMatcher.processOneInputTuple(inputTuple);
+    }
+
+    @Override
+    protected void cleanUp() throws DataFlowException {
+    }
+
+    /**
+     * Source Operator doesn't need an input operator. Calling setInputOperator
+     * won't have any effects.
+     */
+    @Override
+    public void setInputOperator(IOperator inputOperator) {
+    }
+
+    public KeywordPredicate getPredicate() {
+        return this.predicate;
+    }
+    
+    public String getTableName() {
+        return this.tableName;
+    }
+
+    /**
+     * Creates a Query object as a boolean Query on all attributes Example: For
+     * creating a query like (TestConstants.DESCRIPTION + ":lin" + " AND " +
+     * TestConstants.LAST_NAME + ":lin") we provide a list of AttributeFields
+     * (Description, Last_name) to search on and a query string (lin)
+     *
+     * @return Query
+     * @throws ParseException
+     * @throws DataFlowException
+     */
+    private Query createLuceneQueryObject() throws DataFlowException {
+        Query query = null;
+        if (this.predicate.getOperatorType() == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+            query = buildConjunctionQuery();
+        }
+        if (this.predicate.getOperatorType() == KeywordMatchingType.PHRASE_INDEXBASED) {
+            query = buildPhraseQuery();
+        }
+        if (this.predicate.getOperatorType() == KeywordMatchingType.SUBSTRING_SCANBASED) {
+            query = buildScanQuery();
+        }
+
+        return query;
+    }
+
+    private Query buildConjunctionQuery() throws DataFlowException {
+        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            if (attributeType == AttributeType.STRING) {
+                Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery));
+                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+            }
+            if (attributeType == AttributeType.TEXT) {
+                BooleanQuery.Builder fieldQueryBuilder = new BooleanQuery.Builder();
+                for (String token : this.predicate.getQueryTokenSet()) {
+                    Query termQuery = new TermQuery(new Term(attributeName, token.toLowerCase()));
+                    fieldQueryBuilder.add(termQuery, BooleanClause.Occur.MUST);
+                }
+                booleanQueryBuilder.add(fieldQueryBuilder.build(), BooleanClause.Occur.SHOULD);
+            }
+
+        }
+
+        return booleanQueryBuilder.build();
+    }
+
+    private Query buildPhraseQuery() throws DataFlowException {
+        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            if (attributeType == AttributeType.STRING) {
+                Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery));
+                booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+            }
+            if (attributeType == AttributeType.TEXT) {
+                if (this.predicate.getQueryTokenList().size() == 1) {
+                    Query termQuery = new TermQuery(new Term(attributeName, this.keywordQuery.toLowerCase()));
+                    booleanQueryBuilder.add(termQuery, BooleanClause.Occur.SHOULD);
+                } else {
+                    PhraseQuery.Builder phraseQueryBuilder = new PhraseQuery.Builder();
+                    for (int i = 0; i < this.predicate.getQueryTokensWithStopwords().size(); i++) {
+                        if (!StandardAnalyzer.STOP_WORDS_SET
+                                .contains(this.predicate.getQueryTokensWithStopwords().get(i))) {
+                            phraseQueryBuilder.add(new Term(attributeName,
+                                    this.predicate.getQueryTokensWithStopwords().get(i).toLowerCase()), i);
+                        }
+                    }
+                    PhraseQuery phraseQuery = phraseQueryBuilder.build();
+                    booleanQueryBuilder.add(phraseQuery, BooleanClause.Occur.SHOULD);
+                }
+            }
+
+        }
+
+        return booleanQueryBuilder.build();
+    }
+
+    private Query buildScanQuery() throws DataFlowException {
+        for (String attributeName : this.predicate.getAttributeNames()) {
+            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException(
+                        "KeywordPredicate: Fields other than STRING and TEXT are not supported yet");
+            }
+        }
+
+        return new MatchAllDocsQuery();
+    }
+
+
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatchingType.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatchingType.java
@@ -1,4 +1,4 @@
-package edu.uci.ics.textdb.exp.common;
+package edu.uci.ics.textdb.exp.keywordmatcher;
 
 /**
  * KeywordMatchingType: the type of keyword matching to perform. <br>

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPredicate.java
@@ -1,0 +1,81 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
+
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.utils.DataflowUtils;
+
+/**
+ * @author Zuozhi Wang
+ * @author prakul
+ *
+ * This class handles creation of predicate for querying using Keyword Matcher
+ */
+public class KeywordPredicate implements IPredicate {
+
+    private List<String> attributeNames;
+    private String query;
+    private Query luceneQuery;
+    private ArrayList<String> queryTokenList;
+    private HashSet<String> queryTokenSet;
+    private ArrayList<String> queryTokensWithStopwords;
+    private Analyzer luceneAnalyzer;
+    private KeywordMatchingType operatorType;
+
+    /*
+     * query refers to string of keywords to search for. For Ex. New york if
+     * searched in TextField, we would consider both tokens New and York; if
+     * searched in String field we search for Exact string.
+     */
+    public KeywordPredicate(String query, List<String> attributeNames, Analyzer luceneAnalyzer,
+            KeywordMatchingType operatorType) {
+        this.query = query;
+        this.queryTokenList = DataflowUtils.tokenizeQuery(luceneAnalyzer, query);
+        this.queryTokenSet = new HashSet<>(this.queryTokenList);
+        this.queryTokensWithStopwords = DataflowUtils.tokenizeQueryWithStopwords(query);
+
+        this.attributeNames = attributeNames;
+        this.operatorType = operatorType;
+
+        this.luceneAnalyzer = luceneAnalyzer;
+    }
+
+    public KeywordMatchingType getOperatorType() {
+        return operatorType;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public List<String> getAttributeNames() {
+        return attributeNames;
+    }
+
+    public Query getQueryObject() {
+        return this.luceneQuery;
+    }
+
+    public ArrayList<String> getQueryTokenList() {
+        return this.queryTokenList;
+    }
+
+    public HashSet<String> getQueryTokenSet() {
+        return this.queryTokenSet;
+    }
+
+    public ArrayList<String> getQueryTokensWithStopwords() {
+        return this.queryTokensWithStopwords;
+    }
+
+    public Analyzer getLuceneAnalyzer() {
+        return luceneAnalyzer;
+    }
+
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/ScanBasedSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/ScanBasedSourceOperator.java
@@ -1,0 +1,78 @@
+package edu.uci.ics.textdb.exp.source;
+
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.StorageException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+
+import edu.uci.ics.textdb.api.constants.ErrorMessages;
+import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.storage.DataReader;
+import edu.uci.ics.textdb.storage.RelationManager;
+
+/**
+ * Created by chenli on 3/28/16.
+ */
+public class ScanBasedSourceOperator implements ISourceOperator {
+
+    private DataReader dataReader;
+    
+    private boolean isOpen = false;
+
+    public ScanBasedSourceOperator(String tableName) throws DataFlowException {
+        try {
+            this.dataReader = RelationManager.getRelationManager().getTableDataReader(tableName, new MatchAllDocsQuery());
+            // TODO add an option to set if payload is added in the future.
+            this.dataReader.setPayloadAdded(true);
+        } catch (StorageException e) {
+            throw new DataFlowException(e);
+        }
+    }
+
+    @Override
+    public void open() throws TextDBException {
+        if (isOpen) {
+            return;
+        }
+        try {
+            dataReader.open();
+            isOpen = true;
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Tuple getNextTuple() throws TextDBException {
+        if (! isOpen) {
+            throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
+        }
+        try {
+            return dataReader.getNextTuple();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws TextDBException {
+        if (! isOpen) {
+            return;
+        }
+        try {
+            dataReader.close();
+            isOpen = false;
+        } catch (Exception e) {
+            throw new DataFlowException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        return dataReader.getOutputSchema();
+    }
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
@@ -1,0 +1,295 @@
+package edu.uci.ics.textdb.exp.utils;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.*;
+
+public class DataflowUtils {
+    
+    /**
+     * Returns the AttributeType of a field object.
+     * 
+     * @param field
+     * @return
+     */
+    public static AttributeType getAttributeType(IField field) {
+        if (field instanceof DateField) {
+            return AttributeType.DATE;
+        } else if (field instanceof DoubleField) {
+            return AttributeType.DOUBLE;
+        } else if (field instanceof IDField) {
+            return AttributeType._ID_TYPE;
+        } else if (field instanceof IntegerField) {
+            return AttributeType.INTEGER;
+        } else if (field instanceof ListField) {
+            return AttributeType.LIST;
+        } else if (field instanceof StringField) {
+            return AttributeType.STRING;
+        } else if (field instanceof TextField) {
+            return AttributeType.TEXT;
+        } else {
+            throw new RuntimeException("no existing type mapping of this field object");
+        }
+    }
+
+    /**
+     * @about Creating a new span tuple from span schema, field list
+     */
+    public static Tuple getSpanTuple(List<IField> fieldList, List<Span> spanList, Schema spanSchema) {
+        IField spanListField = new ListField<Span>(new ArrayList<>(spanList));
+        List<IField> fieldListDuplicate = new ArrayList<>(fieldList);
+        fieldListDuplicate.add(spanListField);
+
+        IField[] fieldsDuplicate = fieldListDuplicate.toArray(new IField[fieldListDuplicate.size()]);
+        return new Tuple(spanSchema, fieldsDuplicate);
+    }
+    
+    /**
+     * Tokenizes the query string using the given analyser
+     * 
+     * @param luceneAnalyzer
+     * @param query
+     * @return ArrayList<String> list of results
+     */
+    public static ArrayList<String> tokenizeQuery(Analyzer luceneAnalyzer, String query) {
+        ArrayList<String> result = new ArrayList<String>();
+        TokenStream tokenStream = luceneAnalyzer.tokenStream(null, new StringReader(query));
+        CharTermAttribute term = tokenStream.addAttribute(CharTermAttribute.class);
+
+        try {
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                result.add(term.toString());
+            }
+            tokenStream.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+
+    public static ArrayList<String> tokenizeQueryWithStopwords(String query) {
+        ArrayList<String> result = new ArrayList<String>();
+        CharArraySet emptyStopwords = new CharArraySet(1, true);
+        Analyzer luceneAnalyzer = new StandardAnalyzer(emptyStopwords);
+        TokenStream tokenStream = luceneAnalyzer.tokenStream(null, new StringReader(query));
+        CharTermAttribute term = tokenStream.addAttribute(CharTermAttribute.class);
+
+        try {
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                String token = term.toString();
+                int tokenIndex = query.toLowerCase().indexOf(token);
+                // Since tokens are converted to lower case,
+                // get the exact token from the query string.
+                String actualQueryToken = query.substring(tokenIndex, tokenIndex + token.length());
+                result.add(actualQueryToken);
+            }
+            tokenStream.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        luceneAnalyzer.close();
+
+        return result;
+    }
+    
+    
+    public static JSONArray getTupleListJSON(List<Tuple> tupleList) {
+        JSONArray jsonArray = new JSONArray();
+        
+        for (Tuple tuple : tupleList) {
+            jsonArray.put(getTupleJSON(tuple));
+        }
+        
+        return jsonArray;
+    }
+    
+    public static JSONObject getTupleJSON(Tuple tuple) {
+        JSONObject jsonObject = new JSONObject();
+        
+        for (String attrName : tuple.getSchema().getAttributeNames()) {
+            if (attrName.equalsIgnoreCase(SchemaConstants.SPAN_LIST)) {
+                ListField<Span> spanListField = tuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
+                jsonObject.put(attrName, getSpanListJSON(spanList));
+            } else {
+                jsonObject.put(attrName, tuple.getField(attrName).getValue().toString());
+            }
+        }
+        
+        return jsonObject;
+    }
+    
+    public static JSONArray getSpanListJSON(List<Span> spanList) {
+        JSONArray jsonArray = new JSONArray();
+        
+        for (Span span : spanList) {
+            jsonArray.put(getSpanJSON(span));
+        }
+        
+        return jsonArray;
+    }
+    
+    public static JSONObject getSpanJSON(Span span) {
+        JSONObject jsonObject = new JSONObject();
+        
+        jsonObject.put("key", span.getKey());
+        jsonObject.put("value", span.getValue());
+        jsonObject.put("field", span.getAttributeName());
+        jsonObject.put("start", span.getStart());
+        jsonObject.put("end", span.getEnd());
+        jsonObject.put("token offset", span.getTokenOffset());
+
+        return jsonObject;
+    }
+
+    public static String getTupleListString(List<Tuple> tupleList) {
+        StringBuilder sb = new StringBuilder();
+        for (Tuple tuple : tupleList) {
+            sb.append(getTupleString(tuple));
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Transform a tuple into string
+     * 
+     * @param tuple
+     * @return string representation of the tuple
+     */
+    public static String getTupleString(Tuple tuple) {
+        StringBuilder sb = new StringBuilder();
+
+        Schema schema = tuple.getSchema();
+        for (Attribute attribute : schema.getAttributes()) {
+            if (attribute.getAttributeName().equals(SchemaConstants.SPAN_LIST)) {
+                ListField<Span> spanListField = tuple.getField(SchemaConstants.SPAN_LIST);
+                List<Span> spanList = spanListField.getValue();
+                sb.append(getSpanListString(spanList));
+                sb.append("\n");
+            } else {
+                sb.append(attribute.getAttributeName());
+                sb.append("(");
+                sb.append(attribute.getAttributeType().toString());
+                sb.append(")");
+                sb.append(": ");
+                sb.append(tuple.getField(attribute.getAttributeName()).getValue().toString());
+                sb.append("\n");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Transform a list of spans into string
+     * 
+     * @param tuple
+     * @return string representation of a list of spans
+     */
+    public static String getSpanListString(List<Span> spanList) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("span list:\n");
+        for (Span span : spanList) {
+            sb.append(getSpanString(span));
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Transform a span into string
+     * 
+     * @param tuple
+     * @return string representation of a span
+     */
+    public static String getSpanString(Span span) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("field: " + span.getAttributeName() + "\n");
+        sb.append("start: " + span.getStart() + "\n");
+        sb.append("end:   " + span.getEnd() + "\n");
+        sb.append("key:   " + span.getKey() + "\n");
+        sb.append("value: " + span.getValue() + "\n");
+        sb.append("token offset: " + span.getTokenOffset() + "\n");
+
+        return sb.toString();
+    }
+
+    public static List<Span> generatePayloadFromTuple(Tuple tuple, Analyzer luceneAnalyzer) {
+        List<Span> tuplePayload = tuple.getSchema().getAttributes().stream()
+                .filter(attr -> (attr.getAttributeType() == AttributeType.TEXT)) // generate payload only for TEXT field
+                .map(attr -> attr.getAttributeName())
+                .map(attributeName -> generatePayload(attributeName, tuple.getField(attributeName).getValue().toString(),
+                        luceneAnalyzer))
+                .flatMap(payload -> payload.stream()) // flatten a list of lists to a list
+                .collect(Collectors.toList());
+
+        return tuplePayload;
+    }
+
+    public static List<Span> generatePayload(String attributeName, String fieldValue, Analyzer luceneAnalyzer) {
+        List<Span> payload = new ArrayList<>();
+        
+        try {
+            TokenStream tokenStream = luceneAnalyzer.tokenStream(null, new StringReader(fieldValue));
+            OffsetAttribute offsetAttribute = tokenStream.addAttribute(OffsetAttribute.class);
+            CharTermAttribute charTermAttribute = tokenStream.addAttribute(CharTermAttribute.class);
+            PositionIncrementAttribute positionIncrementAttribute = 
+                    tokenStream.addAttribute(PositionIncrementAttribute.class);
+            
+            int tokenPositionCounter = -1;
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                tokenPositionCounter += positionIncrementAttribute.getPositionIncrement();
+                
+                int tokenPosition = tokenPositionCounter;
+                int charStart = offsetAttribute.startOffset();
+                int charEnd = offsetAttribute.endOffset();
+                String analyzedTermStr = charTermAttribute.toString();
+                String originalTermStr = fieldValue.substring(charStart, charEnd);
+
+                payload.add(new Span(attributeName, charStart, charEnd, analyzedTermStr, originalTermStr, tokenPosition));
+            }
+            tokenStream.close();
+        } catch (IOException e) {
+            payload.clear(); // return empty payload
+        }
+
+        return payload;
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordConjunctionTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordConjunctionTest.java
@@ -1,0 +1,518 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.constants.TestConstantsChinese;
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+import edu.uci.ics.textdb.api.utils.Utils;
+
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Prakul
+ * 
+ * @author Qinhua Huang
+ *
+ */
+public class KeywordConjunctionTest {
+
+    public static final String PEOPLE_TABLE = KeywordTestHelper.PEOPLE_TABLE;
+    public static final String MEDLINE_TABLE = KeywordTestHelper.MEDLINE_TABLE;
+    public static final String CHINESE_TABLE = KeywordTestHelper.CHINESE_TABLE;
+    
+    public static final KeywordMatchingType conjunction = KeywordMatchingType.CONJUNCTION_INDEXBASED;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        KeywordTestHelper.writeTestTables();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        KeywordTestHelper.deleteTestTables();
+    }
+
+    /**
+     * Verifies Keyword Matcher on a multi-word string. Since both tokens in Query
+     * "short tall" don't exist in any single document, it should not return any
+     * tuple.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testKeywordMatcher() throws Exception {
+        // Prepare the query
+        String query = "short TAll";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Perform the query
+        List<Tuple> results = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // check the results
+        Assert.assertEquals(0, results.size());
+    }
+
+    /**
+     * Verifies GetNextTuple of Keyword Matcher and single word queries in
+     * String Field
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSingleWordQueryInStringField() throws Exception {
+        // Prepare the query
+        String query = "bruce";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare the expected result list
+        List<Span> list = new ArrayList<>();
+        Span span = new Span("firstName", 0, 5, "bruce", "bruce");
+        list.add(span);
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<>(list) };
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies GetNextTuple of Keyword Matcher and single word queries in Text
+     * Field
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSingleWordQueryInTextField() throws Exception {
+        // Prepare the query
+        String query = "TaLL";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare the expected result list
+        List<Span> list = new ArrayList<>();
+        Span span = new Span("description", 0, 4, "tall", "Tall", 0);
+        list.add(span);
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<>(list) };
+
+        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
+                new ListField<>(list) };
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+        expectedResultList.add(tuple2);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies the List<ITuple> returned by Keyword Matcher on multiple-word
+     * queries
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMultipleWordsQuery() throws Exception {
+        // Prepare the query
+        String query = "george lin lin";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare the expected result list
+        List<Span> list = new ArrayList<Span>();
+        Span span1 = new Span("firstName", 0, 14, "george lin lin", "george lin lin");
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: data source has multiple attributes, and an entity can appear
+     * in all the fields and multiple times.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testWordInMultipleFieldsQuery() throws Exception {
+        // Prepare the query
+        String query = "lin clooney";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare the expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("lastName", 0, 11, "lin clooney", "lin clooney");
+        Span span2 = new Span("description", 0, 3, "lin", "Lin", 0);
+        Span span3 = new Span("description", 25, 28, "lin", "lin", 5);
+        Span span4 = new Span("description", 4, 11, "clooney", "Clooney", 1);
+        Span span5 = new Span("description", 29, 36, "clooney", "clooney", 6);
+        list.add(span1);
+        list.add(span2);
+        list.add(span3);
+        list.add(span4);
+        list.add(span5);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: All tokens of Query should appear in a Single Field of each
+     * document in Data source otherwise it doesnt return anything
+     *
+     * Ex: For Document: new StringField("george lin lin"), new StringField("lin
+     * clooney"), new IntegerField(43), new DoubleField(6.06), new DateField(new
+     * SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")), new TextField("Lin
+     * Clooney is Short and lin clooney is Angry")
+     * 
+     * For Query : george clooney
+     * 
+     * Result: Nothing should be returned as george and clooney exist in
+     * different fields of same document
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testQueryWordsFoundInMultipleFields() throws Exception {
+        // Prepare the query
+        String query = "george clooney";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction);
+
+        // Check the results
+        Assert.assertEquals(0, resultList.size());
+
+    }
+
+    @Test
+    public void testMatchingWithLimit() throws TextDBException, ParseException, java.text.ParseException {
+        String query = "angry";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction, 3, 0);
+        List<Tuple> expectedList = new ArrayList<>();
+
+        Span span1 = new Span("description", 5, 10, "angry", "Angry", 1);
+        Span span2 = new Span("description", 6, 11, "angry", "Angry", 1);
+        Span span3 = new Span("description", 40, 45, "angry", "Angry", 8);
+        Span span4 = new Span("description", 6, 11, "angry", "angry", 1);
+
+        List<Span> list1 = new ArrayList<>();
+        list1.add(span1);
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<>(list1) };
+        List<Span> list2 = new ArrayList<>();
+        list2.add(span2);
+        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
+                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
+                new TextField("White Angry"), new ListField<>(list2) };
+
+        List<Span> list3 = new ArrayList<>();
+        list3.add(span3);
+        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
+
+        List<Span> list4 = new ArrayList<>();
+        list4.add(span4);
+        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
+                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
+                new TextField("Short angry"), new ListField<>(list4) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
+        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
+
+        expectedList.add(tuple1);
+        expectedList.add(tuple2);
+        expectedList.add(tuple3);
+        expectedList.add(tuple4);
+
+        resultList = Utils.removeFields(resultList, SchemaConstants.PAYLOAD);
+
+        Assert.assertEquals(expectedList.size(), 4);
+        Assert.assertEquals(resultList.size(), 3);
+        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
+    }
+
+    @Test
+    public void testMatchingWithLimitOffset() throws TextDBException, ParseException, java.text.ParseException {
+        String query = "angry";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, conjunction, 3, 2);
+        List<Tuple> expectedList = new ArrayList<>();
+
+        Span span1 = new Span("description", 5, 10, "angry", "Angry", 1);
+        Span span2 = new Span("description", 6, 11, "angry", "Angry", 1);
+        Span span3 = new Span("description", 40, 45, "angry", "Angry", 8);
+        Span span4 = new Span("description", 6, 11, "angry", "angry", 1);
+
+        List<Span> list1 = new ArrayList<>();
+        list1.add(span1);
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<>(list1) };
+        List<Span> list2 = new ArrayList<>();
+        list2.add(span2);
+        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
+                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
+                new TextField("White Angry"), new ListField<>(list2) };
+
+        List<Span> list3 = new ArrayList<>();
+        list3.add(span3);
+        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
+
+        List<Span> list4 = new ArrayList<>();
+        list4.add(span4);
+        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
+                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
+                new TextField("Short angry"), new ListField<>(list4) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
+        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
+
+        expectedList.add(tuple1);
+        expectedList.add(tuple2);
+        expectedList.add(tuple3);
+        expectedList.add(tuple4);
+
+        resultList = Utils.removeFields(resultList, SchemaConstants.PAYLOAD);
+
+        Assert.assertEquals(expectedList.size(), 4);
+        Assert.assertEquals(resultList.size(), 2);
+        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
+    }
+    
+    
+    /**
+     * Verifies GetNextTuple of Keyword Matcher and single word queries in Text
+     * Field using Chinese.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSingleWordQueryInTextFieldChinese() throws Exception {
+        // Prepare the query
+        String query = "北京大学";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstantsChinese.FIRST_NAME);
+        attributeNames.add(TestConstantsChinese.LAST_NAME);
+        attributeNames.add(TestConstantsChinese.DESCRIPTION);
+        
+     // Prepare the expected result list
+        List<Span> list = new ArrayList<>();
+        Span span = new Span("description", 0, 4, "北京大学", "北京大学", 0);
+        list.add(span);
+        Attribute[] schemaAttributes = new Attribute[TestConstantsChinese.ATTRIBUTES_PEOPLE.length + 1];
+
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstantsChinese.ATTRIBUTES_PEOPLE[count];
+        }
+
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("无忌"), new StringField("长孙"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("北京大学电气工程学院"), new ListField<>(list) };
+
+        IField[] fields2 = { new StringField("孔明"), new StringField("洛克贝尔"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("北京大学计算机学院"),
+                new ListField<>(list) };
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+        expectedResultList.add(tuple2);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(CHINESE_TABLE, query, attributeNames, 
+                conjunction, Integer.MAX_VALUE, 0);
+        
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+    
+    
+    /**
+     * Verifies: data source has multiple attributes, and an entity can appear
+     * in all the fields and multiple times.
+     * Test for Chinese data.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryChinese() throws Exception {
+        // Prepare the query
+        String query = "建筑";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstantsChinese.FIRST_NAME);
+        attributeNames.add(TestConstantsChinese.LAST_NAME);
+        attributeNames.add(TestConstantsChinese.DESCRIPTION);
+
+        // Prepare the expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("lastName", 0, 2, "建筑", "建筑");
+        Span span2 = new Span("description", 3, 5, "建筑", "建筑", 2);
+        list.add(span1);
+        list.add(span2);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("宋江"), new StringField("建筑"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), 
+                new TextField("伟大的建筑是历史的坐标，具有传承的价值。"), new ListField<>(list)};
+        
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform the query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(CHINESE_TABLE, query, attributeNames, 
+                conjunction, Integer.MAX_VALUE, 0);
+
+        // check the results
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPhraseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPhraseTest.java
@@ -1,0 +1,400 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+
+/**
+ * @author Prakul
+ *
+ */
+public class KeywordPhraseTest {
+
+    public static final String PEOPLE_TABLE = KeywordTestHelper.PEOPLE_TABLE;
+    public static final String MEDLINE_TABLE = KeywordTestHelper.MEDLINE_TABLE;
+    
+    public static final KeywordMatchingType phrase = KeywordMatchingType.PHRASE_INDEXBASED;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        KeywordTestHelper.writeTestTables();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        KeywordTestHelper.deleteTestTables();
+    }
+
+
+    /**
+     * Verifies Phrase Matcher where Query phrase doesn't exist in any document.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testKeywordMatcher() throws Exception {
+        // Prepare Query
+        String query = "lin clooney is short and angry";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Perform Query
+        List<Tuple> results = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        Assert.assertEquals(0, results.size());
+    }
+
+    /**
+     * Verifies List<ITuple> returned by Phrase Matcher on multiple word query
+     * on a String Field
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testPhraseSearchForStringField() throws Exception {
+        // Prepare Query
+        String query = "george lin lin";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<Span>();
+        Span span1 = new Span("firstName", 0, 14, "george lin lin", "george lin lin");
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: getNextTuple should return Combined Span info for the phrase
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCombinedSpanInMultipleFieldsQuery() throws Exception {
+        // Prepare Query
+        String query = "lin clooney";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("lastName", 0, 11, "lin clooney", "lin clooney");
+        Span span2 = new Span("description", 0, 11, "lin clooney", "Lin Clooney");
+        Span span3 = new Span("description", 25, 36, "lin clooney", "lin clooney");
+
+        list.add(span1);
+        list.add(span2);
+        list.add(span3);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Query with Stop Words match corresponding phrases in the
+     * document
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryWithStopWords1() throws Exception {
+        // Prepare Query
+        String query = "lin and and angry";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("description", 25, 45, "lin and and angry", "lin clooney is Angry");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Query with Stop Words match corresponding phrases in the
+     * document
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryWithStopWords2() throws Exception {
+        // Prepare Query
+        String query = "lin clooney and angry";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("description", 25, 45, "lin clooney and angry", "lin clooney is Angry");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getQueryResults(PEOPLE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Query with Stop Words match corresponding phrases with Medline
+     * data
+     * 
+     * @throws Exception
+     *             with Medline data
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryWithStopWords3() throws Exception {
+        // Prepare Query
+        String query = "skin rash";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(keywordTestConstants.ABSTRACT);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span(keywordTestConstants.ABSTRACT, 192, 201, "skin rash", "skin rash");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[keywordTestConstants.ATTRIBUTES_MEDLINE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = keywordTestConstants.ATTRIBUTES_MEDLINE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new IntegerField(14347980), new TextField(""),
+                new TextField("CHRONIC MENINGOCOCCEMIA; EPIDEMIOLOGY, DIAGNOSIS AND TREATMENT."),
+                new TextField("D S BLOOM"), new StringField("103 Aug, 1965"), new TextField("California medicine"),
+                new TextField("DRUG THERAPY, MENINGOCOCCAL INFECTIONS, PENICILLIN G, SULFONAMIDES"),
+                new TextField("Drug Therapy, Meningococcal Infections, Penicillin G, Sulfonamides"),
+                new TextField(
+                        "This report describes four cases of chronic meningococcemia with the characteristic manifestations of recurrent episodes of "
+                                + "fever, chills, night sweats, headache and anorexia, associated with skin rash and arthralgias. The diagnosis was established in all instances by blood culture. Administration "
+                                + "of sulfonamides in three cases and penicillin in the fourth resulted in prompt recovery. The recent finding of a strain of sulfonamide-resistant meningococci, however, indicates "
+                                + "that antibiotic-sensitivity tests should be carried out in all cases of meningococcal disease. While waiting for the results of such tests to be reported, the clinician should "
+                                + "initiate treatment with large doses of a sulfonamide and penicillin in combination."),
+                new DoubleField(0.664347980), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+        
+        List<Tuple> results = KeywordTestHelper.getQueryResults(
+                MEDLINE_TABLE, query, attributeNames, phrase);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, results);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Query with Stop Words match corresponding phrases in the
+     * document Used to cause exception if there is a special symbol with the
+     * words, ex: big(
+     * 
+     * @throws Exception
+     *             with Medline data
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryWithStopWords4() throws Exception {
+        // Prepare Query
+        String query = "x-ray";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(keywordTestConstants.ABSTRACT);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span(keywordTestConstants.ABSTRACT, 226, 231, "x-ray", "x-ray");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[keywordTestConstants.ATTRIBUTES_MEDLINE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = keywordTestConstants.ATTRIBUTES_MEDLINE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields = { new IntegerField(17832788), new TextField(""), new TextField("Cosmic X-ray Sources."),
+                new TextField("S Bowyer, E T Byram, T A Chubb, H Friedman"), new StringField("147-3656 Jan 22, 1965"),
+                new TextField("Science (New York, N.Y.)"), new TextField(""), new TextField(""),
+                new TextField(
+                        "Eight new sources of cosmic x-rays were detected by two Aerobee surveys in 1964. One source, from Sagittarius, is close to the galactic center, and the other, "
+                                + "from Ophiuchus, may coincide with Kepler's 1604 supernova. All the x-ray sources are fairly close to the galactic plane."),
+                new DoubleField(0.667832788), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        List<Tuple> results = KeywordTestHelper.getQueryResults(
+                MEDLINE_TABLE, query, attributeNames, phrase);
+        
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, results);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Query with Stop Words match corresponding phrases in the
+     * document Used to cause exception sometimes if there is a space between
+     * words
+     * 
+     * @throws Exception
+     *             with Medline data
+     */
+    @Test
+    public void testWordInMultipleFieldsQueryWithStopWords5() throws Exception {
+        // Prepare Query
+        String query = "gain weight";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(keywordTestConstants.ABSTRACT);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span(keywordTestConstants.ABSTRACT, 26, 37, "gain weight", "gain weight");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[keywordTestConstants.ATTRIBUTES_MEDLINE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = keywordTestConstants.ATTRIBUTES_MEDLINE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields = { new IntegerField(4566015), new TextField(""),
+                new TextField("Significance of milk pH in newborn infants."), new TextField("V C Harrison, G Peat"),
+                new StringField("4-5839 Dec 2, 1972"), new TextField("British medical journal"), new TextField(""),
+                new TextField("Infant Nutritional Physiological Phenomena, Infant, Newborn, Milk"),
+                new TextField(
+                        "Bottle-fed infants do not gain weight as rapidly as breast-fed babies during the first week of life. This "
+                                + "weight lag can be corrected by the addition of a small amount of alkali (sodium bicarbonate or trometamol) to "
+                                + "the feeds. The alkali corrects the acidity of cow's milk which now assumes some of the properties of human breast "
+                                + "milk. It has a bacteriostatic effect on specific Escherichia coli in vitro, and in infants it produces a stool with"
+                                + " a preponderance of lactobacilli over E. coli organisms. When alkali is removed from the milk there is a decrease in"
+                                + " the weight of an infant and the stools contain excessive numbers of E. coli bacteria.A pH-corrected milk appears to"
+                                + " be more physiological than unaltered cow's milk and may provide some protection against gastroenteritis in early "
+                                + "life. Its bacteriostatic effect on specific E. coli may be of practical significance in feed preparations where "
+                                + "terminal sterilization and refrigeration are not available. The study was conducted during the week after birth, and "
+                                + "no conclusions are derived for older infants. The long-term effects of trometamol are unknown. No recommendation can "
+                                + "be given for the addition of sodium bicarbonate to milks containing a higher content of sodium."),
+                new DoubleField(0.667832788), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        List<Tuple> results = KeywordTestHelper.getQueryResults(
+                MEDLINE_TABLE, query, attributeNames, phrase);
+        
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, results);
+        Assert.assertTrue(contains);
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordSubstringTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordSubstringTest.java
@@ -1,0 +1,202 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+
+/**
+ * @author ZhenfengQi
+ *
+ */
+public class KeywordSubstringTest {
+
+    public static final String PEOPLE_TABLE = KeywordTestHelper.PEOPLE_TABLE;
+    public static final String MEDLINE_TABLE = KeywordTestHelper.MEDLINE_TABLE;
+    
+    public static final KeywordMatchingType substring = KeywordMatchingType.SUBSTRING_SCANBASED;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        KeywordTestHelper.writeTestTables();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        KeywordTestHelper.deleteTestTables();
+    }
+
+
+    /**
+     * Verifies Substring Matcher where Query phrase does not exist in any
+     * document.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSubstringMatcher() throws Exception {
+        // Prepare Query
+        String query = "brad and angelina";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Perform Query
+        List<Tuple> results = KeywordTestHelper.getScanSourceResults(PEOPLE_TABLE, query, attributeNames, substring, Integer.MAX_VALUE, 0);
+
+        // Perform Check
+        Assert.assertEquals(0, results.size());
+    }
+
+    /**
+     * Verifies List<ITuple> returned by Substring Matcher on query with
+     * multiple spaces and stop words on a String Field
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSubstringForStringField() throws Exception {
+        // Prepare Query
+        String query = "short and lin";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<Span>();
+        Span span1 = new Span("description", 15, 28, "short and lin", "Short and lin");
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getScanSourceResults(PEOPLE_TABLE, query, attributeNames, substring, Integer.MAX_VALUE, 0);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Verifies List<ITuple> returned multiple results by Substring
+     * Matcher on query with spaces on both left side and right side.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCombinedSpanInMultipleFieldsQuery() throws Exception {
+        // Prepare Query
+        String query = " lin ";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("description", 24, 29, " lin ", " lin ");
+
+        list.add(span1);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getScanSourceResults(PEOPLE_TABLE, query, attributeNames, substring, Integer.MAX_VALUE, 0);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+    /**
+     * Verifies: Verifies List<ITuple> returned multiple results by Substring
+     * Matcher on query with spaces on both left side and right side.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSubstringWithStopwordQuery() throws Exception {
+        // Prepare Query
+        String query = "is";
+        ArrayList<String> attributeNames = new ArrayList<>();
+        attributeNames.add(TestConstants.FIRST_NAME);
+        attributeNames.add(TestConstants.LAST_NAME);
+        attributeNames.add(TestConstants.DESCRIPTION);
+
+        // Prepare expected result list
+        List<Span> list = new ArrayList<>();
+        Span span1 = new Span("description", 12, 14, "is", "is");
+        Span span2 = new Span("description", 37, 39, "is", "is");
+
+        list.add(span1);
+        list.add(span2);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = SchemaConstants.SPAN_LIST_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        List<Tuple> expectedResultList = new ArrayList<>();
+        expectedResultList.add(tuple1);
+
+        // Perform Query
+        List<Tuple> resultList = KeywordTestHelper.getScanSourceResults(PEOPLE_TABLE, query, attributeNames, substring, Integer.MAX_VALUE, 0);
+
+        // Perform Check
+        boolean contains = TestUtils.equals(expectedResultList, resultList);
+        Assert.assertTrue(contains);
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordTestHelper.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordTestHelper.java
@@ -1,0 +1,165 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.constants.TestConstantsChinese;
+import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+import edu.uci.ics.textdb.exp.source.ScanBasedSourceOperator;
+import edu.uci.ics.textdb.storage.DataWriter;
+import edu.uci.ics.textdb.storage.RelationManager;
+import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
+
+/**
+ * A helper class for functions that are used in multiple keyword matcher tests.
+ * This class contains functions that: 
+ *   create and write test tables,
+ *   delete test tables
+ *   get the results from a keyword matcher
+ * @author Zuozhi Wang
+ * @author Qinhua Huang
+ *
+ */
+public class KeywordTestHelper {
+    
+    public static final String PEOPLE_TABLE = "keyword_test_people";
+    public static final String MEDLINE_TABLE = "keyword_test_medline";
+    public static final String CHINESE_TABLE = "keyword_test_chinese";
+    
+    public static void writeTestTables() throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        
+        // create the people table and write tuples
+        relationManager.createTable(PEOPLE_TABLE, "../index/test_tables/" + PEOPLE_TABLE, 
+                TestConstants.SCHEMA_PEOPLE, LuceneAnalyzerConstants.standardAnalyzerString());
+
+        DataWriter peopleDataWriter = relationManager.getTableDataWriter(PEOPLE_TABLE);
+        peopleDataWriter.open();
+        for (Tuple tuple : TestConstants.getSamplePeopleTuples()) {
+            peopleDataWriter.insertTuple(tuple);
+        }
+        peopleDataWriter.close();
+        
+        // create the medline table and write tuples
+        relationManager.createTable(MEDLINE_TABLE, "../index/test_tables/" + MEDLINE_TABLE,
+                keywordTestConstants.SCHEMA_MEDLINE, LuceneAnalyzerConstants.standardAnalyzerString());
+   
+        DataWriter medDataWriter = relationManager.getTableDataWriter(MEDLINE_TABLE);
+        medDataWriter.open();
+        for (Tuple tuple : keywordTestConstants.getSampleMedlineRecord()) {
+            medDataWriter.insertTuple(tuple);
+        }
+        medDataWriter.close();
+        
+        // create the people table and write tuples in Chinese
+        relationManager.createTable(CHINESE_TABLE, "../index/test_tables/" + CHINESE_TABLE, 
+                TestConstantsChinese.SCHEMA_PEOPLE, LuceneAnalyzerConstants.chineseAnalyzerString());
+        DataWriter chineseDataWriter = relationManager.getTableDataWriter(CHINESE_TABLE);
+        chineseDataWriter.open();
+        for (Tuple tuple : TestConstantsChinese.getSamplePeopleTuples()) {
+            chineseDataWriter.insertTuple(tuple);
+        }
+        chineseDataWriter.close();
+    }
+    
+    public static void deleteTestTables() throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+
+        relationManager.deleteTable(PEOPLE_TABLE);
+        relationManager.deleteTable(MEDLINE_TABLE);
+        relationManager.deleteTable(CHINESE_TABLE);
+    }
+    
+    public static List<Tuple> getQueryResults(String tableName, String keywordQuery, List<String> attributeNames,
+            KeywordMatchingType matchingType) throws TextDBException {
+        return getQueryResults(tableName, keywordQuery, attributeNames, matchingType, Integer.MAX_VALUE, 0);
+    }
+    
+    public static List<Tuple> getQueryResults(String tableName, String keywordQuery, List<String> attributeNames,
+            KeywordMatchingType matchingType, int limit, int offset) throws TextDBException {
+        
+        // results from a scan on the table followed by a keyword match
+        List<Tuple> scanSourceResults = getScanSourceResults(tableName, keywordQuery, attributeNames,
+                matchingType, limit, offset);
+        // results from index-based keyword search on the table
+        List<Tuple> keywordSourceResults = getKeywordSourceResults(tableName, keywordQuery, attributeNames,
+                matchingType, limit, offset);
+        
+        // if limit and offset are not relevant, the results from scan source and keyword source must be the same
+        if (limit == Integer.MAX_VALUE && offset == 0) {
+            if (TestUtils.equals(scanSourceResults, keywordSourceResults)) {
+                return scanSourceResults;
+            } else {
+                throw new DataFlowException("results from scanSource and keywordSource are inconsistent");
+            }
+        }
+        // if limit and offset are relevant, then the results can be different (since the order doesn't matter)
+        // in this case, we get all the results and test if the whole result set contains both results
+        else {
+            List<Tuple> allResults = getKeywordSourceResults(tableName, keywordQuery, attributeNames,
+                    matchingType, Integer.MAX_VALUE, 0);
+            
+            if (scanSourceResults.size() == keywordSourceResults.size() &&
+                    TestUtils.containsAll(allResults, scanSourceResults) && 
+                    TestUtils.containsAll(allResults, keywordSourceResults)) {
+                return scanSourceResults;
+            } else {
+                throw new DataFlowException("results from scanSource and keywordSource are inconsistent");
+            }   
+        }
+    }
+    
+    public static List<Tuple> getScanSourceResults(String tableName, String keywordQuery, List<String> attributeNames,
+            KeywordMatchingType matchingType, int limit, int offset) throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        
+        ScanBasedSourceOperator scanSource = new ScanBasedSourceOperator(tableName);
+        
+        KeywordPredicate keywordPredicate = new KeywordPredicate(
+                keywordQuery, attributeNames, relationManager.getTableAnalyzer(tableName), matchingType);
+        KeywordMatcher keywordMatcher = new KeywordMatcher(keywordPredicate);
+        keywordMatcher.setLimit(limit);
+        keywordMatcher.setOffset(offset);
+        
+        keywordMatcher.setInputOperator(scanSource);
+        
+        Tuple tuple;
+        List<Tuple> results = new ArrayList<>();
+        
+        keywordMatcher.open();
+        while ((tuple = keywordMatcher.getNextTuple()) != null) {
+            results.add(tuple);
+        }  
+        keywordMatcher.close();
+        
+        return results;
+    }
+    
+    public static List<Tuple> getKeywordSourceResults(String tableName, String keywordQuery, List<String> attributeNames,
+            KeywordMatchingType matchingType, int limit, int offset) throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        KeywordPredicate keywordPredicate = new KeywordPredicate(
+                keywordQuery, attributeNames, relationManager.getTableAnalyzer(tableName), matchingType);
+        KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
+                keywordPredicate, tableName);
+        keywordSource.setLimit(limit);
+        keywordSource.setOffset(offset);
+        
+        Tuple tuple;
+        List<Tuple> results = new ArrayList<>();
+        
+        keywordSource.open();
+        while ((tuple = keywordSource.getNextTuple()) != null) {
+            results.add(tuple);
+        }
+        keywordSource.close();
+        
+        return results;
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/keywordTestConstants.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/keywordmatcher/keywordTestConstants.java
@@ -1,0 +1,93 @@
+package edu.uci.ics.textdb.exp.keywordmatcher;
+
+import java.util.Arrays;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.*;
+
+public class keywordTestConstants {
+    public static final String PMID = "pmid";
+    public static final String AFFILIATION = "affiliation";
+    public static final String ARTICLE_TITLE = "article_title";
+    public static final String AUTHORS = "authors";
+    public static final String JOURNAL_ISSUE = "journal_issue";
+    public static final String JOURNAL_TITLE = "journal_title";
+    public static final String KEYWORDS = "keywords";
+    public static final String MESH_HEADINGS = "mesh_headings";
+    public static final String ABSTRACT = "abstract";
+    public static final String ZIPF_SCORE = "zipf_score";
+
+    public static final Attribute PMID_ATTR = new Attribute(PMID, AttributeType.INTEGER);
+    public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, AttributeType.TEXT);
+    public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, AttributeType.TEXT);
+    public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, AttributeType.TEXT);
+    public static final Attribute JOURNAL_ISSUE_ATTR = new Attribute(JOURNAL_ISSUE, AttributeType.STRING);
+    public static final Attribute JOURNAL_TITLE_ATTR = new Attribute(JOURNAL_TITLE, AttributeType.TEXT);
+    public static final Attribute KEYWORDS_ATTR = new Attribute(KEYWORDS, AttributeType.TEXT);
+    public static final Attribute MESH_HEADINGS_ATTR = new Attribute(MESH_HEADINGS, AttributeType.TEXT);
+    public static final Attribute ABSTRACT_ATTR = new Attribute(ABSTRACT, AttributeType.TEXT);
+    public static final Attribute ZIPF_SCORE_ATTR = new Attribute(ZIPF_SCORE, AttributeType.DOUBLE);
+
+    public static final Attribute[] ATTRIBUTES_MEDLINE = { PMID_ATTR, AFFILIATION_ATTR, ARTICLE_TITLE_ATTR,
+            AUTHORS_ATTR, JOURNAL_ISSUE_ATTR, JOURNAL_TITLE_ATTR, KEYWORDS_ATTR, MESH_HEADINGS_ATTR, ABSTRACT_ATTR,
+            ZIPF_SCORE_ATTR };
+
+    public static final Schema SCHEMA_MEDLINE = new Schema(ATTRIBUTES_MEDLINE);
+
+    public static List<Tuple> getSampleMedlineRecord() {
+
+        IField[] fields1 = { new IntegerField(14347980), new TextField(""),
+                new TextField("CHRONIC MENINGOCOCCEMIA; EPIDEMIOLOGY, DIAGNOSIS AND TREATMENT."),
+                new TextField("D S BLOOM"), new StringField("103 Aug, 1965"), new TextField("California medicine"),
+                new TextField("DRUG THERAPY, MENINGOCOCCAL INFECTIONS, PENICILLIN G, SULFONAMIDES"),
+                new TextField("Drug Therapy, Meningococcal Infections, Penicillin G, Sulfonamides"),
+                new TextField(
+                        "This report describes four cases of chronic meningococcemia with the characteristic manifestations of recurrent episodes of "
+                                + "fever, chills, night sweats, headache and anorexia, associated with skin rash and arthralgias. The diagnosis was established in all instances by blood culture. Administration "
+                                + "of sulfonamides in three cases and penicillin in the fourth resulted in prompt recovery. The recent finding of a strain of sulfonamide-resistant meningococci, however, indicates "
+                                + "that antibiotic-sensitivity tests should be carried out in all cases of meningococcal disease. While waiting for the results of such tests to be reported, the clinician should "
+                                + "initiate treatment with large doses of a sulfonamide and penicillin in combination."),
+                new DoubleField(0.664347980) };
+
+        IField[] fields2 = { new IntegerField(17832788), new TextField(""), new TextField("Cosmic X-ray Sources."),
+                new TextField("S Bowyer, E T Byram, T A Chubb, H Friedman"), new StringField("147-3656 Jan 22, 1965"),
+                new TextField("Science (New York, N.Y.)"), new TextField(""), new TextField(""),
+                new TextField(
+                        "Eight new sources of cosmic x-rays were detected by two Aerobee surveys in 1964. One source, from Sagittarius, is close to the galactic center, and the other, "
+                                + "from Ophiuchus, may coincide with Kepler's 1604 supernova. All the x-ray sources are fairly close to the galactic plane."),
+                new DoubleField(0.667832788) };
+
+        IField[] fields3 = { new IntegerField(4566015), new TextField(""),
+                new TextField("Significance of milk pH in newborn infants."), new TextField("V C Harrison, G Peat"),
+                new StringField("4-5839 Dec 2, 1972"), new TextField("British medical journal"), new TextField(""),
+                new TextField("Infant Nutritional Physiological Phenomena, Infant, Newborn, Milk"),
+                new TextField(
+                        "Bottle-fed infants do not gain weight as rapidly as breast-fed babies during the first week of life. This "
+                                + "weight lag can be corrected by the addition of a small amount of alkali (sodium bicarbonate or trometamol) to "
+                                + "the feeds. The alkali corrects the acidity of cow's milk which now assumes some of the properties of human breast "
+                                + "milk. It has a bacteriostatic effect on specific Escherichia coli in vitro, and in infants it produces a stool with"
+                                + " a preponderance of lactobacilli over E. coli organisms. When alkali is removed from the milk there is a decrease in"
+                                + " the weight of an infant and the stools contain excessive numbers of E. coli bacteria.A pH-corrected milk appears to"
+                                + " be more physiological than unaltered cow's milk and may provide some protection against gastroenteritis in early "
+                                + "life. Its bacteriostatic effect on specific E. coli may be of practical significance in feed preparations where "
+                                + "terminal sterilization and refrigeration are not available. The study was conducted during the week after birth, and "
+                                + "no conclusions are derived for older infants. The long-term effects of trometamol are unknown. No recommendation can "
+                                + "be given for the addition of sodium bicarbonate to milks containing a higher content of sodium."),
+                new DoubleField(0.667832788) };
+
+        Tuple tuple1 = new Tuple(SCHEMA_MEDLINE, fields1);
+        Tuple tuple2 = new Tuple(SCHEMA_MEDLINE, fields2);
+        Tuple tuple3 = new Tuple(SCHEMA_MEDLINE, fields3);
+
+        return Arrays.asList(tuple1, tuple2, tuple3);
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/source/ScanBasedSourceOperatorTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/source/ScanBasedSourceOperatorTest.java
@@ -1,0 +1,73 @@
+/**
+ * 
+ */
+package edu.uci.ics.textdb.exp.source;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.storage.DataWriter;
+import edu.uci.ics.textdb.storage.RelationManager;
+import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
+
+/**
+ * @author sandeepreddy602
+ *
+ */
+public class ScanBasedSourceOperatorTest {
+
+    public static final String PEOPLE_TABLE = "scan_source_test_people";
+    
+    @BeforeClass
+    public static void setUp() throws TextDBException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        
+        // create the people table and write tuples
+        relationManager.createTable(PEOPLE_TABLE, "../index/test_tables/" + PEOPLE_TABLE, 
+                TestConstants.SCHEMA_PEOPLE, LuceneAnalyzerConstants.standardAnalyzerString());
+        
+        DataWriter peopleDataWriter = relationManager.getTableDataWriter(PEOPLE_TABLE);
+        peopleDataWriter.open();
+        for (Tuple tuple : TestConstants.getSamplePeopleTuples()) {
+            peopleDataWriter.insertTuple(tuple);
+        }
+        peopleDataWriter.close();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        relationManager.deleteTable(PEOPLE_TABLE);
+    }
+
+    @Test
+    public void testFlow() throws TextDBException, ParseException {
+        List<Tuple> actualTuples = TestConstants.getSamplePeopleTuples();
+        
+        ScanBasedSourceOperator scanBasedSourceOperator = new ScanBasedSourceOperator(PEOPLE_TABLE);
+        scanBasedSourceOperator.open();
+        Tuple nextTuple = null;
+        int numTuples = 0;
+        List<Tuple> returnedTuples = new ArrayList<Tuple>();
+        while ((nextTuple = scanBasedSourceOperator.getNextTuple()) != null) {
+            returnedTuples.add(nextTuple);
+            numTuples++;
+        }
+        Assert.assertEquals(actualTuples.size(), numTuples);
+        boolean contains = TestUtils.equals(actualTuples, returnedTuples);
+        Assert.assertTrue(contains);
+        scanBasedSourceOperator.close();
+    }
+
+}


### PR DESCRIPTION
This PR is the first step in the TextDB refactor plan (issue #395). 
The migration plan is :
1. Copy the original files to the textdb-exp folder, one operator at a time
2. Modify the operator and the predicate using the new design, one operator at a time, mark the old one as deprecated
3. After all the operators are migrated, delete the old classes and cleanup the codebase

This PR copies the classes necessary for KeywordMatcher to be copied to textdb-exp.