### PR TITLE
[CLOSED][Issue #452] Add JSON serialization/deserialization for all primary classes

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/JsonConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/JsonConstants.java
@@ -1,0 +1,21 @@
+package edu.uci.ics.textdb.api.constants;
+
+public class JsonConstants {
+    
+    private JsonConstants() { };
+    
+    public static final String ATTRIBUTE_NAME = "attributeName";
+    public static final String ATTRIBUTE_TYPE = "attributeType";
+    public static final String ATTRIBUTES = "attributes";
+    public static final String SCHEMA = "schema";
+    
+    public static final String FIELDS = "fields";
+    public static final String FIELD_VALUE = "value";
+    
+    public static final String SPAN_START = "start";
+    public static final String SPAN_END = "end";
+    public static final String SPAN_KEY = "key";
+    public static final String SPAN_VALUE = "value";
+    public static final String SPAN_TOKEN_OFFSET = "tokenOffset";
+    
+}

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DateField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DateField.java
@@ -2,11 +2,20 @@ package edu.uci.ics.textdb.api.field;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class DateField implements IField {
 
     private Date value;
 
-    public DateField(Date value) {
+    //TODO: current json serialization converts DateField to an int, which is not user friendly
+    @JsonCreator
+    public DateField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Date value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DoubleField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DoubleField.java
@@ -1,10 +1,18 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class DoubleField implements IField {
 
     private Double value;
 
-    public DoubleField(Double value) {
+    @JsonCreator
+    public DoubleField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Double value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IDField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IDField.java
@@ -2,11 +2,19 @@ package edu.uci.ics.textdb.api.field;
 
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class IDField implements IField {
     
     private final String _id;
     
-    public IDField(String idValue) {
+    @JsonCreator
+    public IDField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String idValue) {
         this._id = idValue;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IField.java
@@ -1,8 +1,32 @@
 package edu.uci.ics.textdb.api.field;
 
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+
 /**
  * Created by chenli on 3/31/16.
  */
 public interface IField {
+    
+    @JsonProperty(value = JsonConstants.FIELD_VALUE)
     Object getValue();
+    
+    public static HashMap<Class<? extends IField>, AttributeType> fieldTypeMap = new HashMap<Class<? extends IField>, AttributeType>() {
+        private static final long serialVersionUID = 7780232078216757034L; 
+    {
+        put(DateField.class, AttributeType.DATE);
+        put(DoubleField.class, AttributeType.DOUBLE);
+        put(IDField.class, AttributeType._ID_TYPE);
+        put(IntegerField.class, AttributeType.INTEGER);
+        put(ListField.class, AttributeType.LIST);
+        put(StringField.class, AttributeType.STRING);
+        put(TextField.class, AttributeType.TEXT);
+    }
+    };
+    
+    
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IntegerField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IntegerField.java
@@ -1,10 +1,18 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class IntegerField implements IField {
 
     private Integer value;
 
-    public IntegerField(Integer value) {
+    @JsonCreator
+    public IntegerField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Integer value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/ListField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/ListField.java
@@ -1,19 +1,30 @@
 
 package edu.uci.ics.textdb.api.field;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
 
 public class ListField<T> implements IField {
 
     private List<T> list;
 
-    public ListField(List<T> list) {
+    @JsonCreator
+    public ListField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            List<T> list) {
+        // TODO: make a copy of the list to avoid modifying the list
+        // but need to investigate the cost of doing so
         this.list = list;
     }
 
     @Override
     public List<T> getValue() {
-        return list;
+        return new ArrayList<>(list);
     }
 
     @Override
@@ -45,11 +56,6 @@ public class ListField<T> implements IField {
 
     @Override
     public String toString() {
-        String getStringResult = new String();
-        for (T val : list) {
-            getStringResult = getStringResult.concat(val.toString().concat(" "));
-        }
-        getStringResult = getStringResult.trim();
-        return "ListField [value=" + getStringResult + "]";
+        return "ListField [value=" + list.toString() + "]";
     }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/StringField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/StringField.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 /**
  * Created by chenli on 3/31/16. A field that is indexed but not tokenized: the
  * entire String value is indexed as a single token. For example this might be
@@ -10,7 +15,10 @@ public class StringField implements IField {
 
     private final String value;
 
-    public StringField(String value) {
+    @JsonCreator
+    public StringField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/TextField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/TextField.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 /**
  * Created by chenli on 3/31/16. A field that is indexed and tokenized, without
  * term vectors. For example this would be used on a 'body' field, that contains
@@ -9,7 +14,10 @@ public class TextField implements IField {
 
     private final String value;
 
-    public TextField(String value) {
+    @JsonCreator
+    public TextField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Attribute.java
@@ -1,20 +1,50 @@
 package edu.uci.ics.textdb.api.schema;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+
+/**
+ * An Attribute describes the name and type of a "column".
+ * 
+ * The name of the attribute will always be trimmed and is case insensitive.
+ * 
+ * @author Zuozhi Wang
+ *
+ */
 public class Attribute {
     private final String attributeName;
     private final AttributeType attributeType;
 
-    public Attribute(String attributeName, AttributeType type) {
-        this.attributeName = attributeName;
-        this.attributeType = type;
+    @JsonCreator
+    public Attribute(
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME, required = true)
+            String attributeName, 
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_TYPE, required = true)
+            AttributeType attributeType) {     
+        if (attributeName == null) {
+            throw new TextDBException("Cannot create Attribute: attributeName is null");
+        }
+        if (attributeType == null) {
+            throw new TextDBException("Cannot create Attribute: attributeType is null");
+        }
+        if (attributeName.trim().isEmpty()) {
+            throw new TextDBException("Cannot create Attribute: attributeName is empty");
+        }
+        this.attributeName = attributeName.trim();
+        this.attributeType = attributeType;
     }
-
-    public AttributeType getAttributeType() {
-        return attributeType;
-    }
-
+    
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME)
     public String getAttributeName() {
         return attributeName;
+    }
+
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_TYPE)
+    public AttributeType getAttributeType() {
+        return attributeType;
     }
 
     @Override
@@ -35,14 +65,6 @@ public class Attribute {
         }
         
         Attribute that = (Attribute) toCompare;
-        
-        if (this.attributeName == null) {
-            return that.attributeName == null;
-        }
-        if (this.attributeType == null) {
-            return that.attributeType == null;
-        }
-        
         return this.attributeName.equals(that.attributeName) && this.attributeType.equals(that.attributeType);
     }
     

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/AttributeType.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/AttributeType.java
@@ -1,12 +1,44 @@
 package edu.uci.ics.textdb.api.schema;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+
 public enum AttributeType {
     // A field that is indexed but not tokenized: the entire String
     // value is indexed as a single token
-    STRING, INTEGER, DOUBLE, DATE,
+    STRING("string", StringField.class), 
     // A field that is indexed and tokenized,without term vectors
-    TEXT,
-    _ID_TYPE,
+    TEXT("text", TextField.class),
+    INTEGER("integer", IntegerField.class), 
+    DOUBLE("double", DoubleField.class), 
+    DATE("date", DateField.class),
+
+    _ID_TYPE("_id", IDField.class),
     // A field that is the list of values
-    LIST;
+    LIST("list", ListField.class);
+    
+    private String name;
+    private Class<? extends IField> fieldClass;
+    
+    AttributeType(String name, Class<? extends IField> fieldClass) {
+        this.name = name;
+        this.fieldClass = fieldClass;
+    }
+    
+    @JsonValue
+    public String getName() {
+        return this.name;
+    }
+    
+    public Class<? extends IField> getFieldClass() {
+        return this.fieldClass;
+    }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/span/Span.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/span/Span.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.span;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class Span {
     // The name of the field (in the tuple) where this span is present
     private String attributeName;
@@ -22,43 +27,60 @@ public class Span {
      * index of character 'n'+ 1 OR start+length Both of then result in same
      * values. tokenOffset = 2 position of word 'brown'
      */
-
     public static int INVALID_TOKEN_OFFSET = -1;
 
-    public Span(String attributeName, int start, int end, String key, String value) {
+    @JsonCreator
+    public Span(
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME, required = true)
+            String attributeName, 
+            @JsonProperty(value = JsonConstants.SPAN_START, required = true)
+            int start, 
+            @JsonProperty(value = JsonConstants.SPAN_END, required = true)
+            int end, 
+            @JsonProperty(value = JsonConstants.SPAN_KEY, required = true)
+            String key, 
+            @JsonProperty(value = JsonConstants.SPAN_VALUE, required = true)
+            String value,
+            @JsonProperty(value = JsonConstants.SPAN_TOKEN_OFFSET, required = true)
+            int tokenOffset) {
         this.attributeName = attributeName;
         this.start = start;
         this.end = end;
         this.key = key;
         this.value = value;
-        this.tokenOffset = INVALID_TOKEN_OFFSET;
-    }
-
-    public Span(String attributeName, int start, int end, String key, String value, int tokenOffset) {
-        this(attributeName, start, end, key, value);
         this.tokenOffset = tokenOffset;
     }
 
+    public Span(String attributeName, int start, int end, String key, String value) {
+        this(attributeName, start, end, key, value, INVALID_TOKEN_OFFSET);
+    }
+
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME)
     public String getAttributeName() {
         return attributeName;
     }
 
-    public String getKey() {
-        return key;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
+    @JsonProperty(value = JsonConstants.SPAN_START)
     public int getStart() {
         return start;
     }
 
+    @JsonProperty(value = JsonConstants.SPAN_END)
     public int getEnd() {
         return end;
     }
+    
+    @JsonProperty(value = JsonConstants.SPAN_KEY)
+    public String getKey() {
+        return key;
+    }
 
+    @JsonProperty(value = JsonConstants.SPAN_VALUE)
+    public String getValue() {
+        return value;
+    }
+
+    @JsonProperty(value = JsonConstants.SPAN_TOKEN_OFFSET)
     public int getTokenOffset() {
         return tokenOffset;
     }
@@ -84,35 +106,20 @@ public class Span {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        Span other = (Span) obj;
-
-        if (attributeName == null) {
-            if (other.attributeName != null)
-                return false;
-        } else if (!attributeName.equals(other.attributeName))
-            return false;
-
-        if (start != other.start)
-            return false;
-
-        if (end != other.end)
-            return false;
-
-        if (key == null) {
-            if (other.key != null)
-                return false;
-        } else if (!key.equals(other.key))
-            return false;
-
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-
-        if (tokenOffset != other.tokenOffset)
-            return false;
-
-        return true;
+        
+        Span that = (Span) obj;
+        
+        return this.attributeName.equals(that.attributeName) &&
+                this.start == that.start && 
+                this.end == that.end &&
+                this.key.equals(that.key) &&
+                this.value.equals(that.value) &&
+                this.tokenOffset == that.tokenOffset;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("Span[attributeName=%s, start=%d, end=%d, key=%s, value=%s, tokenOffset=%d]", 
+                attributeName, start, end, key, value, tokenOffset);
     }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -2,9 +2,14 @@ package edu.uci.ics.textdb.api.tuple;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Schema;
 
@@ -15,27 +20,44 @@ import edu.uci.ics.textdb.api.schema.Schema;
  * 
  * Created on 3/25/16.
  */
+@JsonDeserialize(using = TupleJsonDeserializer.class)
 public class Tuple {
     private final Schema schema;
     private final List<IField> fields;
 
     public Tuple(Schema schema, IField... fields) {
-        this.schema = schema;
-        // Converting to java.util.Arrays.ArrayList
-        // so that the collection remains static and cannot be extended/shrunk
-        // This makes List<IField> partially immutable.
-        // Partial because we can still replace an element at particular index.
-        this.fields = Arrays.asList(fields);
+        this(schema, Arrays.asList(fields));
     }
     
-    public Tuple(Schema schema, List<IField> fields) {
+    @JsonCreator
+    public Tuple(
+            @JsonProperty(value = JsonConstants.SCHEMA, required = true)
+            Schema schema, 
+            @JsonProperty(value = JsonConstants.FIELDS, required = true)
+            List<IField> fields) {
+        validateTuple(schema, fields);
         this.schema = schema;
         this.fields = fields;
     }
-
+    
+    @JsonProperty(value = JsonConstants.SCHEMA)
+    public Schema getSchema() {
+        return schema;
+    }
+    
+    @JsonProperty(value = JsonConstants.FIELDS)
+    public List<IField> getFields() {
+        return new ArrayList<>(this.fields);
+    }
+    
     @SuppressWarnings("unchecked")
     public <T extends IField> T getField(int index) {
-        return (T) fields.get(index);
+        if (index < fields.size()) {
+            return (T) fields.get(index);
+        }
+        throw new TextDBException(String.format(
+                "Cannot get field at index %d: tuple only has %d fields", 
+                index, fields.size()));
     }
     
     public <T extends IField> T getField(int index, Class<T> fieldClass) {
@@ -49,7 +71,32 @@ public class Tuple {
     public <T extends IField> T getField(String attributeName, Class<T> fieldClass) {
         return getField(schema.getIndex(attributeName));
     }
+    
+    /*
+     * Validates if the schema and the fields are consistent. 
+     * Throws TextDBException if not.
+     */
+    private void validateTuple(Schema schema, List<IField> fields) throws TextDBException {
+        // check if the size of schema and fields are the same
+        if (schema.size() != fields.size()) {
+            throw new TextDBException(String.format(
+                    "Cannot create Tuple: schema has %d attributes, but there are %d fields.", 
+                    schema.size(),
+                    fields.size()));
+        }
+        // check if the field classes are consistent with the schema's attribute types
+        for (int i = 0; i < fields.size(); i++) {
+            if (! schema.getAttribute(i).getAttributeType().getFieldClass().equals(
+                    fields.get(i).getClass())) {
+                throw new TextDBException(String.format(
+                        "Cannot create Tuple: attribute %s has type %s, but got %s",
+                        schema.getAttribute(i).getAttributeName(), schema.getAttribute(i).getAttributeType(),
+                        IField.fieldTypeMap.get(fields.get(i).getClass())));
+            }
+        }
+    }
 
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
@@ -58,6 +105,7 @@ public class Tuple {
         return result;
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
@@ -79,15 +127,9 @@ public class Tuple {
         return true;
     }
 
+    @Override
     public String toString() {
         return "Tuple [schema=" + schema + ", fields=" + fields + "]";
     }
 
-    public List<IField> getFields() {
-        return new ArrayList<>(this.fields);
-    }
-
-    public Schema getSchema() {
-        return schema;
-    }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
@@ -1,0 +1,48 @@
+package edu.uci.ics.textdb.api.tuple;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+
+public class TupleJsonDeserializer extends StdDeserializer<Tuple> {
+
+    private static final long serialVersionUID = 6244351898113632246L;
+    
+    public TupleJsonDeserializer() {
+        this(null);
+    }
+
+    public TupleJsonDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Tuple deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        JsonNode node = p.getCodec().readTree(p);
+        JsonNode schemaNode = node.get(JsonConstants.SCHEMA);
+        JsonNode fieldsNode = node.get(JsonConstants.FIELDS);
+        
+        Schema schema = new ObjectMapper().treeToValue(schemaNode, Schema.class);
+        ArrayList<IField> fields = new ArrayList<>();
+        for (int i = 0; i < schema.size(); i++) {
+            AttributeType attributeType = schema.getAttribute(i).getAttributeType();
+            JsonNode fieldNode = fieldsNode.get(i);
+            IField field = new ObjectMapper().treeToValue(fieldNode, attributeType.getFieldClass());
+            fields.add(field);
+        }
+        return new Tuple(schema, fields);
+    }
+
+
+}

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/Utils.java
@@ -183,7 +183,8 @@ public class Utils {
     * @return
     */
    public static Tuple removeFields(Tuple tuple, String... removeFields) {
-       List<String> removeFieldList = Arrays.asList(removeFields);
+       List<String> removeFieldList = Arrays.asList(removeFields).stream()
+               .filter(field -> tuple.getSchema().containsField(field)).collect(Collectors.toList());
        List<Integer> removedFeidsIndex = removeFieldList.stream()
                .map(attributeName -> tuple.getSchema().getIndex(attributeName)).collect(Collectors.toList());
        

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
@@ -1,0 +1,129 @@
+package edu.uci.ics.textdb.api;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import junit.framework.Assert;
+
+public class JsonSerializationTest {
+    
+    public static JsonNode testJsonSerialization(Object object) {
+        return testJsonSerialization(object, false);
+    }
+    
+    public static JsonNode testJsonSerialization(Object object, boolean printResults) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(object);
+            Object resultObject = objectMapper.readValue(json, object.getClass());
+            String resultJson = objectMapper.writeValueAsString(resultObject);
+            
+            JsonNode jsonNode = objectMapper.readValue(json, JsonNode.class);
+            JsonNode resultJsonNode = objectMapper.readValue(resultJson, JsonNode.class);
+            
+            if (printResults) {
+                System.out.println(resultJson);
+            }
+            
+            Assert.assertEquals(jsonNode, resultJsonNode);
+            return jsonNode;
+        } catch (IOException e) {
+            throw new TextDBException(e);
+        }
+    }
+    
+    @Test
+    public void testAttributeType() {
+        for (AttributeType attributeType : Arrays.asList(AttributeType.values())) {
+            testJsonSerialization(attributeType);
+        }
+    }
+    
+    @Test
+    public void testAttribute() {
+        Attribute attribute = new Attribute("attrName", AttributeType.TEXT);
+        testJsonSerialization(attribute);
+    }
+    
+    @Test
+    public void testSchema() {
+        Schema schema = new Schema(Arrays.asList(
+                new Attribute("_id", AttributeType._ID_TYPE),
+                new Attribute("text", AttributeType.TEXT),
+                new Attribute("payload", AttributeType.LIST)));
+        testJsonSerialization(schema);
+    }
+    
+    @Test
+    public void testSpan() {
+        Span span = new Span("attrName", 0, 10, "key", "value", 0);
+        testJsonSerialization(span);
+    }
+    
+    @Test
+    public void testSpanList() {
+        ListField<Span> spanListField = new ListField<Span>(Arrays.asList(
+                new Span("attrName", 0, 10, "key1", "value1", 0),
+                new Span("attrName", 11, 20, "key2", "value2", 1)));
+        testJsonSerialization(spanListField);
+    }
+    
+    @Test
+    public void testTextField() {
+        TextField textField = new TextField("text field test");
+        JsonNode jsonNode = testJsonSerialization(textField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isTextual());
+    }
+    
+    @Test
+    public void testIntegerField() {
+        IntegerField integerField = new IntegerField(100);
+        JsonNode jsonNode = testJsonSerialization(integerField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isInt());
+    }
+    
+    @Test
+    public void testDoubleField() {
+        DoubleField doubleField = new DoubleField(11.11);
+        JsonNode jsonNode = testJsonSerialization(doubleField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isFloatingPointNumber());
+    }
+    
+    @Test
+    public void testDateField() {
+        DateField dateField = new DateField(new Date());
+        testJsonSerialization(dateField);
+    } 
+
+    @Test
+    public void testTuple() {
+        Schema schema = new Schema(Arrays.asList(
+                new Attribute("_id", AttributeType._ID_TYPE),
+                new Attribute("text", AttributeType.TEXT)));
+        Tuple tuple = new Tuple(schema, Arrays.asList(
+                IDField.newRandomID(), new TextField("tuple test text")));
+        testJsonSerialization(tuple);
+    }
+    
+    
+    
+}

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/common/SchemaTest.java
@@ -8,6 +8,7 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
@@ -69,29 +70,27 @@ public class SchemaTest {
         Assert.assertEquals(expectedAttrNames, actualAttrNames);
     }
     
-    @Test
+    @Test(expected = TextDBException.class)
     public void testGetInvalidAttribute() {
-        Attribute retrievedAttribute1 = schema.getAttribute("invalid_attribute");
-        
-        Assert.assertNull(retrievedAttribute1);
+        schema.getAttribute("invalid_attribute");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddingNewAttribute() { // Should fail due to immutability
+    @Test
+    public void testAddingNewAttribute() {
+        // modifying the attributes returned by schema shouldn't affect the original schema
+        // because schema is immutable
         List<Attribute> attributes = schema.getAttributes();
         attributes.add(new Attribute("sampleField_3", AttributeType.STRING));
+        Assert.assertFalse(attributes.equals(schema.getAttributes()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRemovingAttribute() { // Should fail due to immutability
+    @Test
+    public void testRemovingAttribute() {
+        // modifying the attributes returned by schema shouldn't affect the original schema
+        // because schema is immutable
         List<Attribute> attributes = schema.getAttributes();
         attributes.remove(0);
+        Assert.assertFalse(attributes.equals(schema.getAttributes()));        
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddingInBetween() { // Should fail due to immutability
-        List<Attribute> attributes = schema.getAttributes();
-        attributes.add(0, new Attribute("sampleField_3", AttributeType.STRING));
-
-    }
 }

--- a/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
+++ b/textdb/textdb-storage/src/test/java/edu/uci/ics/textdb/storage/DataWriterReaderTest.java
@@ -13,6 +13,7 @@ import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.constants.TestConstants;
 import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
 import edu.uci.ics.textdb.api.utils.Utils;
 import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 
@@ -56,19 +57,8 @@ public class DataWriterReaderTest {
         }
         dataReader.close();
         
-        boolean equals = containsAllResults(TestConstants.getSamplePeopleTuples(), returnedTuples);
+        boolean equals = TestUtils.equals(TestConstants.getSamplePeopleTuples(), returnedTuples);
         Assert.assertTrue(equals);
     }
 
-    public static boolean containsAllResults(List<Tuple> expectedResults, List<Tuple> exactResults) {
-        expectedResults = Utils.removeFields(expectedResults, SchemaConstants._ID, SchemaConstants.PAYLOAD);
-        exactResults = Utils.removeFields(exactResults, SchemaConstants._ID, SchemaConstants.PAYLOAD);
-
-        if (expectedResults.size() != exactResults.size())
-            return false;
-        if (!(expectedResults.containsAll(exactResults)) || !(exactResults.containsAll(expectedResults)))
-            return false;
-
-        return true;
-    }
 }


### PR DESCRIPTION
According to the proposal in issue #452 , we want to add the ability to automatically convert every class inside TextDB to a JSON string using the Jackson library. So we don't have to write our own code to translate, for example, a tuple to JSON. Since this approach is error-prone and not elegant.

This PR adds the JSON serialization/deserialization support for all primary classes, including:
```
AttributeType
Attribute
Schema
IField subclasses (TextField, IntegerField, etc...)
Tuple
```

The test cases of JSON serialization/deserialization have also been added.