### PR TITLE
[Issue #474] Introduce TEXTDB_HOME environment variable and start using it.

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
@@ -3,12 +3,6 @@
  */
 package edu.uci.ics.textdb.api.constants;
 
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Arrays;
-
-import edu.uci.ics.textdb.api.exception.TextDBException;
-
 /**
  * @author sandeepreddy602
  * @author Zuozhi Wang (zuozhi)

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
@@ -3,6 +3,12 @@
  */
 package edu.uci.ics.textdb.api.constants;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import edu.uci.ics.textdb.api.exception.TextDBException;
+
 /**
  * @author sandeepreddy602
  * @author Zuozhi Wang (zuozhi)
@@ -10,6 +16,27 @@ package edu.uci.ics.textdb.api.constants;
  */
 public class DataConstants {
     public static final String TEXTDB_HOME = "TEXTDB_HOME";
+    
+    public enum TextdbProject {
+        TEXTDB_API("textdb-api"),
+        TEXTDB_DATAFLOW("textdb-dataflow"),
+        TEXTDB_EXP("textdb-exp"),
+        TEXTDB_PERFTEST("textdb-perftest"),
+        TEXTDB_SANDBOX("textdb-sandbox"),
+        TEXTDB_STORAGE("textdb-storage"),
+        TEXTDB_TEXTQL("textdb-textql"),
+        TEXTDB_WEB("textdb-web");
+        
+        private String projectName;
+        
+        TextdbProject(String projectName) {
+            this.projectName = projectName;
+        }
+        
+        public String getProjectName() {
+            return this.projectName;
+        }
+    }
     
     public static final String INDEX_DIR = "../index";
     public static final String SCAN_QUERY = "*:*";

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
@@ -9,6 +9,8 @@ package edu.uci.ics.textdb.api.constants;
  *
  */
 public class DataConstants {
+    public static final String TEXTDB_HOME = "TEXTDB_HOME";
+    
     public static final String INDEX_DIR = "../index";
     public static final String SCAN_QUERY = "*:*";
     public static final int MAX_RESULTS = 100;

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/DataConstants.java
@@ -9,7 +9,9 @@ package edu.uci.ics.textdb.api.constants;
  *
  */
 public class DataConstants {
-    public static final String TEXTDB_HOME = "TEXTDB_HOME";
+    
+    public static final String HOME_ENV_VAR = "TEXTDB_HOME";
+    public static final String HOME_FOLDER_NAME = "textdb";
     
     public enum TextdbProject {
         TEXTDB_API("textdb-api"),

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
@@ -11,7 +11,7 @@ import java.util.stream.IntStream;
 import edu.uci.ics.textdb.api.constants.DataConstants;
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.constants.DataConstants.TextdbProject;
-import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.exception.StorageException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.Schema;
@@ -19,7 +19,23 @@ import edu.uci.ics.textdb.api.tuple.Tuple;
 
 public class Utils {
     
-    public static String findResourcePath(String resourcePath, TextdbProject subProject) {
+    /**
+     * Find the path of resource files under textdb-perftest by:
+     *   1): try to use TEXTDB_HOME environment variable, 
+     *   if it fails then:
+     *   2): compare if the current directory is textdb (where TEXTDB_HOME should be), 
+     *   if it's not then:
+     *   3): compare if the current directory is a textdb subproject, 
+     *   if it's not then:
+
+     *   Finding resources will fail
+     * 
+     * @param resourcePath, the path to a resource relative to textdb-xxx/src/main/resources
+     * @param subProject, the sub project where the resource is located
+     * @return the real absolute path to the resource
+     * @throws StorageException if finding fails
+     */
+    public static String findResourcePath(String resourcePath, TextdbProject subProject) throws StorageException{
         try {
             // try use TEXTDB_HOME environment variable first
             if (System.getenv(DataConstants.TEXTDB_HOME) != null) {
@@ -45,11 +61,11 @@ public class Utils {
                     return Paths.get(currentWorkingDirectory, "../", subProject.getProjectName(), "/src/main/resources", resourcePath)
                             .toRealPath().toString(); 
                 }
-                throw new TextDBException(
+                throw new StorageException(
                         "Finding perftest resource failed. Current working directory is " + currentWorkingDirectory);
             }
         } catch (IOException e) {
-            throw new TextDBException(e);
+            throw new StorageException(e);
         }
     }
     

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
@@ -20,28 +20,41 @@ import edu.uci.ics.textdb.api.tuple.Tuple;
 public class Utils {
     
     /**
-     * Find the path of resource files under textdb-perftest by:
+     * Gets the path of resource files under the a subproject's resource folder (in src/main/resources)
+     * 
+     * @param resourcePath, the path to a resource relative to textdb-xxx/src/main/resources
+     * @param subProject, the sub project where the resource is located
+     * @return the path to the resource
+     * @throws StorageException if finding fails
+     */
+    public static String getResourcePath(String resourcePath, TextdbProject subProject) throws StorageException {
+        return Paths.get(
+                getTextdbHomePath(), 
+                subProject.getProjectName(), 
+                "/src/main/resources", 
+                resourcePath).toString();
+    }
+    
+    /**
+     * Gets the path of the textdb home directory by:
      *   1): try to use TEXTDB_HOME environment variable, 
      *   if it fails then:
      *   2): compare if the current directory is textdb (where TEXTDB_HOME should be), 
      *   if it's not then:
      *   3): compare if the current directory is a textdb subproject, 
      *   if it's not then:
-
-     *   Finding resources will fail
+     *   
+     *   Finding textdb home directory will fail
      * 
-     * @param resourcePath, the path to a resource relative to textdb-xxx/src/main/resources
-     * @param subProject, the sub project where the resource is located
-     * @return the real absolute path to the resource
-     * @throws StorageException if finding fails
+     * @return the real absolute path to textdb home directory
+     * @throws StorageException if can not find textdb home
      */
-    public static String findResourcePath(String resourcePath, TextdbProject subProject) throws StorageException{
+    public static String getTextdbHomePath() throws StorageException {
         try {
             // try use TEXTDB_HOME environment variable first
             if (System.getenv(DataConstants.TEXTDB_HOME) != null) {
                 String textdbHome = System.getenv(DataConstants.TEXTDB_HOME);
-                return Paths.get(textdbHome, subProject.getProjectName(), "/src/main/resources", resourcePath)
-                        .toRealPath().toString();
+                return Paths.get(textdbHome).toRealPath().toString();
             } else {
                 // if environment is not found, try if the current directory is 
                 String currentWorkingDirectory = Paths.get("").toRealPath().toString();
@@ -54,15 +67,13 @@ public class Utils {
                     .filter(project -> currentWorkingDirectory.endsWith(project)).findAny().isPresent();
                 
                 if (isTextdbHome) {
-                    return Paths.get(currentWorkingDirectory, subProject.getProjectName(), "/src/main/resources", resourcePath)
-                            .toRealPath().toString();
+                    return Paths.get(currentWorkingDirectory).toRealPath().toString();
                 }
                 if (isSubProject) {
-                    return Paths.get(currentWorkingDirectory, "../", subProject.getProjectName(), "/src/main/resources", resourcePath)
-                            .toRealPath().toString(); 
+                    return Paths.get(currentWorkingDirectory, "../").toRealPath().toString(); 
                 }
                 throw new StorageException(
-                        "Finding perftest resource failed. Current working directory is " + currentWorkingDirectory);
+                        "Finding textdb home path failed. Current working directory is " + currentWorkingDirectory);
             }
         } catch (IOException e) {
             throw new StorageException(e);

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
@@ -1,18 +1,57 @@
 package edu.uci.ics.textdb.api.utils;
 
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import edu.uci.ics.textdb.api.constants.DataConstants;
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.constants.DataConstants.TextdbProject;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.tuple.Tuple;
 
 public class Utils {
+    
+    public static String findResourcePath(String resourcePath, TextdbProject subProject) {
+        try {
+            // try use TEXTDB_HOME environment variable first
+            if (System.getenv(DataConstants.TEXTDB_HOME) != null) {
+                String textdbHome = System.getenv(DataConstants.TEXTDB_HOME);
+                return Paths.get(textdbHome, subProject.getProjectName(), "/src/main/resources", resourcePath)
+                        .toRealPath().toString();
+            } else {
+                // if environment is not found, try if the current directory is 
+                String currentWorkingDirectory = Paths.get("").toRealPath().toString();
+                
+                // if the current directory ends with textdb (TEXTDB_HOME location)
+                boolean isTextdbHome = currentWorkingDirectory.endsWith("textdb");
+                // if the current directory is one of the sub-projects
+                boolean isSubProject = Arrays.asList(TextdbProject.values()).stream()
+                    .map(project -> project.getProjectName())
+                    .filter(project -> currentWorkingDirectory.endsWith(project)).findAny().isPresent();
+                
+                if (isTextdbHome) {
+                    return Paths.get(currentWorkingDirectory, subProject.getProjectName(), "/src/main/resources", resourcePath)
+                            .toRealPath().toString();
+                }
+                if (isSubProject) {
+                    return Paths.get(currentWorkingDirectory, "../", subProject.getProjectName(), "/src/main/resources", resourcePath)
+                            .toRealPath().toString(); 
+                }
+                throw new TextDBException(
+                        "Finding perftest resource failed. Current working directory is " + currentWorkingDirectory);
+            }
+        } catch (IOException e) {
+            throw new TextDBException(e);
+        }
+    }
     
     /**
     *

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
@@ -22,7 +22,7 @@ public class Utils {
     /**
      * Gets the path of resource files under the a subproject's resource folder (in src/main/resources)
      * 
-     * @param resourcePath, the path to a resource relative to textdb-xxx/src/main/resources
+     * @param resourcePath, the path to a resource relative to subproject/src/main/resources
      * @param subProject, the sub project where the resource is located
      * @return the path to the resource
      * @throws StorageException if finding fails
@@ -51,16 +51,16 @@ public class Utils {
      */
     public static String getTextdbHomePath() throws StorageException {
         try {
-            // try use TEXTDB_HOME environment variable first
-            if (System.getenv(DataConstants.TEXTDB_HOME) != null) {
-                String textdbHome = System.getenv(DataConstants.TEXTDB_HOME);
+            // try to use TEXTDB_HOME environment variable first
+            if (System.getenv(DataConstants.HOME_ENV_VAR) != null) {
+                String textdbHome = System.getenv(DataConstants.HOME_ENV_VAR);
                 return Paths.get(textdbHome).toRealPath().toString();
             } else {
-                // if environment is not found, try if the current directory is 
+                // if the environment variable is not found, try if the current directory is textdb
                 String currentWorkingDirectory = Paths.get("").toRealPath().toString();
                 
                 // if the current directory ends with textdb (TEXTDB_HOME location)
-                boolean isTextdbHome = currentWorkingDirectory.endsWith("textdb");
+                boolean isTextdbHome = currentWorkingDirectory.endsWith(DataConstants.HOME_FOLDER_NAME);
                 // if the current directory is one of the sub-projects
                 boolean isSubProject = Arrays.asList(TextdbProject.values()).stream()
                     .map(project -> project.getProjectName())

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/planstore/PlanStoreConstants.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/planstore/PlanStoreConstants.java
@@ -1,10 +1,12 @@
 package edu.uci.ics.textdb.exp.planstore;
 
+import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
 import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.utils.Utils;
 
 /**
  * Variables used in PlanStore.java.
@@ -17,7 +19,7 @@ public class PlanStoreConstants {
 
     public static final Pattern VALID_PLAN_NAME = Pattern.compile("^[a-zA-Z0-9\\-_]{1,}$");
 
-    public static final String INDEX_DIR = "../plan";
+    public static final String INDEX_DIR = Paths.get(Utils.getTextdbHomePath(), "plan").toString();
 
     public static final String NAME = "name";
     public static final String DESCRIPTION = "desc";

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -41,9 +41,9 @@ public class SampleExtraction {
     
     public static final String PROMED_SAMPLE_TABLE = "promed";
         
-    public static String promedFilesDirectory = PerfTestUtils.findResourcePath("/sample-data-files/promed");
-    public static String promedIndexDirectory = PerfTestUtils.findResourcePath("/index/standard/promed");
-    public static String sampleDataFilesDirectory = PerfTestUtils.findResourcePath("sample-data-files");        
+    public static String promedFilesDirectory = PerfTestUtils.getResourcePath("/sample-data-files/promed");
+    public static String promedIndexDirectory = PerfTestUtils.getResourcePath("/index/standard/promed");
+    public static String sampleDataFilesDirectory = PerfTestUtils.getResourcePath("sample-data-files");        
     
     
     public static void main(String[] args) throws Exception {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -41,9 +41,9 @@ public class SampleExtraction {
     
     public static final String PROMED_SAMPLE_TABLE = "promed";
         
-    public static String promedFilesDirectory = PerfTestUtils.getResourcePath("/sample-data-files/promed");
-    public static String promedIndexDirectory = PerfTestUtils.getResourcePath("/index/standard/promed");
-    public static String sampleDataFilesDirectory = PerfTestUtils.getResourcePath("sample-data-files");        
+    public static String promedFilesDirectory = PerfTestUtils.findResourcePath("/sample-data-files/promed");
+    public static String promedIndexDirectory = PerfTestUtils.findResourcePath("/index/standard/promed");
+    public static String sampleDataFilesDirectory = PerfTestUtils.findResourcePath("sample-data-files");        
     
     
     public static void main(String[] args) throws Exception {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -21,6 +21,7 @@ import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
 import edu.uci.ics.textdb.dataflow.sink.FileSink;
 import edu.uci.ics.textdb.dataflow.utils.DataflowUtils;
 import edu.uci.ics.textdb.perftest.promed.PromedSchema;
+import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.storage.DataWriter;
 import edu.uci.ics.textdb.storage.RelationManager;
 import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
@@ -30,9 +31,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,37 +41,11 @@ public class SampleExtraction {
     
     public static final String PROMED_SAMPLE_TABLE = "promed";
         
-    public static String promedFilesDirectory;
-    public static String promedIndexDirectory;
-    public static String sampleDataFilesDirectory;
-
-    static {
-        try {
-            // Finding the absolute path to the sample data files directory and index directory
-
-            // Checking if the resource is in a jar
-            String referencePath = SampleExtraction.class.getResource("").toURI().toString();
-            if(referencePath.substring(0, 3).equals("jar")) {
-                promedFilesDirectory = "../textdb-perftest/src/main/resources/sample-data-files/promed/";
-                promedIndexDirectory = "../textdb-perftest/src/main/resources/index/standard/promed/";
-                sampleDataFilesDirectory = "../textdb-perftest/src/main/resources/sample-data-files/";
-            }
-            else {
-                promedFilesDirectory = Paths.get(SampleExtraction.class.getResource("/sample-data-files/promed")
-                        .toURI())
-                        .toString();
-                promedIndexDirectory = Paths.get(SampleExtraction.class.getResource("/index/standard")
-                        .toURI())
-                        .toString() + "/promed";
-                sampleDataFilesDirectory = Paths.get(SampleExtraction.class.getResource("/sample-data-files")
-                        .toURI())
-                        .toString();
-            }
-        }
-        catch(URISyntaxException | FileSystemNotFoundException e) {
-            e.printStackTrace();
-        }
-    }
+    public static String promedFilesDirectory = PerfTestUtils.getResourcePath("/sample-data-files/promed");
+    public static String promedIndexDirectory = PerfTestUtils.getResourcePath("/index/standard/promed");
+    public static String sampleDataFilesDirectory = PerfTestUtils.getResourcePath("sample-data-files");        
+    
+    
     public static void main(String[] args) throws Exception {
         // write the index of data files
         // index only needs to be written once, after the first run, this function can be commented out

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -14,9 +13,9 @@ import java.util.Scanner;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
-import edu.uci.ics.textdb.api.constants.DataConstants;
+import edu.uci.ics.textdb.api.constants.DataConstants.TextdbProject;
 import edu.uci.ics.textdb.api.engine.Engine;
-import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.utils.Utils;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.storage.RelationManager;
 import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
@@ -33,48 +32,14 @@ public class PerfTestUtils {
      * These default paths work only when the program is run from the directory,
      * textdb-perftest
      */
-    public static String fileFolder = getResourcePath("/sample-data-files");
-    public static String standardIndexFolder = getResourcePath("/index/standard");
-    public static String trigramIndexFolder = getResourcePath("/index/trigram");
-    public static String resultFolder = getResourcePath("/perftest-files/results");
-    public static String queryFolder = getResourcePath("/perftest-files/queries");
+    public static String fileFolder = findResourcePath("/sample-data-files");
+    public static String standardIndexFolder = findResourcePath("/index/standard");
+    public static String trigramIndexFolder = findResourcePath("/index/trigram");
+    public static String resultFolder = findResourcePath("/perftest-files/results");
+    public static String queryFolder = findResourcePath("/perftest-files/queries");
     
-    /**
-     * Find the path of resource files under textdb-perftest by:
-     *   1): try to use TEXTDB_HOME environment variable, 
-     *   if it fails then:
-     *   2): compare if the current directory is textdb-perftest, 
-     *   if it's not then:
-     *   3): compare if the current directory is textdb, 
-     *   if it's not then:
-     *   This function will fail.
-     * 
-     * @param resourcePath
-     * @return
-     */
-    public static String getResourcePath(String resourcePath) {
-        try {
-            // try use TEXTDB_HOME environment variable first
-            if (System.getenv(DataConstants.TEXTDB_HOME) != null) {
-                String textdbHome = System.getenv(DataConstants.TEXTDB_HOME);
-                return Paths.get(textdbHome, "/textdb-perftest/src/main/resources", resourcePath)
-                        .toRealPath().toString();
-            } else {
-                // if environment is not found, try if the current directory is 
-                String currentWorkingDirectory = Paths.get("").toRealPath().toString();
-                if (currentWorkingDirectory.endsWith("textdb-perftest")) {
-                    return Paths.get(currentWorkingDirectory, "/src/main/resources", resourcePath)
-                            .toRealPath().toString();
-                } else if (currentWorkingDirectory.endsWith("textdb")){
-                    return Paths.get(currentWorkingDirectory, "/textdb-perftest/src/main/resources", resourcePath)
-                            .toRealPath().toString();
-                }
-                throw new TextDBException(
-                        "Finding perftest resource failed. Current working directory is " + currentWorkingDirectory);
-            }
-        } catch (IOException e) {
-            throw new TextDBException(e);
-        }
+    public static String findResourcePath(String resourcePath) {
+        return Utils.findResourcePath(resourcePath, TextdbProject.TEXTDB_PERFTEST);
     }
 
     /**

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -32,14 +32,14 @@ public class PerfTestUtils {
      * These default paths work only when the program is run from the directory,
      * textdb-perftest
      */
-    public static String fileFolder = findResourcePath("/sample-data-files");
-    public static String standardIndexFolder = findResourcePath("/index/standard");
-    public static String trigramIndexFolder = findResourcePath("/index/trigram");
-    public static String resultFolder = findResourcePath("/perftest-files/results");
-    public static String queryFolder = findResourcePath("/perftest-files/queries");
+    public static String fileFolder = getResourcePath("/sample-data-files");
+    public static String standardIndexFolder = getResourcePath("/index/standard");
+    public static String trigramIndexFolder = getResourcePath("/index/trigram");
+    public static String resultFolder = getResourcePath("/perftest-files/results");
+    public static String queryFolder = getResourcePath("/perftest-files/queries");
     
-    public static String findResourcePath(String resourcePath) {
-        return Utils.findResourcePath(resourcePath, TextdbProject.TEXTDB_PERFTEST);
+    public static String getResourcePath(String resourcePath) {
+        return Utils.getResourcePath(resourcePath, TextdbProject.TEXTDB_PERFTEST);
     }
 
     /**

--- a/textdb/textdb-perftest/src/main/resources/index/standard/.gitignore
+++ b/textdb/textdb-perftest/src/main/resources/index/standard/.gitignore
@@ -1,4 +1,4 @@
 *
 
 !.gitignore
-!abstract_100
+!promed

--- a/textdb/textdb-perftest/src/main/resources/index/trigram/.gitignore
+++ b/textdb/textdb-perftest/src/main/resources/index/trigram/.gitignore
@@ -1,4 +1,4 @@
 *
 
 !.gitignore
-!abstract_100
+!promed

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/CatalogConstants.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.textdb.storage;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,8 +49,8 @@ public class CatalogConstants {
     public static final String TABLE_CATALOG = "tableCatalog";
     public static final String SCHEMA_CATALOG = "schemaCatalog";
 
-    public static final String TABLE_CATALOG_DIRECTORY = "../catalog/table";
-    public static final String SCHEMA_CATALOG_DIRECTORY = "../catalog/schema";
+    public static final String TABLE_CATALOG_DIRECTORY = Paths.get(Utils.getTextdbHomePath(), "catalog", "table").toString();
+    public static final String SCHEMA_CATALOG_DIRECTORY = Paths.get(Utils.getTextdbHomePath(), "catalog", "schema").toString();
 
     // Schema for the "table catalog" table
     public static final String TABLE_NAME = "tableName";


### PR DESCRIPTION
This PR introduces the TEXTDB_HOME into the codebase. 

This PR adds a function to try to use TEXTDB_HOME to locate resources. It will try to use TEXTDB_HOME first, if it doesn't exist, the function will try other methods to locate the resources.