### PR TITLE
[Issue #395] Copy sink operators from dataflow to exp

### DIFF
--- a/textdb/textdb-exp/pom.xml
+++ b/textdb/textdb-exp/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>json</artifactId>
             <version>20160810</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/AbstractSink.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/AbstractSink.java
@@ -1,0 +1,61 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.dataflow.ISink;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+/**
+ * Created by chenli on 5/11/16.
+ *
+ * This abstract class leaves the @processOneTuple() function to be implemented
+ * by the subclass based on the logic of handling each tuple coming from the
+ * subtree.
+ *
+ */
+public abstract class AbstractSink implements ISink {
+
+    private IOperator inputOperator;
+
+    /**
+     * @about Opens the child operator.
+     */
+    @Override
+    public void open() throws TextDBException {
+        inputOperator.open();
+    }
+
+    public void setInputOperator(IOperator inputOperator) {
+        this.inputOperator = inputOperator;
+    }
+
+    public IOperator getInputOperator() {
+        return this.inputOperator;
+    }
+
+    @Override
+    public void processTuples() throws TextDBException {
+        Tuple nextTuple;
+
+        while ((nextTuple = inputOperator.getNextTuple()) != null) {
+            processOneTuple(nextTuple);
+        }
+    }
+
+    /**
+     *
+     * @param nextTuple
+     *            A tuple that needs to be processed during each iteration
+     */
+    protected abstract void processOneTuple(Tuple nextTuple) throws TextDBException;
+
+    @Override
+    public void close() throws TextDBException {
+        inputOperator.close();
+    }
+    
+    public Schema getOutputSchema() {
+        return this.inputOperator.getOutputSchema();
+    }
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/FileSink.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/FileSink.java
@@ -1,0 +1,60 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+/**
+ * Created by chenli on 5/11/16.
+ *
+ * This class serializes each tuple from the subtree to a given file.
+ */
+public class FileSink extends AbstractSink {
+    
+    @FunctionalInterface
+    public static interface TupleToString {
+        String convertToString(Tuple tuple);
+    }
+
+    private PrintWriter printWriter;
+    private final File file;   
+    private TupleToString toStringFunction = (tuple -> tuple.toString());
+    
+    public FileSink(File file) {
+        this.file = file;
+    }
+    
+    public void setToStringFunction(TupleToString toStringFunction) {
+        this.toStringFunction = toStringFunction;
+    }
+
+    @Override
+    public void open() throws TextDBException {
+        super.open();
+        try {
+            this.printWriter = new PrintWriter(file);
+        } catch (FileNotFoundException e) {
+            throw new TextDBException("Failed to open file sink", e);
+        }
+    }
+
+    @Override
+    public void close() throws TextDBException {
+        if (this.printWriter != null) {
+            this.printWriter.close();
+        }
+        super.close();
+    }
+
+    @Override
+    protected void processOneTuple(Tuple nextTuple) {
+        printWriter.write(toStringFunction.convertToString(nextTuple));
+    }
+    
+    public File getFile() {
+        return this.file;
+    }
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/IndexSink.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/IndexSink.java
@@ -1,0 +1,50 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import edu.uci.ics.textdb.api.exception.DataFlowException;
+import edu.uci.ics.textdb.api.exception.StorageException;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.storage.DataWriter;
+import edu.uci.ics.textdb.storage.RelationManager;
+
+/**
+ * IndexSink is a sink that writes tuples into an index.
+ * 
+ * @author zuozhi
+ */
+public class IndexSink extends AbstractSink {
+
+    private DataWriter dataWriter;
+    private boolean isAppend = false;
+
+    public IndexSink(String tableName, boolean isAppend) throws DataFlowException {
+        try {
+            RelationManager relationManager = RelationManager.getRelationManager();
+            this.dataWriter = relationManager.getTableDataWriter(tableName);
+            this.isAppend = isAppend;
+        } catch (StorageException e) {
+            throw new DataFlowException(e);
+        }
+
+    }
+
+    public void open() throws TextDBException {
+        super.open();
+        this.dataWriter.open();
+        if (! this.isAppend) {
+            this.dataWriter.clearData();
+        }
+    }
+
+    protected void processOneTuple(Tuple nextTuple) throws TextDBException {
+        dataWriter.insertTuple(nextTuple);
+    }
+
+    public void close() throws TextDBException {
+        if (this.dataWriter != null) {
+            this.dataWriter.close();
+        }
+        super.close();
+    }
+
+}

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/TupleStreamSink.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/TupleStreamSink.java
@@ -1,0 +1,101 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.dataflow.ISink;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.Utils;
+
+/**
+ * TupleStreamSink is a sink that can be used by the caller to get tuples one by one.
+ * 
+ * @author Zuozhi Wang
+ *
+ */
+public class TupleStreamSink implements ISink {
+    
+    private IOperator inputOperator;
+    
+    private Schema inputSchema;
+    private Schema outputSchema;
+    
+    private boolean isOpen = false;;
+
+    /**
+     * TupleStreamSink is a sink that can be used to
+     *   collect tuples to an in-memory list.
+     *
+     * TupleStreamSink removes the _id attribute and payload attribute
+     *   from the schema and each tuple.
+     *
+     */
+    public TupleStreamSink() {
+    }
+    
+    public void setInputOperator(IOperator inputOperator) {
+        this.inputOperator = inputOperator;
+    }
+    
+    public IOperator getInputOperator() {
+        return this.inputOperator;
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
+
+    @Override
+    public void open() throws TextDBException {
+        if (isOpen) {
+            return;
+        }     
+        inputOperator.open();
+        inputSchema = inputOperator.getOutputSchema();
+        outputSchema = Utils.removeAttributeFromSchema(inputSchema, SchemaConstants._ID, SchemaConstants.PAYLOAD);
+        isOpen = true;
+    }
+
+    @Override
+    public void processTuples() throws TextDBException {
+        return;
+    }
+    
+    @Override
+    public Tuple getNextTuple() throws TextDBException {
+        Tuple tuple = inputOperator.getNextTuple();
+        if (tuple == null) {
+            return null;
+        }
+        return Utils.removeFields(tuple, SchemaConstants._ID, SchemaConstants.PAYLOAD);
+    }
+
+    @Override
+    public void close() throws TextDBException {
+        if (! isOpen) {
+        }
+        inputOperator.close();
+        isOpen = false;        
+    }
+
+    /**
+     * Collects ALL the tuples to an in-memory list.
+     *
+     * @return a list of tuples
+     * @throws TextDBException
+     */
+    public List<Tuple> collectAllTuples() throws TextDBException {
+        ArrayList<Tuple> results = new ArrayList<>();
+        Tuple tuple;
+        while ((tuple = inputOperator.getNextTuple()) != null) {
+            results.add(Utils.removeFields(tuple, SchemaConstants._ID, SchemaConstants.PAYLOAD));
+        }
+        return results;
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/AbstractSinkTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/AbstractSinkTest.java
@@ -1,0 +1,51 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+public class AbstractSinkTest {
+
+    private AbstractSink sink;
+    private IOperator childOperator;
+
+    @Before
+    public void setUp() {
+        childOperator = Mockito.mock(IOperator.class);
+        sink = new AbstractSink() {
+            @Override
+            protected void processOneTuple(Tuple nextTuple) {
+
+            }
+        };
+        sink.setInputOperator(childOperator);
+    }
+
+    @Test
+    public void testOpen() throws Exception {
+        sink.open();
+        // verify that childOperator called open() method
+        Mockito.verify(childOperator).open();
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        sink.close();
+        // verify that childOperator called close() method
+        Mockito.verify(childOperator).close();
+    }
+
+    @Test
+    public void testProcessTuples() throws Exception {
+        Tuple sampleTuple = Mockito.mock(Tuple.class);
+        // Set the behavior for childOperator,
+        // first it returns some non-null tuple and second time it returns null
+        Mockito.when(childOperator.getNextTuple()).thenReturn(sampleTuple).thenReturn(null);
+        sink.processTuples();
+        // Verify that childOperator.getNextTuple() is called twice
+        Mockito.verify(childOperator, Mockito.times(2)).getNextTuple();
+    }
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/FileSinkTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/FileSinkTest.java
@@ -1,0 +1,63 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+
+public class FileSinkTest {
+
+    private FileSink fileSink;
+    private IOperator childOperator;
+    private File file;
+
+    @Before
+    public void setUp() throws FileNotFoundException {
+        childOperator = Mockito.mock(IOperator.class);
+        file = new File("sample.txt");
+        fileSink = new FileSink(file);
+        fileSink.setInputOperator(childOperator);
+    }
+
+    @After
+    public void cleanUp() {
+        if (file != null) {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testOpen() throws Exception {
+        fileSink.open();
+        // verify that childOperator called open() method
+        Mockito.verify(childOperator).open();
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        fileSink.close();
+        // verify that childOperator called close() method
+        Mockito.verify(childOperator).close();
+    }
+
+    @Test
+    public void testProcessTuples() throws Exception {
+        Tuple sampleTuple = Mockito.mock(Tuple.class);
+        Mockito.when(sampleTuple.toString()).thenReturn("Sample Tuple");
+        // Set the behavior for childOperator,
+        // first it returns some non-null tuple and second time it returns null
+        Mockito.when(childOperator.getNextTuple()).thenReturn(sampleTuple).thenReturn(null);
+        fileSink.open();
+        fileSink.processTuples();
+        // Verify that childOperator.getNextTuple() is called twice
+        Mockito.verify(childOperator, Mockito.times(2)).getNextTuple();
+        fileSink.close();
+
+    }
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/TupleStreamSinkTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/TupleStreamSinkTest.java
@@ -1,0 +1,72 @@
+package edu.uci.ics.textdb.exp.sink;
+
+import java.io.FileNotFoundException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import junit.framework.Assert;
+
+public class TupleStreamSinkTest {
+    
+    private TupleStreamSink tupleStreamSink;
+    private IOperator inputOperator;
+    private Schema inputSchema = new Schema(
+            SchemaConstants._ID_ATTRIBUTE, new Attribute("content", AttributeType.TEXT), SchemaConstants.PAYLOAD_ATTRIBUTE);
+
+    @Before
+    public void setUp() throws FileNotFoundException {
+        inputOperator = Mockito.mock(IOperator.class);
+        Mockito.when(inputOperator.getOutputSchema()).thenReturn(inputSchema);
+        
+        tupleStreamSink = new TupleStreamSink();
+        tupleStreamSink.setInputOperator(inputOperator);
+    }
+
+    @After
+    public void cleanUp() {
+    }
+
+    @Test
+    public void testOpen() throws Exception {
+        tupleStreamSink.open();
+        // verify that inputOperator called open() method
+        Mockito.verify(inputOperator).open();
+        // assert that the tuple stream sink removes the _ID and PAYLOAD attribute
+        Assert.assertEquals(new Schema(new Attribute("content", AttributeType.TEXT)), tupleStreamSink.getOutputSchema());
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        tupleStreamSink.close();
+        // verify that inputOperator called close() method
+        Mockito.verify(inputOperator).close();
+    }
+
+    @Test
+    public void testGetNextTuple() throws Exception {
+        Tuple sampleTuple = Mockito.mock(Tuple.class);
+        Mockito.when(sampleTuple.toString()).thenReturn("Sample Tuple");
+        Mockito.when(sampleTuple.getSchema()).thenReturn(inputSchema);
+        // Set the behavior for inputOperator,
+        // first it returns some non-null tuple and second time it returns null
+        Mockito.when(inputOperator.getNextTuple()).thenReturn(sampleTuple).thenReturn(null);
+        
+        tupleStreamSink.open();
+        tupleStreamSink.getNextTuple();
+        
+        // Verify that input operator's getNextTuple is called
+        Mockito.verify(inputOperator, Mockito.times(1)).getNextTuple();
+
+        tupleStreamSink.close();
+    }
+    
+}


### PR DESCRIPTION
This PR copies the "sink" operators from the dataflow package to exp package, for the convenience of further refactoring.   