### PR TITLE
[Issue #471] Host new Angular GUI from textdb-web

### DIFF
--- a/textdb/textdb-angular-gui/app/services/current-data-service.ts
+++ b/textdb/textdb-angular-gui/app/services/current-data-service.ts
@@ -7,7 +7,7 @@ import { Data } from './data';
 
 declare var jQuery: any;
 
-const textdbUrl = 'http://localhost:8080/newqueryplan/execute';
+const textdbUrl = 'http://localhost:8080/api/newqueryplan/execute';
 
 const defaultData = {
     top: 20,

--- a/textdb/textdb-angular-gui/package.json
+++ b/textdb/textdb-angular-gui/package.json
@@ -4,6 +4,7 @@
   "description": "QuickStart package.json from the documentation, supplemented with testing support",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",
+    "compile": "tsc && concurrently", 
     "e2e": "tsc && concurrently \"http-server -s\" \"protractor protractor.config.js\" --kill-others --success first",
     "lint": "tslint ./app/**/*.ts -t verbose",
     "lite": "lite-server",

--- a/textdb/textdb-scripts/build.sh
+++ b/textdb/textdb-scripts/build.sh
@@ -1,0 +1,3 @@
+cd $TEXTDB_HOME
+mvn clean install -DskipTests
+./textdb-scripts/gui.sh

--- a/textdb/textdb-scripts/gui.sh
+++ b/textdb/textdb-scripts/gui.sh
@@ -1,0 +1,3 @@
+cd $TEXTDB_HOME/textdb-angular-gui
+npm install
+npm run compile

--- a/textdb/textdb-scripts/server.sh
+++ b/textdb/textdb-scripts/server.sh
@@ -1,0 +1,1 @@
+java -jar textdb-web/target/textdb-web-1.0-SNAPSHOT.jar server textdb-web/sample-config.yml 

--- a/textdb/textdb-web/pom.xml
+++ b/textdb/textdb-web/pom.xml
@@ -33,6 +33,11 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.dirkraft.dropwizard</groupId>
+            <artifactId>dropwizard-file-assets</artifactId>
+            <version>0.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.8.7</version>

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/TextdbWebApplication.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/TextdbWebApplication.java
@@ -2,11 +2,13 @@ package edu.uci.ics.textdb.web;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.github.dirkraft.dropwizard.fileassets.FileAssetsBundle;
 
 import edu.uci.ics.textdb.api.engine.Plan;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.dataflow.sink.TupleStreamSink;
 import edu.uci.ics.textdb.perftest.sample.SampleExtraction;
+import edu.uci.ics.textdb.perftest.twitter.TwitterSample;
 import edu.uci.ics.textdb.plangen.LogicalPlan;
 import edu.uci.ics.textdb.web.healthcheck.SampleHealthCheck;
 import edu.uci.ics.textdb.web.request.beans.KeywordSourceBean;
@@ -43,11 +45,14 @@ public class TextdbWebApplication extends Application<TextdbWebConfiguration> {
 
     @Override
     public void initialize(Bootstrap<TextdbWebConfiguration> bootstrap) {
-        // Will have some initialization information here
+        // serve static frontend GUI files
+        bootstrap.addBundle(new FileAssetsBundle("./textdb-angular-gui/", "/", "index.html"));
     }
 
     @Override
     public void run(TextdbWebConfiguration textdbWebConfiguration, Environment environment) throws Exception {
+        // serve backend at /api
+        environment.jersey().setUrlPattern("/api/*");
         // Creates an instance of the QueryPlanResource class to register with Jersey
         final QueryPlanResource queryPlanResource = new QueryPlanResource();
         // Registers the QueryPlanResource with Jersey
@@ -109,6 +114,9 @@ public class TextdbWebApplication extends Application<TextdbWebConfiguration> {
         System.out.println("Started Loading Stanford NLP");
         loadStanfordNLP();
         System.out.println("Finished Loading Stanford NLP");
+        System.out.println("Writing twitter index");
+        TwitterSample.writeTwitterIndex();
+        System.out.println("Finished writing twitter index");
         new TextdbWebApplication().run(args);
     }
 }

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/QueryPlanRequestTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/request/QueryPlanRequestTest.java
@@ -162,7 +162,7 @@ public class QueryPlanRequestTest {
                 "}";
         boolean exceptionThrownFlag = false;
         try {
-            QueryPlanRequest queryPlanRequest = MAPPER.readValue(jsonString, QueryPlanRequest.class);
+            MAPPER.readValue(jsonString, QueryPlanRequest.class);
         }
         catch(JsonMappingException e) {
             exceptionThrownFlag = true;

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/NewQueryPlanResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/NewQueryPlanResourceTest.java
@@ -41,6 +41,8 @@ public class NewQueryPlanResourceTest {
     public static final DropwizardAppRule<TextdbWebConfiguration> RULE =
             new DropwizardAppRule<>(TextdbWebApplication.class, ResourceHelpers.resourceFilePath("test-config.yml"));
     
+    public static String queryPlanEndpoint = "http://localhost:%d/api/newqueryplan/execute";
+    
     public static final String TEST_TABLE = "query_plan_test_table";
     
     public static final Schema TEST_SCHEMA = new Schema(
@@ -114,7 +116,7 @@ public class NewQueryPlanResourceTest {
         client.property(ClientProperties.CONNECT_TIMEOUT, 5000);
         client.property(ClientProperties.READ_TIMEOUT,    5000);
         Response response = client.target(
-                String.format("http://localhost:%d/newqueryplan/execute", RULE.getLocalPort()))
+                String.format(queryPlanEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(
                         new ObjectMapper().writeValueAsString(getLogicalPlan1()), 

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/PlanStoreResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/PlanStoreResourceTest.java
@@ -31,6 +31,8 @@ public class PlanStoreResourceTest {
     public static final DropwizardAppRule<TextdbWebConfiguration> RULE =
             new DropwizardAppRule<>(TextdbWebApplication.class, ResourceHelpers.resourceFilePath("test-config.yml"));
     public static Client client;
+    
+    public static String planStoreEndpoint = "http://localhost:%d/api/planstore";
 
     public static final String queryPlan1 = "  {\n" +
             "  \"name\": \"plan1\",\n" +
@@ -141,11 +143,11 @@ public class PlanStoreResourceTest {
     @Before
     public void deleteQueryPlans() {
         client.target(
-                String.format("http://localhost:%d/planstore/plan1", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan1", RULE.getLocalPort()))
                 .request()
                 .delete();
         client.target(
-                String.format("http://localhost:%d/planstore/plan2", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan2", RULE.getLocalPort()))
                 .request()
                 .delete();
     }
@@ -153,14 +155,14 @@ public class PlanStoreResourceTest {
     @Test
     public void checkAddOnePlan() throws IOException{
         Response response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlan1, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore/plan1", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan1", RULE.getLocalPort()))
                 .request()
                 .get();
         String returnedJson = response.readEntity(String.class);
@@ -172,21 +174,21 @@ public class PlanStoreResourceTest {
     public void checkUpdatePlan() throws IOException {
 
         Response response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlan1, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore/plan1", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan1", RULE.getLocalPort()))
                 .request()
                 .put(Entity.entity(updatedQueryPlan1, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore/plan1", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan1", RULE.getLocalPort()))
                 .request()
                 .get();
         String returnedJson = response.readEntity(String.class);
@@ -197,14 +199,14 @@ public class PlanStoreResourceTest {
     @Test
     public void checkDeletePlan() {
         Response response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlan2, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore/plan2", RULE.getLocalPort()))
+                String.format(planStoreEndpoint + "/plan2", RULE.getLocalPort()))
                 .request()
                 .delete();
 
@@ -214,21 +216,21 @@ public class PlanStoreResourceTest {
     @Test
     public void checkAddMultiplePlans() throws IOException{
         Response response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlan2, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlan1, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/planstore", RULE.getLocalPort()))
+                String.format(planStoreEndpoint, RULE.getLocalPort()))
                 .request()
                 .get();
 

--- a/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
+++ b/textdb/textdb-web/src/test/java/edu/uci/ics/textdb/web/resource/QueryPlanResourceTest.java
@@ -30,6 +30,8 @@ public class QueryPlanResourceTest {
     public static final DropwizardAppRule<TextdbWebConfiguration> RULE =
             new DropwizardAppRule<>(TextdbWebApplication.class, ResourceHelpers.resourceFilePath("test-config.yml"));
 
+    public static String queryPlanEndpoint = "http://localhost:%d/api/queryplan/execute";
+    
     public static final String queryPlanRequestString = "{\n" +
             "    \"operators\": [{\n" +
             "        \"operator_id\": \"operator1\",\n" +
@@ -99,14 +101,14 @@ public class QueryPlanResourceTest {
         client.property(ClientProperties.CONNECT_TIMEOUT, 5000);
         client.property(ClientProperties.READ_TIMEOUT,    5000);
         Response response = client.target(
-                String.format("http://localhost:%d/queryplan/execute", RULE.getLocalPort()))
+                String.format(queryPlanEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(queryPlanRequestString, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
 
         response = client.target(
-                String.format("http://localhost:%d/queryplan/execute", RULE.getLocalPort()))
+                String.format(queryPlanEndpoint, RULE.getLocalPort()))
                 .request()
                 .post(Entity.entity(faultyQueryPlanRequestString, MediaType.APPLICATION_JSON));
 


### PR DESCRIPTION
This PR hosts the new Angular GUI files from textdb-web.

The `index.html` file is mapped to the root URL. Users can directly visit the angular GUI by typing the website URL, for example `localhost:8080/`

The old API endpoints are re-mapped to base URL `/api`, for example:
old `/queryplan/execute` becomes `/api/queryplan/execute`