### PR TITLE
[Issue #395] Add test cases for predicate-json serialization/deserialization

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
@@ -1,5 +1,8 @@
 package edu.uci.ics.textdb.exp.common;
 
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -64,5 +67,18 @@ import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
         @Type(value = TupleSinkPredicate.class, name = "ViewResults"),
 })
 public abstract class PredicateBase implements IPredicate {
+    
+    // default id is random uuid (internal code doesn't care about id)
+    private String id = UUID.randomUUID().toString();
+    
+    @JsonProperty("operatorID")
+    public void setID(String id) {
+        this.id = id;
+    }
+    
+    @JsonProperty("operatorID")
+    public String getID() {
+        return id;
+    }
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
@@ -5,15 +5,24 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionaryPredicate;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionarySourcePredicate;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenPredicate;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenSourcePredicate;
+import edu.uci.ics.textdb.exp.join.JoinDistancePredicate;
+import edu.uci.ics.textdb.exp.join.SimilarityJoinPredicate;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordPredicate;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordSourcePredicate;
 import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityPredicate;
 import edu.uci.ics.textdb.exp.nlp.sentiment.NlpSentimentPredicate;
+import edu.uci.ics.textdb.exp.projection.ProjectionPredicate;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexPredicate;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexSourcePredicate;
 import edu.uci.ics.textdb.exp.regexsplit.RegexSplitPredicate;
 import edu.uci.ics.textdb.exp.sampler.SamplerPredicate;
 import edu.uci.ics.textdb.exp.sink.tuple.TupleSinkPredicate;
-import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
 import edu.uci.ics.textdb.exp.source.file.FileSourcePredicate;
+import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
 
 
 /**
@@ -29,13 +38,24 @@ import edu.uci.ics.textdb.exp.source.file.FileSourcePredicate;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME, // logical user-defined type names are used (rather than Java class names)
         include = JsonTypeInfo.As.PROPERTY, // make the type info as a property in the JSON representation
-        property = "operator_type" // the name of the JSON property indicating the type
+        property = "operatorType" // the name of the JSON property indicating the type
 )
 @JsonSubTypes({ 
+        @Type(value = DictionaryPredicate.class, name = "DictionaryMatcher"), 
+        @Type(value = DictionarySourcePredicate.class, name = "DictionarySource"), 
+        @Type(value = FuzzyTokenPredicate.class, name = "FuzzyTokenMatcher"), 
+        @Type(value = FuzzyTokenSourcePredicate.class, name = "FuzzyTokenSource"), 
         @Type(value = KeywordPredicate.class, name = "KeywordMatcher"), 
         @Type(value = KeywordSourcePredicate.class, name = "KeywordSource"), 
+        @Type(value = RegexPredicate.class, name = "RegexMatcher"), 
+        @Type(value = RegexSourcePredicate.class, name = "RegexSource"), 
         
+        @Type(value = JoinDistancePredicate.class, name = "JoinDistance"),
+        @Type(value = SimilarityJoinPredicate.class, name = "SimilarityJoin"),
+        
+        @Type(value = NlpEntityPredicate.class, name = "NlpEntity"),
         @Type(value = NlpSentimentPredicate.class, name = "NlpSentiment"),
+        @Type(value = ProjectionPredicate.class, name = "Projection"),
         @Type(value = RegexSplitPredicate.class, name = "RegexSplit"),
         @Type(value = SamplerPredicate.class, name = "Sampler"),
         

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryPredicate.java
@@ -6,11 +6,11 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
 
-public class DictionaryPredicate implements IPredicate {
+public class DictionaryPredicate extends PredicateBase {
 
     private final Dictionary dictionary;
     private final List<String> attributeNames;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenPredicate.java
@@ -7,7 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import edu.uci.ics.textdb.exp.utils.DataflowUtils;
 
@@ -18,7 +18,7 @@ import edu.uci.ics.textdb.exp.utils.DataflowUtils;
  * The threshold for boolean searches is taken input as a ratio with is converted to integer. 
  * In the worst case if this integer becomes 0, we will set it to 1. 
  */
-public class FuzzyTokenPredicate implements IPredicate {
+public class FuzzyTokenPredicate extends PredicateBase {
 
     private final String query;
     private final List<String> attributeNames;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/JoinDistancePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/JoinDistancePredicate.java
@@ -17,6 +17,7 @@ import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.*;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 /**
@@ -25,7 +26,7 @@ import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
  * @author Zuozhi Wang
  *
  */
-public class JoinDistancePredicate implements IJoinPredicate {
+public class JoinDistancePredicate extends PredicateBase implements IJoinPredicate {
 
     private String joinAttributeName;
     private Integer threshold;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/SimilarityJoinPredicate.java
@@ -17,6 +17,7 @@ import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.*;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import info.debatty.java.stringsimilarity.NormalizedLevenshtein;
 
@@ -53,7 +54,7 @@ import info.debatty.java.stringsimilarity.NormalizedLevenshtein;
  * @author Zuozhi Wang
  *
  */
-public class SimilarityJoinPredicate implements IJoinPredicate {
+public class SimilarityJoinPredicate extends PredicateBase implements IJoinPredicate {
     
     public static final String INNER_PREFIX = "inner_";
     public static final String OUTER_PREFIX = "outer_";

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/entity/NlpEntityPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/entity/NlpEntityPredicate.java
@@ -6,10 +6,10 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
-public class NlpEntityPredicate implements IPredicate {
+public class NlpEntityPredicate extends PredicateBase {
     
     private NlpEntityType nlpEntityType;
     private List<String> attributeNames;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/sentiment/NlpSentimentPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/sentiment/NlpSentimentPredicate.java
@@ -2,10 +2,10 @@ package edu.uci.ics.textdb.exp.nlp.sentiment;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
-public class NlpSentimentPredicate implements IPredicate {
+public class NlpSentimentPredicate extends PredicateBase {
     
     private final String inputAttributeName;
     private final String resultAttributeName;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/projection/ProjectionPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/projection/ProjectionPredicate.java
@@ -7,10 +7,10 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
-public class ProjectionPredicate implements IPredicate {
+public class ProjectionPredicate extends PredicateBase {
     
     private final List<String> projectionFields;
     

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexPredicate.java
@@ -6,7 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 
@@ -17,7 +17,7 @@ import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
  * @author Shuying Lai
  *
  */
-public class RegexPredicate implements IPredicate {
+public class RegexPredicate extends PredicateBase {
 
     private final String regex;
     private final List<String> attributeNames;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexSourcePredicate.java
@@ -52,7 +52,7 @@ public class RegexSourcePredicate extends RegexPredicate {
         }
     }
     
-    @JsonProperty(PropertyNameConstants.REGEX_USE_INDEX)
+    @JsonProperty(PropertyNameConstants.TABLE_NAME)
     public String getTableName() {
         return this.tableName;
     }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexsplit/RegexSplitPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexsplit/RegexSplitPredicate.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 /**
  * @author Qinhua Huang
  *
  */
-public class RegexSplitPredicate implements IPredicate {
+public class RegexSplitPredicate extends PredicateBase {
     
     public enum SplitType {
         GROUP_LEFT("left"), // the regex is grouped with the text on its left

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sampler/SamplerPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sampler/SamplerPredicate.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import edu.uci.ics.textdb.api.dataflow.IPredicate;
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 /**
  * @author Qinhua Huang
  */
-public class SamplerPredicate implements IPredicate {
+public class SamplerPredicate extends PredicateBase {
     
     public enum SampleType {
         RANDOM_SAMPLE("random"),
@@ -35,7 +35,7 @@ public class SamplerPredicate implements IPredicate {
     @JsonCreator
     public SamplerPredicate(
             @JsonProperty(value = PropertyNameConstants.SAMPLE_SIZE, required = true)
-            int sampleSize,
+            Integer sampleSize,
             @JsonProperty(value = PropertyNameConstants.SAMPLE_TYPE, required = true)
             SampleType sampleType ) {
         if (sampleSize < 1) {
@@ -48,7 +48,7 @@ public class SamplerPredicate implements IPredicate {
     }
     
     @JsonProperty(PropertyNameConstants.SAMPLE_SIZE)
-    public double getSampleSize() {
+    public Integer getSampleSize() {
         return sampleSize;
     }
     

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/file/FileSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/file/FileSourcePredicate.java
@@ -7,9 +7,10 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
-public class FileSourcePredicate {
+public class FileSourcePredicate extends PredicateBase {
     
     public static final List<String> defaultAllowedExtensions = Arrays.asList(
             "txt", "json", "xml", "csv", "html", "md");

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.uci.ics.textdb.exp.dictionarymatcher.Dictionary;
@@ -47,11 +48,12 @@ public class PredicateBaseTest {
         PredicateBase resultPredicate = objectMapper.readValue(predicateJson, PredicateBase.class);
         String resultPredicateJson = objectMapper.writeValueAsString(resultPredicate);
         
-        System.out.println(predicateJson);
-        System.out.println(resultPredicateJson);
+        JsonNode predicateJsonNode = objectMapper.readValue(predicateJson, JsonNode.class);
+        JsonNode resultPredicateJsonNode = objectMapper.readValue(resultPredicateJson, JsonNode.class);
 
-        Assert.assertEquals(predicateJson, resultPredicateJson);
+        Assert.assertEquals(predicateJsonNode, resultPredicateJsonNode);
         Assert.assertTrue(predicateJson.contains("operatorType"));
+        Assert.assertTrue(predicateJson.contains("operatorID"));
     }
     
     private static List<String> attributeNames = Arrays.asList("attr1", "attr2");

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
@@ -1,0 +1,192 @@
+package edu.uci.ics.textdb.exp.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.uci.ics.textdb.exp.dictionarymatcher.Dictionary;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionaryPredicate;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionarySourcePredicate;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenPredicate;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenSourcePredicate;
+import edu.uci.ics.textdb.exp.join.JoinDistancePredicate;
+import edu.uci.ics.textdb.exp.join.SimilarityJoinPredicate;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordPredicate;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordSourcePredicate;
+import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityPredicate;
+import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityType;
+import edu.uci.ics.textdb.exp.nlp.sentiment.NlpSentimentPredicate;
+import edu.uci.ics.textdb.exp.projection.ProjectionPredicate;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexPredicate;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexSourcePredicate;
+import edu.uci.ics.textdb.exp.regexsplit.RegexSplitPredicate;
+import edu.uci.ics.textdb.exp.regexsplit.RegexSplitPredicate.SplitType;
+import edu.uci.ics.textdb.exp.sampler.SamplerPredicate;
+import edu.uci.ics.textdb.exp.sampler.SamplerPredicate.SampleType;
+import edu.uci.ics.textdb.exp.source.file.FileSourcePredicate;
+import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
+import junit.framework.Assert;
+
+public class PredicateBaseTest {
+    
+    /*
+     * A helper test function to assert if a predicate is 
+     *   serialized / deserialized correctly
+     *   by converting predicate to json, then back to predicate, then back to json again,
+     *   assert two json strings are the same, (test if anything changed between conversions)
+     *   and the json contains "operatorType". (test if the predicate is registered in PredicateBase)
+     *   
+     */
+    public static void testPredicate(PredicateBase predicate) throws Exception {  
+        ObjectMapper objectMapper = new ObjectMapper();
+        String predicateJson = objectMapper.writeValueAsString(predicate);
+        PredicateBase resultPredicate = objectMapper.readValue(predicateJson, PredicateBase.class);
+        String resultPredicateJson = objectMapper.writeValueAsString(resultPredicate);
+        
+//        System.out.println(predicateJson);
+//        System.out.println(resultPredicateJson);
+
+        Assert.assertEquals(predicateJson, resultPredicateJson);
+        Assert.assertTrue(predicateJson.contains("operatorType"));
+    }
+    
+    private static List<String> attributeNames = Arrays.asList("attr1", "attr2");
+    
+    @Test
+    public void testDictionary() throws Exception {
+        DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(
+                new Dictionary(Arrays.asList("entry1", "entry2")),
+                attributeNames,
+                "standard",
+                KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        testPredicate(dictionaryPredicate);
+        
+        DictionarySourcePredicate dictionarySourcePredicate = new DictionarySourcePredicate(
+                new Dictionary(Arrays.asList("entry1", "entry2")),
+                attributeNames,
+                "standard",
+                KeywordMatchingType.CONJUNCTION_INDEXBASED, 
+                "tableName");
+        testPredicate(dictionarySourcePredicate);
+    }
+    
+    @Test
+    public void testFuzzyToken() throws Exception {
+        FuzzyTokenPredicate fuzzyTokenPredicate = new FuzzyTokenPredicate(
+                "token1 token2 token3",
+                attributeNames,
+                "standard",
+                0.8);
+        testPredicate(fuzzyTokenPredicate);
+        
+        FuzzyTokenSourcePredicate fuzzyTokenSourcePredicate = new FuzzyTokenSourcePredicate(
+                "token1 token2 token3",
+                attributeNames,
+                "standard",
+                0.8,
+                "tableName");
+        testPredicate(fuzzyTokenSourcePredicate);
+    }
+    
+    @Test
+    public void testJoinDistance() throws Exception {
+        JoinDistancePredicate joinDistancePredicate = new JoinDistancePredicate("attr1", "attr1", 100);
+        testPredicate(joinDistancePredicate);
+    }
+    
+    @Test
+    public void testSimilarityJoin() throws Exception {
+        SimilarityJoinPredicate similarityJoinPredicate = new SimilarityJoinPredicate("attr1", "attr1", 0.8);
+        testPredicate(similarityJoinPredicate);
+    }
+    
+    @Test
+    public void testKeyword() throws Exception {
+        KeywordPredicate keywordPredicate = new KeywordPredicate(
+                "keyword",
+                attributeNames,
+                "standard",
+                KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        testPredicate(keywordPredicate);
+        
+        KeywordSourcePredicate keywordSourcePredicate = new KeywordSourcePredicate(
+                "keyword",
+                attributeNames,
+                "standard",
+                KeywordMatchingType.CONJUNCTION_INDEXBASED,
+                "tableName");
+        testPredicate(keywordSourcePredicate);
+    }
+    
+    @Test
+    public void testNlpEntity() throws Exception {
+        NlpEntityPredicate nlpEntityPredicate = new NlpEntityPredicate(
+                NlpEntityType.LOCATION,
+                attributeNames);
+        testPredicate(nlpEntityPredicate);
+    }
+    
+    @Test
+    public void testNlpSentiment() throws Exception {
+        NlpSentimentPredicate nlpSentimentPredicate = new NlpSentimentPredicate(
+                "inputAttr",
+                "resultAttr");
+        testPredicate(nlpSentimentPredicate);
+    }
+    
+    @Test
+    public void testProjection() throws Exception {
+        ProjectionPredicate projectionPredicate = new ProjectionPredicate(attributeNames);
+        testPredicate(projectionPredicate);
+    }
+    
+    @Test
+    public void testRegexMatcher() throws Exception {
+        RegexPredicate regexPredicate = new RegexPredicate(
+                "regex",
+                attributeNames);
+        testPredicate(regexPredicate);
+        
+        RegexSourcePredicate regexSourcePredicate = new RegexSourcePredicate(
+                "regex",
+                attributeNames,
+                "tableName");
+        testPredicate(regexSourcePredicate);
+    }
+    
+    @Test
+    public void testRegexSplit() throws Exception {
+        RegexSplitPredicate regexSplitPredicate = new RegexSplitPredicate(
+                "regex",
+                "attr1",
+                SplitType.STANDALONE);
+        testPredicate(regexSplitPredicate);
+    }
+    
+    @Test
+    public void testSampler() throws Exception {
+        SamplerPredicate samplerPredicate = new SamplerPredicate(
+                10,
+                SampleType.FIRST_K_ARRIVAL);
+        testPredicate(samplerPredicate);
+    }
+    
+    @Test
+    public void testFileSource() throws Exception {
+        FileSourcePredicate fileSourcePredicate = new FileSourcePredicate(
+                "./file.txt",
+                "attr1");
+        testPredicate(fileSourcePredicate);
+    }
+    
+    @Test
+    public void testScanSource() throws Exception {
+        ScanSourcePredicate ScanSourcePredicate = new ScanSourcePredicate("tableName");
+        testPredicate(ScanSourcePredicate);
+    }
+
+}

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
@@ -38,7 +38,7 @@ public class PredicateBaseTest {
      *   serialized / deserialized correctly
      *   by converting predicate to json, then back to predicate, then back to json again,
      *   assert two json strings are the same, (test if anything changed between conversions)
-     *   and the json contains "operatorType". (test if the predicate is registered in PredicateBase)
+     *   and the json contains "operatorType" and "id". (test if the predicate is registered in PredicateBase)
      *   
      */
     public static void testPredicate(PredicateBase predicate) throws Exception {  
@@ -47,8 +47,8 @@ public class PredicateBaseTest {
         PredicateBase resultPredicate = objectMapper.readValue(predicateJson, PredicateBase.class);
         String resultPredicateJson = objectMapper.writeValueAsString(resultPredicate);
         
-//        System.out.println(predicateJson);
-//        System.out.println(resultPredicateJson);
+        System.out.println(predicateJson);
+        System.out.println(resultPredicateJson);
 
         Assert.assertEquals(predicateJson, resultPredicateJson);
         Assert.assertTrue(predicateJson.contains("operatorType"));


### PR DESCRIPTION
The migrations for the operators are mostly completed. This PR adds test cases for predicate-json serialization/deserialization.

The test cases would construct a predicate object, convert it to json, convert it back to predicate object, then convert it to json again, and see if two json strings are the same. This is to make sure that nothing is changed in predicate-to-json conversion.

Following the test cases, this PR also fixes a small bug in `RegexSource`.

This PR also registers ALL the operator predicates to the `PredicateBase` class, which is used to automatically add a field called `operatorType` and `operatorID` to the json, so that Jackson can automatically know the predicate type to map into.