### PR TITLE
[Issue #417] Change TextDBException from Exception to RuntimeException

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/exception/TextDBException.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/exception/TextDBException.java
@@ -3,7 +3,7 @@ package edu.uci.ics.textdb.api.exception;
 /**
  * Superclass of all exceptions inside TextDB Engine.
  */
-public class TextDBException extends Exception {
+public class TextDBException extends RuntimeException {
 
     private static final long serialVersionUID = 4359106470500687632L;
 


### PR DESCRIPTION
Following the discussion in issue #417 , this PR changes TextDBException from inheriting Exception to inheriting RuntimeException.