### PR TITLE
Add a new Tuple Source Operator

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.api.tuple;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +84,7 @@ public class Tuple {
     }
 
     public List<IField> getFields() {
-        return Collections.unmodifiableList(fields);
+        return new ArrayList<>(this.fields);
     }
 
     public Schema getSchema() {

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.textdb.api.tuple;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import edu.uci.ics.textdb.api.field.IField;
@@ -24,6 +25,11 @@ public class Tuple {
         // This makes List<IField> partially immutable.
         // Partial because we can still replace an element at particular index.
         this.fields = Arrays.asList(fields);
+    }
+    
+    public Tuple(Schema schema, List<IField> fields) {
+        this.schema = schema;
+        this.fields = fields;
     }
 
     @SuppressWarnings("unchecked")
@@ -77,7 +83,7 @@ public class Tuple {
     }
 
     public List<IField> getFields() {
-        return fields;
+        return Collections.unmodifiableList(fields);
     }
 
     public Schema getSchema() {

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/tuple/TupleSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/tuple/TupleSourceOperator.java
@@ -1,0 +1,85 @@
+package edu.uci.ics.textdb.exp.source.tuple;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.Utils;
+
+/*
+ * This operator takes a collection of tuples and serves them as a source operator.
+ * 
+ * If the "_id" field is not in the schema, this operator will add an "_id" field to the schema and tuples.
+ * 
+ * This operator is intended for internal use and testing purposes. 
+ * It will NOT be exposed to the web API, therefore it doesn't have a corresponding predicate.
+ * 
+ */
+public class TupleSourceOperator implements ISourceOperator {
+    
+    private Collection<Tuple> inputTuples;
+    private Iterator<Tuple> tupleIterator;
+    private Schema outputSchema;
+    
+    private int cursor = CLOSED;
+    
+    public TupleSourceOperator(Collection<Tuple> inputTuples, Schema schema) {
+        if (! schema.containsField(SchemaConstants._ID)) {
+            this.outputSchema = Utils.getSchemaWithID(schema);
+            this.inputTuples = new ArrayList<>();
+            for (Tuple tuple : inputTuples) {
+                List<IField> fieldsWithID = new ArrayList<>();
+                fieldsWithID.add(IDField.newRandomID());
+                fieldsWithID.addAll(tuple.getFields());
+                this.inputTuples.add(new Tuple(outputSchema, fieldsWithID));
+            }
+        } else {
+            this.outputSchema = schema;
+            this.inputTuples = inputTuples;
+        }
+    }
+
+    @Override
+    public void open() throws TextDBException {
+        if (cursor != CLOSED) {
+            return;
+        }
+        this.tupleIterator = this.inputTuples.iterator();
+        cursor = OPENED;
+    }
+
+    @Override
+    public Tuple getNextTuple() throws TextDBException {
+        if (cursor == CLOSED) {
+            return null;
+        }
+        if (tupleIterator.hasNext()) {
+            return tupleIterator.next();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws TextDBException {
+        if (cursor == CLOSED) {
+            return;
+        }
+        this.tupleIterator = null;
+        cursor = CLOSED;
+    }
+
+    @Override
+    public Schema getOutputSchema() {
+        return outputSchema;
+    }
+    
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/source/tuple/TupleSourceOperatorTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/source/tuple/TupleSourceOperatorTest.java
@@ -1,0 +1,47 @@
+package edu.uci.ics.textdb.exp.source.tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.constants.TestConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
+import edu.uci.ics.textdb.api.utils.Utils;
+
+public class TupleSourceOperatorTest {
+    
+    @Test
+    public void test1() throws TextDBException {
+        TupleSourceOperator tupleSource = new TupleSourceOperator(
+                TestConstants.getSamplePeopleTuples(), TestConstants.SCHEMA_PEOPLE);
+        
+        tupleSource.open();
+        
+        Tuple tuple;
+        List<Tuple> results = new ArrayList<>();
+        Schema outputSchema = tupleSource.getOutputSchema();
+        while ((tuple = tupleSource.getNextTuple()) != null) {
+            results.add(tuple);
+        }
+        
+        tupleSource.close();
+        
+        // assert result is equal to input
+        Assert.assertTrue(TestUtils.equals(TestConstants.getSamplePeopleTuples(), results));
+        // assert _id is added to schema
+        Assert.assertTrue(outputSchema.equals(Utils.getSchemaWithID(TestConstants.SCHEMA_PEOPLE)));
+        // assert all tuples contain _id field
+        for (Tuple resultTuple : results) {
+            Assert.assertTrue(resultTuple.getField(SchemaConstants._ID).getClass().equals(IDField.class));
+        }
+        
+    }
+
+}


### PR DESCRIPTION
This PR adds a new Tuple Source Operator, which serves as a source operator from a collection of tuples. This operator is only for internal use.

This operator is almost identical to the old `TupleStreamSourceOperator`. The old operator will be discarded after finishing the refactoring of the engine.

This PR also changes the `Tuple` class by adding a new convenient constructor, and make getFields() returns an immutable copy of the field list.