### PR TITLE
[Issue #452] Add JSON serialization/deserialization for all primary classes 

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/JsonConstants.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/constants/JsonConstants.java
@@ -1,0 +1,21 @@
+package edu.uci.ics.textdb.api.constants;
+
+public class JsonConstants {
+    
+    private JsonConstants() { };
+    
+    public static final String ATTRIBUTE_NAME = "attributeName";
+    public static final String ATTRIBUTE_TYPE = "attributeType";
+    public static final String ATTRIBUTES = "attributes";
+    public static final String SCHEMA = "schema";
+    
+    public static final String FIELDS = "fields";
+    public static final String FIELD_VALUE = "value";
+    
+    public static final String SPAN_START = "start";
+    public static final String SPAN_END = "end";
+    public static final String SPAN_KEY = "key";
+    public static final String SPAN_VALUE = "value";
+    public static final String SPAN_TOKEN_OFFSET = "tokenOffset";
+    
+}

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DateField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DateField.java
@@ -2,11 +2,20 @@ package edu.uci.ics.textdb.api.field;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class DateField implements IField {
 
     private Date value;
 
-    public DateField(Date value) {
+    //TODO: current json serialization converts DateField to an int, which is not user friendly
+    @JsonCreator
+    public DateField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Date value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DoubleField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/DoubleField.java
@@ -1,10 +1,18 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class DoubleField implements IField {
 
     private Double value;
 
-    public DoubleField(Double value) {
+    @JsonCreator
+    public DoubleField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Double value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IDField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IDField.java
@@ -2,11 +2,19 @@ package edu.uci.ics.textdb.api.field;
 
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class IDField implements IField {
     
     private final String _id;
     
-    public IDField(String idValue) {
+    @JsonCreator
+    public IDField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String idValue) {
         this._id = idValue;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IField.java
@@ -1,8 +1,17 @@
 package edu.uci.ics.textdb.api.field;
 
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+
 /**
  * Created by chenli on 3/31/16.
  */
 public interface IField {
+    
+    @JsonProperty(value = JsonConstants.FIELD_VALUE)
     Object getValue();
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IntegerField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/IntegerField.java
@@ -1,10 +1,18 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class IntegerField implements IField {
 
     private Integer value;
 
-    public IntegerField(Integer value) {
+    @JsonCreator
+    public IntegerField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            Integer value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/ListField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/ListField.java
@@ -3,11 +3,21 @@ package edu.uci.ics.textdb.api.field;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class ListField<T> implements IField {
 
     private List<T> list;
 
-    public ListField(List<T> list) {
+    @JsonCreator
+    public ListField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            List<T> list) {
+        // TODO: make a copy of the list to avoid modifying the list
+        // but need to investigate the cost of doing so
         this.list = list;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/StringField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/StringField.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 /**
  * Created by chenli on 3/31/16. A field that is indexed but not tokenized: the
  * entire String value is indexed as a single token. For example this might be
@@ -10,7 +15,10 @@ public class StringField implements IField {
 
     private final String value;
 
-    public StringField(String value) {
+    @JsonCreator
+    public StringField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/TextField.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/field/TextField.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.field;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 /**
  * Created by chenli on 3/31/16. A field that is indexed and tokenized, without
  * term vectors. For example this would be used on a 'body' field, that contains
@@ -9,7 +14,10 @@ public class TextField implements IField {
 
     private final String value;
 
-    public TextField(String value) {
+    @JsonCreator
+    public TextField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
+            String value) {
         this.value = value;
     }
 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Attribute.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Attribute.java
@@ -1,20 +1,32 @@
 package edu.uci.ics.textdb.api.schema;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class Attribute {
     private final String attributeName;
     private final AttributeType attributeType;
 
-    public Attribute(String attributeName, AttributeType type) {
+    @JsonCreator
+    public Attribute(
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME, required = true)
+            String attributeName, 
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_TYPE, required = true)
+            AttributeType attributeType) {     
         this.attributeName = attributeName;
-        this.attributeType = type;
+        this.attributeType = attributeType;
     }
-
-    public AttributeType getAttributeType() {
-        return attributeType;
-    }
-
+    
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME)
     public String getAttributeName() {
         return attributeName;
+    }
+
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_TYPE)
+    public AttributeType getAttributeType() {
+        return attributeType;
     }
 
     @Override

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/AttributeType.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/AttributeType.java
@@ -1,12 +1,44 @@
 package edu.uci.ics.textdb.api.schema;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.StringField;
+import edu.uci.ics.textdb.api.field.TextField;
+
 public enum AttributeType {
     // A field that is indexed but not tokenized: the entire String
     // value is indexed as a single token
-    STRING, INTEGER, DOUBLE, DATE,
+    STRING("string", StringField.class), 
     // A field that is indexed and tokenized,without term vectors
-    TEXT,
-    _ID_TYPE,
+    TEXT("text", TextField.class),
+    INTEGER("integer", IntegerField.class), 
+    DOUBLE("double", DoubleField.class), 
+    DATE("date", DateField.class),
+
+    _ID_TYPE("_id", IDField.class),
     // A field that is the list of values
-    LIST;
+    LIST("list", ListField.class);
+    
+    private String name;
+    private Class<? extends IField> fieldClass;
+    
+    AttributeType(String name, Class<? extends IField> fieldClass) {
+        this.name = name;
+        this.fieldClass = fieldClass;
+    }
+    
+    @JsonValue
+    public String getName() {
+        return this.name;
+    }
+    
+    public Class<? extends IField> getFieldClass() {
+        return this.fieldClass;
+    }
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Schema.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.textdb.api.constants.JsonConstants;
-import edu.uci.ics.textdb.api.exception.TextDBException;
 
 public class Schema {
     private List<Attribute> attributes;
@@ -19,6 +18,14 @@ public class Schema {
 
     public Schema(Attribute... attributes) {
         this(Arrays.asList(attributes));
+    }
+    
+    @JsonCreator
+    public Schema(
+            @JsonProperty(value = JsonConstants.ATTRIBUTES, required = true)
+            List<Attribute> attributes) {
+        this.attributes = attributes;
+        populateAttributeNameVsIndexMap();
     }
 
     private void populateAttributeNameVsIndexMap() {
@@ -34,6 +41,7 @@ public class Schema {
         return attributes;
     }
     
+    @JsonIgnore
     public List<String> getAttributeNames() {
         return attributes.stream().map(attr -> attr.getAttributeName()).collect(Collectors.toList());
     }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Schema.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/schema/Schema.java
@@ -6,17 +6,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+
 public class Schema {
     private List<Attribute> attributes;
     private Map<String, Integer> attributeNameVsIndex;
 
     public Schema(Attribute... attributes) {
-        // Converting to java.util.Arrays.ArrayList
-        // so that the collection remains static and cannot be extended/shrunk
-        // This makes List<Attribute> partially immutable.
-        // Partial because we can still replace an element at particular index.
-        this.attributes = Arrays.asList(attributes);
-        populateAttributeNameVsIndexMap();
+        this(Arrays.asList(attributes));
     }
 
     private void populateAttributeNameVsIndexMap() {
@@ -27,6 +29,7 @@ public class Schema {
         }
     }
 
+    @JsonProperty(value = JsonConstants.ATTRIBUTES)
     public List<Attribute> getAttributes() {
         return attributes;
     }
@@ -47,6 +50,7 @@ public class Schema {
         return attributes.get(attrIndex);
     }
 
+    @JsonIgnore
     public boolean containsField(String attributeName) {
         return attributeNameVsIndex.keySet().contains(attributeName.toLowerCase());
     }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/span/Span.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/span/Span.java
@@ -1,5 +1,10 @@
 package edu.uci.ics.textdb.api.span;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+
 public class Span {
     // The name of the field (in the tuple) where this span is present
     private String attributeName;
@@ -22,43 +27,60 @@ public class Span {
      * index of character 'n'+ 1 OR start+length Both of then result in same
      * values. tokenOffset = 2 position of word 'brown'
      */
-
     public static int INVALID_TOKEN_OFFSET = -1;
 
-    public Span(String attributeName, int start, int end, String key, String value) {
+    @JsonCreator
+    public Span(
+            @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME, required = true)
+            String attributeName, 
+            @JsonProperty(value = JsonConstants.SPAN_START, required = true)
+            int start, 
+            @JsonProperty(value = JsonConstants.SPAN_END, required = true)
+            int end, 
+            @JsonProperty(value = JsonConstants.SPAN_KEY, required = true)
+            String key, 
+            @JsonProperty(value = JsonConstants.SPAN_VALUE, required = true)
+            String value,
+            @JsonProperty(value = JsonConstants.SPAN_TOKEN_OFFSET, required = true)
+            int tokenOffset) {
         this.attributeName = attributeName;
         this.start = start;
         this.end = end;
         this.key = key;
         this.value = value;
-        this.tokenOffset = INVALID_TOKEN_OFFSET;
-    }
-
-    public Span(String attributeName, int start, int end, String key, String value, int tokenOffset) {
-        this(attributeName, start, end, key, value);
         this.tokenOffset = tokenOffset;
     }
 
+    public Span(String attributeName, int start, int end, String key, String value) {
+        this(attributeName, start, end, key, value, INVALID_TOKEN_OFFSET);
+    }
+
+    @JsonProperty(value = JsonConstants.ATTRIBUTE_NAME)
     public String getAttributeName() {
         return attributeName;
     }
 
-    public String getKey() {
-        return key;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
+    @JsonProperty(value = JsonConstants.SPAN_START)
     public int getStart() {
         return start;
     }
 
+    @JsonProperty(value = JsonConstants.SPAN_END)
     public int getEnd() {
         return end;
     }
+    
+    @JsonProperty(value = JsonConstants.SPAN_KEY)
+    public String getKey() {
+        return key;
+    }
 
+    @JsonProperty(value = JsonConstants.SPAN_VALUE)
+    public String getValue() {
+        return value;
+    }
+
+    @JsonProperty(value = JsonConstants.SPAN_TOKEN_OFFSET)
     public int getTokenOffset() {
         return tokenOffset;
     }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import edu.uci.ics.textdb.api.constants.JsonConstants;
-import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Schema;
 
@@ -35,7 +34,6 @@ public class Tuple {
             Schema schema, 
             @JsonProperty(value = JsonConstants.FIELDS, required = true)
             List<IField> fields) {
-        validateTuple(schema, fields);
         this.schema = schema;
         this.fields = fields;
     }
@@ -99,12 +97,5 @@ public class Tuple {
     public String toString() {
         return "Tuple [schema=" + schema + ", fields=" + fields + "]";
     }
-
-    public List<IField> getFields() {
-        return new ArrayList<>(this.fields);
-    }
-
-    public Schema getSchema() {
-        return schema;
-    }
+    
 }

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -2,9 +2,14 @@ package edu.uci.ics.textdb.api.tuple;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Schema;
 
@@ -15,24 +20,36 @@ import edu.uci.ics.textdb.api.schema.Schema;
  * 
  * Created on 3/25/16.
  */
+@JsonDeserialize(using = TupleJsonDeserializer.class)
 public class Tuple {
     private final Schema schema;
     private final List<IField> fields;
 
     public Tuple(Schema schema, IField... fields) {
-        this.schema = schema;
-        // Converting to java.util.Arrays.ArrayList
-        // so that the collection remains static and cannot be extended/shrunk
-        // This makes List<IField> partially immutable.
-        // Partial because we can still replace an element at particular index.
-        this.fields = Arrays.asList(fields);
+        this(schema, Arrays.asList(fields));
     }
     
-    public Tuple(Schema schema, List<IField> fields) {
+    @JsonCreator
+    public Tuple(
+            @JsonProperty(value = JsonConstants.SCHEMA, required = true)
+            Schema schema, 
+            @JsonProperty(value = JsonConstants.FIELDS, required = true)
+            List<IField> fields) {
+        validateTuple(schema, fields);
         this.schema = schema;
         this.fields = fields;
     }
-
+    
+    @JsonProperty(value = JsonConstants.SCHEMA)
+    public Schema getSchema() {
+        return schema;
+    }
+    
+    @JsonProperty(value = JsonConstants.FIELDS)
+    public List<IField> getFields() {
+        return new ArrayList<>(this.fields);
+    }
+    
     @SuppressWarnings("unchecked")
     public <T extends IField> T getField(int index) {
         return (T) fields.get(index);

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
@@ -1,0 +1,48 @@
+package edu.uci.ics.textdb.api.tuple;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.field.IField;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+
+public class TupleJsonDeserializer extends StdDeserializer<Tuple> {
+
+    private static final long serialVersionUID = 6244351898113632246L;
+    
+    public TupleJsonDeserializer() {
+        this(null);
+    }
+
+    public TupleJsonDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Tuple deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        JsonNode node = p.getCodec().readTree(p);
+        JsonNode schemaNode = node.get(JsonConstants.SCHEMA);
+        JsonNode fieldsNode = node.get(JsonConstants.FIELDS);
+        
+        Schema schema = new ObjectMapper().treeToValue(schemaNode, Schema.class);
+        ArrayList<IField> fields = new ArrayList<>();
+        for (int i = 0; i < schema.size(); i++) {
+            AttributeType attributeType = schema.getAttribute(i).getAttributeType();
+            JsonNode fieldNode = fieldsNode.get(i);
+            IField field = new ObjectMapper().treeToValue(fieldNode, attributeType.getFieldClass());
+            fields.add(field);
+        }
+        return new Tuple(schema, fields);
+    }
+
+
+}

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
@@ -35,8 +35,8 @@ public class TupleJsonDeserializer extends StdDeserializer<Tuple> {
         
         Schema schema = new ObjectMapper().treeToValue(schemaNode, Schema.class);
         ArrayList<IField> fields = new ArrayList<>();
-        for (int i = 0; i < schema.size(); i++) {
-            AttributeType attributeType = schema.getAttribute(i).getAttributeType();
+        for (int i = 0; i < schema.getAttributes().size(); i++) {
+            AttributeType attributeType = schema.getAttributes().get(i).getAttributeType();
             JsonNode fieldNode = fieldsNode.get(i);
             IField field = new ObjectMapper().treeToValue(fieldNode, attributeType.getFieldClass());
             fields.add(field);

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/TupleJsonDeserializer.java
@@ -15,6 +15,30 @@ import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 
+/**
+ * This class is a custom Json Deserializer for the Tuple class.
+ * 
+ * The Tuple class cannot use the default Deserializer because there are many
+ *   kinds of fields, and the field doesn't have information of the FieldType.
+ * This custom deserializer can use the schema information to process the JSON.
+ *   
+ * For example, a tuple has an IDField and a TextField, the JSON representation is:
+ * (IDField):   {"value": "id of the tuple"}  ("_id" is also a string)
+ * (TextField): {"value": "some text in the field"}
+ * There's no difference between the representation of IDField and TextField.
+ * 
+ * However, a tuple also contains its schema: 
+ * {"attributes": [
+ *     {"attributeName": "_id", "attributeType": "_id"},
+ *     {"attributeName": "textAttr", "attributeType": " text"}
+ * ]}
+ * Therefore, this custom deserializer can use the information:
+ *   the first field is an IDField, the second field is TextField,
+ *   to map each field to the right class.
+ * 
+ * @author Zuozhi Wang
+ *
+ */
 public class TupleJsonDeserializer extends StdDeserializer<Tuple> {
 
     private static final long serialVersionUID = 6244351898113632246L;

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
@@ -1,9 +1,15 @@
 package edu.uci.ics.textdb.api.utils;
 
+import java.io.IOException;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.tuple.Tuple;
+import junit.framework.Assert;
 
 /**
  * @author sandeepreddy602
@@ -64,6 +70,31 @@ public class TestUtils {
             return false;
         
         return expectedResults.containsAll(exactResults) && exactResults.containsAll(expectedResults);
+    }
+    
+    public static JsonNode testJsonSerialization(Object object) {
+        return testJsonSerialization(object, false);
+    }
+    
+    public static JsonNode testJsonSerialization(Object object, boolean printResults) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(object);
+            Object resultObject = objectMapper.readValue(json, object.getClass());
+            String resultJson = objectMapper.writeValueAsString(resultObject);
+            
+            JsonNode jsonNode = objectMapper.readValue(json, JsonNode.class);
+            JsonNode resultJsonNode = objectMapper.readValue(resultJson, JsonNode.class);
+            
+            if (printResults) {
+                System.out.println(resultJson);
+            }
+            
+            Assert.assertEquals(jsonNode, resultJsonNode);
+            return jsonNode;
+        } catch (IOException e) {
+            throw new TextDBException(e);
+        }
     }
     
 }

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
@@ -1,0 +1,129 @@
+package edu.uci.ics.textdb.api;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.uci.ics.textdb.api.constants.JsonConstants;
+import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.DateField;
+import edu.uci.ics.textdb.api.field.DoubleField;
+import edu.uci.ics.textdb.api.field.IDField;
+import edu.uci.ics.textdb.api.field.IntegerField;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.field.TextField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
+import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
+import edu.uci.ics.textdb.api.tuple.Tuple;
+import junit.framework.Assert;
+
+public class JsonSerializationTest {
+    
+    public static JsonNode testJsonSerialization(Object object) {
+        return testJsonSerialization(object, false);
+    }
+    
+    public static JsonNode testJsonSerialization(Object object, boolean printResults) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(object);
+            Object resultObject = objectMapper.readValue(json, object.getClass());
+            String resultJson = objectMapper.writeValueAsString(resultObject);
+            
+            JsonNode jsonNode = objectMapper.readValue(json, JsonNode.class);
+            JsonNode resultJsonNode = objectMapper.readValue(resultJson, JsonNode.class);
+            
+            if (printResults) {
+                System.out.println(resultJson);
+            }
+            
+            Assert.assertEquals(jsonNode, resultJsonNode);
+            return jsonNode;
+        } catch (IOException e) {
+            throw new TextDBException(e);
+        }
+    }
+    
+    @Test
+    public void testAttributeType() {
+        for (AttributeType attributeType : Arrays.asList(AttributeType.values())) {
+            testJsonSerialization(attributeType);
+        }
+    }
+    
+    @Test
+    public void testAttribute() {
+        Attribute attribute = new Attribute("attrName", AttributeType.TEXT);
+        testJsonSerialization(attribute);
+    }
+    
+    @Test
+    public void testSchema() {
+        Schema schema = new Schema(Arrays.asList(
+                new Attribute("_id", AttributeType._ID_TYPE),
+                new Attribute("text", AttributeType.TEXT),
+                new Attribute("payload", AttributeType.LIST)));
+        testJsonSerialization(schema);
+    }
+    
+    @Test
+    public void testSpan() {
+        Span span = new Span("attrName", 0, 10, "key", "value", 0);
+        testJsonSerialization(span);
+    }
+    
+    @Test
+    public void testSpanList() {
+        ListField<Span> spanListField = new ListField<Span>(Arrays.asList(
+                new Span("attrName", 0, 10, "key1", "value1", 0),
+                new Span("attrName", 11, 20, "key2", "value2", 1)));
+        testJsonSerialization(spanListField);
+    }
+    
+    @Test
+    public void testTextField() {
+        TextField textField = new TextField("text field test");
+        JsonNode jsonNode = testJsonSerialization(textField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isTextual());
+    }
+    
+    @Test
+    public void testIntegerField() {
+        IntegerField integerField = new IntegerField(100);
+        JsonNode jsonNode = testJsonSerialization(integerField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isInt());
+    }
+    
+    @Test
+    public void testDoubleField() {
+        DoubleField doubleField = new DoubleField(11.11);
+        JsonNode jsonNode = testJsonSerialization(doubleField);
+        Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isFloatingPointNumber());
+    }
+    
+    @Test
+    public void testDateField() {
+        DateField dateField = new DateField(new Date());
+        testJsonSerialization(dateField);
+    } 
+
+    @Test
+    public void testTuple() {
+        Schema schema = new Schema(Arrays.asList(
+                new Attribute("_id", AttributeType._ID_TYPE),
+                new Attribute("text", AttributeType.TEXT)));
+        Tuple tuple = new Tuple(schema, Arrays.asList(
+                IDField.newRandomID(), new TextField("tuple test text")));
+        testJsonSerialization(tuple);
+    }
+    
+    
+    
+}

--- a/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
+++ b/textdb/textdb-api/src/test/java/edu/uci/ics/textdb/api/JsonSerializationTest.java
@@ -1,16 +1,13 @@
 package edu.uci.ics.textdb.api;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.uci.ics.textdb.api.constants.JsonConstants;
-import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.DateField;
 import edu.uci.ics.textdb.api.field.DoubleField;
 import edu.uci.ics.textdb.api.field.IDField;
@@ -22,46 +19,22 @@ import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.api.utils.TestUtils;
 import junit.framework.Assert;
 
 public class JsonSerializationTest {
     
-    public static JsonNode testJsonSerialization(Object object) {
-        return testJsonSerialization(object, false);
-    }
-    
-    public static JsonNode testJsonSerialization(Object object, boolean printResults) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            String json = objectMapper.writeValueAsString(object);
-            Object resultObject = objectMapper.readValue(json, object.getClass());
-            String resultJson = objectMapper.writeValueAsString(resultObject);
-            
-            JsonNode jsonNode = objectMapper.readValue(json, JsonNode.class);
-            JsonNode resultJsonNode = objectMapper.readValue(resultJson, JsonNode.class);
-            
-            if (printResults) {
-                System.out.println(resultJson);
-            }
-            
-            Assert.assertEquals(jsonNode, resultJsonNode);
-            return jsonNode;
-        } catch (IOException e) {
-            throw new TextDBException(e);
-        }
-    }
-    
     @Test
     public void testAttributeType() {
         for (AttributeType attributeType : Arrays.asList(AttributeType.values())) {
-            testJsonSerialization(attributeType);
+            TestUtils.testJsonSerialization(attributeType);
         }
     }
     
     @Test
     public void testAttribute() {
         Attribute attribute = new Attribute("attrName", AttributeType.TEXT);
-        testJsonSerialization(attribute);
+        TestUtils.testJsonSerialization(attribute);
     }
     
     @Test
@@ -70,13 +43,13 @@ public class JsonSerializationTest {
                 new Attribute("_id", AttributeType._ID_TYPE),
                 new Attribute("text", AttributeType.TEXT),
                 new Attribute("payload", AttributeType.LIST)));
-        testJsonSerialization(schema);
+        TestUtils.testJsonSerialization(schema);
     }
     
     @Test
     public void testSpan() {
         Span span = new Span("attrName", 0, 10, "key", "value", 0);
-        testJsonSerialization(span);
+        TestUtils.testJsonSerialization(span);
     }
     
     @Test
@@ -84,34 +57,34 @@ public class JsonSerializationTest {
         ListField<Span> spanListField = new ListField<Span>(Arrays.asList(
                 new Span("attrName", 0, 10, "key1", "value1", 0),
                 new Span("attrName", 11, 20, "key2", "value2", 1)));
-        testJsonSerialization(spanListField);
+        TestUtils.testJsonSerialization(spanListField);
     }
     
     @Test
     public void testTextField() {
         TextField textField = new TextField("text field test");
-        JsonNode jsonNode = testJsonSerialization(textField);
+        JsonNode jsonNode = TestUtils.testJsonSerialization(textField);
         Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isTextual());
     }
     
     @Test
     public void testIntegerField() {
         IntegerField integerField = new IntegerField(100);
-        JsonNode jsonNode = testJsonSerialization(integerField);
+        JsonNode jsonNode = TestUtils.testJsonSerialization(integerField);
         Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isInt());
     }
     
     @Test
     public void testDoubleField() {
         DoubleField doubleField = new DoubleField(11.11);
-        JsonNode jsonNode = testJsonSerialization(doubleField);
+        JsonNode jsonNode = TestUtils.testJsonSerialization(doubleField);
         Assert.assertTrue(jsonNode.get(JsonConstants.FIELD_VALUE).isFloatingPointNumber());
     }
     
     @Test
     public void testDateField() {
         DateField dateField = new DateField(new Date());
-        testJsonSerialization(dateField);
+        TestUtils.testJsonSerialization(dateField);
     } 
 
     @Test
@@ -121,7 +94,7 @@ public class JsonSerializationTest {
                 new Attribute("text", AttributeType.TEXT)));
         Tuple tuple = new Tuple(schema, Arrays.asList(
                 IDField.newRandomID(), new TextField("tuple test text")));
-        testJsonSerialization(tuple);
+        TestUtils.testJsonSerialization(tuple);
     }
     
     

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/common/PredicateBaseTest.java
@@ -6,8 +6,8 @@ import java.util.List;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.uci.ics.textdb.api.utils.TestUtils;
 import edu.uci.ics.textdb.exp.dictionarymatcher.Dictionary;
 import edu.uci.ics.textdb.exp.dictionarymatcher.DictionaryPredicate;
 import edu.uci.ics.textdb.exp.dictionarymatcher.DictionarySourcePredicate;
@@ -47,17 +47,9 @@ public class PredicateBaseTest {
      *   
      */
     public static void testPredicate(PredicateBase predicate) throws Exception {  
-        ObjectMapper objectMapper = new ObjectMapper();
-        String predicateJson = objectMapper.writeValueAsString(predicate);
-        PredicateBase resultPredicate = objectMapper.readValue(predicateJson, PredicateBase.class);
-        String resultPredicateJson = objectMapper.writeValueAsString(resultPredicate);
-        
-        JsonNode predicateJsonNode = objectMapper.readValue(predicateJson, JsonNode.class);
-        JsonNode resultPredicateJsonNode = objectMapper.readValue(resultPredicateJson, JsonNode.class);
-        
-        Assert.assertEquals(predicateJsonNode, resultPredicateJsonNode);
-        Assert.assertTrue(predicateJson.contains(PropertyNameConstants.OPERATOR_TYPE));
-        Assert.assertTrue(predicateJson.contains(PropertyNameConstants.OPERATOR_ID));
+        JsonNode jsonNode = TestUtils.testJsonSerialization(predicate);
+        Assert.assertTrue(jsonNode.has(PropertyNameConstants.OPERATOR_TYPE));
+        Assert.assertTrue(jsonNode.has(PropertyNameConstants.OPERATOR_ID));
     }
     
     private static List<String> attributeNames = Arrays.asList("attr1", "attr2");

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/plangen/LogicalPlanJsonSerializationTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/plangen/LogicalPlanJsonSerializationTest.java
@@ -2,39 +2,20 @@ package edu.uci.ics.textdb.exp.plangen;
 
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import junit.framework.Assert;
+import edu.uci.ics.textdb.api.utils.TestUtils;
 
 public class LogicalPlanJsonSerializationTest {
     
     @Test
     public void testLogicalPlan() throws Exception {
         LogicalPlan logicalPlan = LogicalPlanTest.getLogicalPlan1();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String logicalPlanJson = objectMapper.writeValueAsString(logicalPlan);
-        LogicalPlan resultLogicalPlan = objectMapper.readValue(logicalPlanJson, LogicalPlan.class);
-        String rseultLogicalPlanJson = objectMapper.writeValueAsString(resultLogicalPlan);
-        
-        JsonNode logicalPlanJsonNode = objectMapper.readValue(logicalPlanJson, JsonNode.class);
-        JsonNode resultLogicalPlanJsonNode = objectMapper.readValue(rseultLogicalPlanJson, JsonNode.class);
-        
-        Assert.assertEquals(logicalPlanJsonNode, resultLogicalPlanJsonNode);
+        TestUtils.testJsonSerialization(logicalPlan);
     }
     
     @Test
     public void testOperatorLink() throws Exception {
         OperatorLink operatorLink = new OperatorLink("origin", "destination");
-        ObjectMapper objectMapper = new ObjectMapper();
-        String operatorLinkJson = objectMapper.writeValueAsString(operatorLink);
-        OperatorLink resultOperatorLink = objectMapper.readValue(operatorLinkJson, OperatorLink.class);
-        String rseultOperatorLinkJson = objectMapper.writeValueAsString(resultOperatorLink);
-        
-        JsonNode operatorLinkJsonNode = objectMapper.readValue(operatorLinkJson, JsonNode.class);
-        JsonNode resultOperatorLinkJsonNode = objectMapper.readValue(rseultOperatorLinkJson, JsonNode.class);
-        
-        Assert.assertEquals(operatorLinkJsonNode, resultOperatorLinkJsonNode);
+        TestUtils.testJsonSerialization(operatorLink);
     }
 
 }


### PR DESCRIPTION
According to the proposal in issue #452 , we want to add the ability to automatically convert every class inside TextDB to a JSON string using the Jackson library. So we don't have to write our own code to translate, for example, a tuple to JSON. Since this approach is error-prone and not elegant.

This PR adds the JSON serialization/deserialization support for all primary classes, including:

AttributeType
Attribute
Schema
IField subclasses (TextField, IntegerField, etc...)
Tuple
The test cases of JSON serialization/deserialization have also been added.