### PR TITLE
Migrate the old TupleStreamSink to new TupleSink in textdb-exp

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/ErrorMessages.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/ErrorMessages.java
@@ -11,4 +11,5 @@ public class ErrorMessages {
     public static final String OPERATOR_NOT_OPENED = "The operator is not opened";
     public static final String SCHEMA_CANNOT_BE_NULL = "Schema cannot be null or empty";
     public static final String INPUT_OPERATOR_NOT_SPECIFIED = "Input operator is not specified";
+    public static final String INPUT_OPERATOR_CHANGED_AFTER_OPEN = "Input Operator cannot be changed after opening the operator";
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import edu.uci.ics.textdb.api.dataflow.IPredicate;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordPredicate;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordSourcePredicate;
+import edu.uci.ics.textdb.exp.sink.tuple.TupleSinkPredicate;
 import edu.uci.ics.textdb.exp.source.ScanSourcePredicate;
 
 
@@ -29,7 +30,9 @@ import edu.uci.ics.textdb.exp.source.ScanSourcePredicate;
         @Type(value = KeywordPredicate.class, name = "KeywordMatcher"), 
         @Type(value = KeywordSourcePredicate.class, name = "KeywordSource"), 
         
-        @Type(value = ScanSourcePredicate.class, name = "ScanSource")
+        @Type(value = ScanSourcePredicate.class, name = "ScanSource"),
+        
+        @Type(value = TupleSinkPredicate.class, name = "ViewResults"),
 })
 public abstract class PredicateBase implements IPredicate {
     

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/tuple/TupleSinkPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sink/tuple/TupleSinkPredicate.java
@@ -1,0 +1,12 @@
+package edu.uci.ics.textdb.exp.sink.tuple;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import edu.uci.ics.textdb.api.dataflow.IPredicate;
+
+public class TupleSinkPredicate implements IPredicate {
+    
+    @JsonCreator
+    public TupleSinkPredicate() {}
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/tuple/TupleSinkTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/sink/tuple/TupleSinkTest.java
@@ -1,4 +1,4 @@
-package edu.uci.ics.textdb.exp.sink;
+package edu.uci.ics.textdb.exp.sink.tuple;
 
 import java.io.FileNotFoundException;
 
@@ -13,11 +13,12 @@ import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.exp.sink.tuple.TupleSink;
 import junit.framework.Assert;
 
-public class TupleStreamSinkTest {
+public class TupleSinkTest {
     
-    private TupleStreamSink tupleStreamSink;
+    private TupleSink tupleSink;
     private IOperator inputOperator;
     private Schema inputSchema = new Schema(
             SchemaConstants._ID_ATTRIBUTE, new Attribute("content", AttributeType.TEXT), SchemaConstants.PAYLOAD_ATTRIBUTE);
@@ -27,8 +28,8 @@ public class TupleStreamSinkTest {
         inputOperator = Mockito.mock(IOperator.class);
         Mockito.when(inputOperator.getOutputSchema()).thenReturn(inputSchema);
         
-        tupleStreamSink = new TupleStreamSink();
-        tupleStreamSink.setInputOperator(inputOperator);
+        tupleSink = new TupleSink();
+        tupleSink.setInputOperator(inputOperator);
     }
 
     @After
@@ -37,16 +38,18 @@ public class TupleStreamSinkTest {
 
     @Test
     public void testOpen() throws Exception {
-        tupleStreamSink.open();
+        tupleSink.open();
         // verify that inputOperator called open() method
         Mockito.verify(inputOperator).open();
-        // assert that the tuple stream sink removes the _ID and PAYLOAD attribute
-        Assert.assertEquals(new Schema(new Attribute("content", AttributeType.TEXT)), tupleStreamSink.getOutputSchema());
+        // assert that the tuple stream sink removes the PAYLOAD attribute
+        Assert.assertEquals(
+                new Schema(SchemaConstants._ID_ATTRIBUTE, new Attribute("content", AttributeType.TEXT)), 
+                tupleSink.getOutputSchema());
     }
 
     @Test
     public void testClose() throws Exception {
-        tupleStreamSink.close();
+        tupleSink.close();
         // verify that inputOperator called close() method
         Mockito.verify(inputOperator).close();
     }
@@ -60,13 +63,13 @@ public class TupleStreamSinkTest {
         // first it returns some non-null tuple and second time it returns null
         Mockito.when(inputOperator.getNextTuple()).thenReturn(sampleTuple).thenReturn(null);
         
-        tupleStreamSink.open();
-        tupleStreamSink.getNextTuple();
+        tupleSink.open();
+        tupleSink.getNextTuple();
         
         // Verify that input operator's getNextTuple is called
         Mockito.verify(inputOperator, Mockito.times(1)).getNextTuple();
 
-        tupleStreamSink.close();
+        tupleSink.close();
     }
     
 }


### PR DESCRIPTION
This PR migrates the old TupleStreamSink to new TupleSink in textdb-exp. This PR also changes its behavior. It used to remove the "_id" and "payload" fields of the schema and tuple. Now it only removes the "payload" field, and keeps the "_id" field.