### PR TITLE
[Issue #395] Modify Property Constants to Camel case

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PredicateBase.java
@@ -43,7 +43,7 @@ import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME, // logical user-defined type names are used (rather than Java class names)
         include = JsonTypeInfo.As.PROPERTY, // make the type info as a property in the JSON representation
-        property = "operatorType" // the name of the JSON property indicating the type
+        property = PropertyNameConstants.OPERATOR_TYPE // the name of the JSON property indicating the type
 )
 @JsonSubTypes({ 
         @Type(value = DictionaryPredicate.class, name = "DictionaryMatcher"), 
@@ -74,12 +74,12 @@ public abstract class PredicateBase implements IPredicate {
     // default id is random uuid (internal code doesn't care about id)
     private String id = UUID.randomUUID().toString();
     
-    @JsonProperty("operatorID")
+    @JsonProperty(PropertyNameConstants.OPERATOR_ID)
     public void setID(String id) {
         this.id = id;
     }
     
-    @JsonProperty("operatorID")
+    @JsonProperty(PropertyNameConstants.OPERATOR_ID)
     public String getID() {
         return id;
     }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PropertyNameConstants.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/common/PropertyNameConstants.java
@@ -11,20 +11,29 @@ public class PropertyNameConstants {
     
     private PropertyNameConstants() {};
     
-    // common property names
+    // metadata property names
+    public static final String OPERATOR_ID = "operatorID";
+    public static final String OPERATOR_TYPE = "operatorType";
+    public static final String ORIGIN_OPERATOR_ID = "origin";
+    public static final String DESTINATION_OPERATOR_ID = "destination";
+    public static final String OPERATOR_LIST = "operators";
+    public static final String OPERATOR_LINK_LIST = "links";
+    
+    // common operator property names
     public static final String ATTRIBUTE_NAMES = "attributes";
     public static final String ATTRIBUTE_NAME = "attribute";
-    public static final String RESULT_ATTRIBUTE_NAME = "result_attribute";
-    public static final String LUCENE_ANALYZER_STRING = "lucene_analzer";
-    public static final String SPAN_LIST_NAME = "span_list_name";
-    public static final String TABLE_NAME = "data_source";
-    public static final String FILE_PATH = "file_path";
+    public static final String RESULT_ATTRIBUTE_NAME = "resultAttribute";
+    public static final String LUCENE_ANALYZER_STRING = "luceneAnalyzer";
+    public static final String SPAN_LIST_NAME = "spanListName";
+    public static final String TABLE_NAME = "tableName";
+    public static final String FILE_PATH = "filePath";
     public static final String LIMIT = "limit";
     public static final String OFFSET = "offset";
+    public static final String ADD_SPANS = "addSpans";
     
     // related to keyword matcher
     public static final String KEYWORD_QUERY = "query";
-    public static final String KEYWORD_MATCHING_TYPE = "matching_type";
+    public static final String KEYWORD_MATCHING_TYPE = "matchingType";
     
     // related to dictionary matcher
     public static final String DICTIONARY = "dictionary";
@@ -48,13 +57,13 @@ public class PropertyNameConstants {
     public static final String SPLIT_REGEX = "splitRegex";
 
     // related to sampler
-    public static final String SAMPLE_SIZE = "sample_size";
-    public static final String SAMPLE_TYPE = "sample_type";
+    public static final String SAMPLE_SIZE = "sampleSize";
+    public static final String SAMPLE_TYPE = "sampleType";
     
     // related to file source
-    public static final String FILE_MAX_DEPTH = "max_depth";
+    public static final String FILE_MAX_DEPTH = "maxDepth";
     public static final String FILE_RECURSIVE = "recursive";
-    public static final String FILE_ALLOWED_EXTENSIONS = "allowed_extensions";
+    public static final String FILE_ALLOWED_EXTENSIONS = "allowedExtensions";
     
     // related to join
     public static final String INNER_ATTRIBUTE_NAME = "innerAttribute";

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
@@ -50,10 +50,10 @@ public class PredicateBaseTest {
         
         JsonNode predicateJsonNode = objectMapper.readValue(predicateJson, JsonNode.class);
         JsonNode resultPredicateJsonNode = objectMapper.readValue(resultPredicateJson, JsonNode.class);
-
+        
         Assert.assertEquals(predicateJsonNode, resultPredicateJsonNode);
-        Assert.assertTrue(predicateJson.contains("operatorType"));
-        Assert.assertTrue(predicateJson.contains("operatorID"));
+        Assert.assertTrue(predicateJson.contains(PropertyNameConstants.OPERATOR_TYPE));
+        Assert.assertTrue(predicateJson.contains(PropertyNameConstants.OPERATOR_ID));
     }
     
     private static List<String> attributeNames = Arrays.asList("attr1", "attr2");


### PR DESCRIPTION
This PR modifies Property Constants from c-style naming `var_name` to Java style naming (which also the naming style of Javascript) `varName`.