### PR TITLE
[Issue #395] add newOperator abstract function

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
@@ -2,11 +2,13 @@ package edu.uci.ics.textdb.exp.common;
 
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.dataflow.IPredicate;
 import edu.uci.ics.textdb.exp.dictionarymatcher.DictionaryPredicate;
 import edu.uci.ics.textdb.exp.dictionarymatcher.DictionarySourcePredicate;
@@ -65,6 +67,7 @@ import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
         @Type(value = ScanSourcePredicate.class, name = "ScanSource"),
         @Type(value = FileSourcePredicate.class, name = "FileSink"),        
         @Type(value = TupleSinkPredicate.class, name = "ViewResults"),
+        
 })
 public abstract class PredicateBase implements IPredicate {
     
@@ -80,5 +83,8 @@ public abstract class PredicateBase implements IPredicate {
     public String getID() {
         return id;
     }
+    
+    @JsonIgnore
+    public abstract IOperator newOperator();
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryPredicate.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
@@ -62,5 +63,9 @@ public class DictionaryPredicate extends PredicateBase {
         return keywordMatchingType;
     }
     
+    @Override
+    public IOperator newOperator() {
+        return new DictionaryMatcher(this);
+    }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionarySourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionarySourcePredicate.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
 
@@ -40,6 +41,11 @@ public class DictionarySourcePredicate extends DictionaryPredicate {
     @JsonProperty(value = PropertyNameConstants.TABLE_NAME)
     public String getTableName() {
         return this.tableName;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new DictionaryMatcherSourceOperator(this);
     }
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenPredicate.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 import edu.uci.ics.textdb.exp.utils.DataflowUtils;
@@ -89,6 +90,11 @@ public class FuzzyTokenPredicate extends PredicateBase {
             threshold = 1;
         }
         return threshold; 
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new FuzzyTokenMatcher(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/fuzzytokenmatcher/FuzzyTokenSourcePredicate.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 public class FuzzyTokenSourcePredicate extends FuzzyTokenPredicate {
@@ -28,6 +29,11 @@ public class FuzzyTokenSourcePredicate extends FuzzyTokenPredicate {
     @JsonProperty(value = PropertyNameConstants.TABLE_NAME)
     public String getTableName() {
         return this.tableName;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new FuzzyTokenMatcherSourceOperator(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/JoinDistancePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/JoinDistancePredicate.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.exception.DataFlowException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.field.ListField;
@@ -296,5 +297,10 @@ public class JoinDistancePredicate extends PredicateBase implements IJoinPredica
 	
 	    return innerField.getValue().equals(outerField.getValue());
 	}
+	
+    @Override
+    public IOperator newOperator() {
+        return new Join(this);
+    }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/SimilarityJoinPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/join/SimilarityJoinPredicate.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.exception.DataFlowException;
 import edu.uci.ics.textdb.api.field.IDField;
 import edu.uci.ics.textdb.api.field.IField;
@@ -250,6 +251,11 @@ public class SimilarityJoinPredicate extends PredicateBase implements IJoinPredi
     @JsonIgnore
     public void setSimilarityFunction(SimilarityFunc similarityFunc) {
         this.similarityFunc = similarityFunc;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new Join(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordPredicate.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
@@ -201,6 +202,11 @@ public class KeywordPredicate extends PredicateBase {
     
     public Integer getOffset() {
         return offset;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new KeywordMatcher(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordSourcePredicate.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 /**
@@ -55,6 +56,11 @@ public class KeywordSourcePredicate extends KeywordPredicate {
     @JsonProperty(PropertyNameConstants.TABLE_NAME)
     public String getTableName() {
         return tableName;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new KeywordMatcherSourceOperator(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/entity/NlpEntityPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/entity/NlpEntityPredicate.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -32,6 +33,11 @@ public class NlpEntityPredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.ATTRIBUTE_NAMES)
     public List<String> getAttributeNames() {
         return new ArrayList<>(attributeNames);
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new NlpEntityOperator(this);
     }
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/sentiment/NlpSentimentPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/sentiment/NlpSentimentPredicate.java
@@ -2,6 +2,7 @@ package edu.uci.ics.textdb.exp.nlp.sentiment;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -28,6 +29,11 @@ public class NlpSentimentPredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.RESULT_ATTRIBUTE_NAME)
     public String getResultAttributeName() {
         return this.resultAttributeName;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new NlpSentimentOperator(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/projection/ProjectionPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/projection/ProjectionPredicate.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -24,5 +25,10 @@ public class ProjectionPredicate extends PredicateBase {
     @JsonProperty(value = PropertyNameConstants.ATTRIBUTE_NAMES)
     public List<String> getProjectionFields() {
         return new ArrayList<>(projectionFields);
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new ProjectionOperator(this);
     }
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexPredicate.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -68,6 +69,11 @@ public class RegexPredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.REGEX_IGNORE_CASE)
     public Boolean isIgnoreCase() {
         return this.ignoreCase;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new RegexMatcher(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexmatcher/RegexSourcePredicate.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
 public class RegexSourcePredicate extends RegexPredicate {
@@ -60,6 +61,11 @@ public class RegexSourcePredicate extends RegexPredicate {
     @JsonProperty(PropertyNameConstants.REGEX_USE_INDEX)
     public Boolean isUseIndex() {
         return this.useIndex;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new RegexMatcherSourceOperator(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexsplit/RegexSplitPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/regexsplit/RegexSplitPredicate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -70,6 +71,11 @@ public class RegexSplitPredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.SPLIT_TYPE)
     public SplitType getSplitType() {
         return splitType;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new RegexSplitOperator(this);
     }
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sampler/SamplerPredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/sampler/SamplerPredicate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -55,6 +56,11 @@ public class SamplerPredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.SAMPLE_TYPE)
     public SampleType getSampleType() {
         return sampleType;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new Sampler(this);
     }
     
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/file/FileSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/file/FileSourcePredicate.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -108,6 +109,11 @@ public class FileSourcePredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.FILE_ALLOWED_EXTENSIONS)
     public List<String> getAllowedExtensions() {
         return Collections.unmodifiableList(this.allowedExtensions);
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new FileSourceOperator(this);
     }
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/scan/ScanSourcePredicate.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/source/scan/ScanSourcePredicate.java
@@ -3,6 +3,7 @@ package edu.uci.ics.textdb.exp.source.scan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.exp.common.PredicateBase;
 import edu.uci.ics.textdb.exp.common.PropertyNameConstants;
 
@@ -26,6 +27,11 @@ public class ScanSourcePredicate extends PredicateBase {
     @JsonProperty(PropertyNameConstants.TABLE_NAME)
     public String getTableName() {
         return this.tableName;
+    }
+    
+    @Override
+    public IOperator newOperator() {
+        return new ScanBasedSourceOperator(this);
     }
     
 }


### PR DESCRIPTION
This PR adds a new abstract function `public IOperator newOperator()` to the `PredicateBase` class. 

The purpose of this function is to bind each predicate with its corresponding operator. So we don't have to write another file to store the map of the predicate class and operator class.