### PR TITLE
Fix a bug where deleteTable doesn't make tableName lowercase.

### DIFF
--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
@@ -54,6 +54,7 @@ public class RelationManager {
      */
     public boolean checkTableExistence(String tableName) {
         try {
+            tableName = tableName.toLowerCase();
             return getTableCatalogTuple(tableName) != null;
         } catch (StorageException e) {
             // TODO: change it to textdb runtime exception
@@ -78,13 +79,12 @@ public class RelationManager {
      */
     public void createTable(String tableName, String indexDirectory, Schema schema, String luceneAnalyzerString)
             throws StorageException {
+        // convert the table name to lower case
+        tableName = tableName.toLowerCase();
         // table should not exist
         if (checkTableExistence(tableName)) {
             throw new StorageException(String.format("Table %s already exists.", tableName));
         }
-        
-        // convert the table name to lower case
-        tableName = tableName.toLowerCase();
         // convert the index directory to its absolute path
         try {
             indexDirectory = new File(indexDirectory).getCanonicalPath();
@@ -139,6 +139,7 @@ public class RelationManager {
      * @throws StorageException
      */
     public void deleteTable(String tableName) throws StorageException {
+        tableName = tableName.toLowerCase();
         // User can't delete catalog table
         if (isSystemCatalog(tableName)) {
             throw new StorageException("Deleting a system catalog table is prohibited.");

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/RelationManagerTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/RelationManagerTest.java
@@ -374,5 +374,27 @@ public class RelationManagerTest {
         relationManager.deleteTable(tableName1);  
     }
     
+    /*
+     * Test that table name with upper case in it is handled properly.
+     */
+    @Test
+    public void test16() throws Exception {
+        String tableName1 = "Relation_Manager_Test_Table_15_1";
+        
+        String indexDirectory = "./index/test_table/relation_manager_test_table_16";
+        Schema schema = new Schema(new Attribute("content", AttributeType.TEXT));
+        String luceneAnalyzerString = "standard";
+        
+        relationManager.deleteTable(tableName1);
+        
+        relationManager.createTable(tableName1, indexDirectory, schema, luceneAnalyzerString);
+        
+        Assert.assertTrue(relationManager.checkTableExistence(tableName1));
+        
+        relationManager.deleteTable(tableName1);  
+        
+        Assert.assertTrue(! relationManager.checkTableExistence(tableName1));
+    }
+    
     
 }


### PR DESCRIPTION
This PR fixes a bug where RelationManager `deleteTable` function doesn't convert the table name to lowercase. This leads to that a table name with upper case in it cannot be properly deleted.

This PR also adds a new test case for this scenario.