### PR TITLE
[Issue #492] Update perftest module to use the new exp module

### DIFF
--- a/textdb/textdb-perftest/pom.xml
+++ b/textdb/textdb-perftest/pom.xml
@@ -18,71 +18,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-            <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
-            <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-queryparser</artifactId>
-            <version>${lucene.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${org.json.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>edu.uci.ics.textdb</groupId>
-            <artifactId>textdb-api</artifactId>
-            <version>${textdb.version}</version>
-        </dependency>
-        <dependency>
         	<groupId>edu.uci.ics.textdb</groupId>
-        	<artifactId>textdb-dataflow</artifactId>
+        	<artifactId>textdb-exp</artifactId>
         	<version>${textdb.version}</version>
         </dependency>
-        <dependency>
-            <groupId>edu.uci.ics.textdb</groupId>
-            <artifactId>textdb-storage</artifactId>
-            <version>${textdb.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>edu.stanford.nlp</groupId>
-            <artifactId>stanford-corenlp</artifactId>
-            <version>3.6.0</version>
-        </dependency>
-        <dependency>
-            <groupId>edu.stanford.nlp</groupId>
-            <artifactId>stanford-corenlp</artifactId>
-            <version>3.6.0</version>
-            <classifier>models</classifier>
-        </dependency>
-        
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.8.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
         </dependency>
     </dependencies>
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -7,20 +7,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-
-import edu.uci.ics.textdb.api.constants.DataConstants;
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
-import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
 import edu.uci.ics.textdb.api.field.ListField;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-import edu.uci.ics.textdb.dataflow.common.Dictionary;
-import edu.uci.ics.textdb.dataflow.common.DictionaryPredicate;
-import edu.uci.ics.textdb.dataflow.dictionarymatcher.DictionaryMatcherSourceOperator;
+import edu.uci.ics.textdb.exp.dictionarymatcher.Dictionary;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionaryMatcherSourceOperator;
+import edu.uci.ics.textdb.exp.dictionarymatcher.DictionarySourcePredicate;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
+import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 
 /**
  * @author Hailey Pan
@@ -74,11 +71,11 @@ public class DictionaryMatcherPerformanceTest {
             String tableName = file.getName().replace(".txt", "");
 
             csvWriter(conjunctionCsv, file.getName(), queryFileName, dictionary,
-                    DataConstants.KeywordMatchingType.CONJUNCTION_INDEXBASED, tableName);
+                    KeywordMatchingType.CONJUNCTION_INDEXBASED, tableName);
             csvWriter(phraseCsv, file.getName(), queryFileName, dictionary,
-                    DataConstants.KeywordMatchingType.PHRASE_INDEXBASED, tableName);
+                    KeywordMatchingType.PHRASE_INDEXBASED, tableName);
             csvWriter(scanCsv, file.getName(), queryFileName, dictionary,
-                    DataConstants.KeywordMatchingType.SUBSTRING_SCANBASED, tableName);
+                    KeywordMatchingType.SUBSTRING_SCANBASED, tableName);
         }
     }
 
@@ -105,7 +102,7 @@ public class DictionaryMatcherPerformanceTest {
         fileWriter.append(recordNum + commaDelimiter);
         fileWriter.append(queryFileName + commaDelimiter);
         fileWriter.append(Integer.toString(dictionary.size()) + commaDelimiter);
-        match(dictionary, opType, new StandardAnalyzer(), tableName);
+        match(dictionary, opType, LuceneAnalyzerConstants.standardAnalyzerString(), tableName);
         fileWriter.append(String.format("%.4f", matchTime) + commaDelimiter);
         fileWriter.append(Integer.toString(resultCount));
         fileWriter.flush();
@@ -115,15 +112,14 @@ public class DictionaryMatcherPerformanceTest {
     /**
      * This function does match for a dictionary
      */
-    public static void match(ArrayList<String> queryList, KeywordMatchingType opType, Analyzer luceneAnalyzer,
+    public static void match(ArrayList<String> queryList, KeywordMatchingType opType, String luceneAnalyzerStr,
             String tableName) throws Exception {
         List<String> attributeNames = Arrays.asList(MedlineIndexWriter.ABSTRACT);
 
         Dictionary dictionary = new Dictionary(queryList);
-        DictionaryPredicate dictionaryPredicate = new DictionaryPredicate(dictionary, attributeNames, luceneAnalyzer,
-                opType);
-        DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionaryPredicate,
-                tableName);
+        DictionarySourcePredicate dictionarySourcePredicate = new DictionarySourcePredicate(dictionary, attributeNames, luceneAnalyzerStr,
+                opType, tableName, null);
+        DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionarySourcePredicate);
 
         long startMatchTime = System.currentTimeMillis();
         dictionaryMatcher.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -1,8 +1,9 @@
 package edu.uci.ics.textdb.perftest.dictionarymatcher;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -96,7 +97,8 @@ public class DictionaryMatcherPerformanceTest {
             ArrayList<String> dictionary, KeywordMatchingType opType, String tableName) throws Exception {
 
         PerfTestUtils.createFile(PerfTestUtils.getResultPath(resultFile), HEADER);
-        FileWriter fileWriter = new FileWriter(PerfTestUtils.getResultPath(resultFile), true);
+        BufferedWriter fileWriter = Files.newBufferedWriter
+                (PerfTestUtils.getResultPath(resultFile), StandardOpenOption.APPEND);
         fileWriter.append(newLine);
         fileWriter.append(currentTime + commaDelimiter);
         fileWriter.append(recordNum + commaDelimiter);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -14,14 +14,11 @@ import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.ListField;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-
-import edu.uci.ics.textdb.dataflow.common.FuzzyTokenPredicate;
-import edu.uci.ics.textdb.dataflow.fuzzytokenmatcher.FuzzyTokenMatcherSourceOperator;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenMatcherSourceOperator;
+import edu.uci.ics.textdb.exp.fuzzytokenmatcher.FuzzyTokenSourcePredicate;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
+import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 
 /**
  * @author Qing Tang
@@ -90,7 +87,7 @@ public class FuzzyTokenMatcherPerformanceTest {
                 fileWriter.append(file.getName() + delimiter);
                 fileWriter.append(Double.toString(threshold) + delimiter);
                 resetStats();
-                match(queries, threshold, new StandardAnalyzer(), tableName, bool);
+                match(queries, threshold, LuceneAnalyzerConstants.standardAnalyzerString(), tableName, bool);
                 avgTime = PerfTestUtils.calculateAverage(timeResults);
                 fileWriter.append(Collections.min(timeResults) + "," + Collections.max(timeResults) + "," + avgTime
                         + "," + PerfTestUtils.calculateSTD(timeResults, avgTime) + ","
@@ -113,15 +110,15 @@ public class FuzzyTokenMatcherPerformanceTest {
     /*
      * This function does match for a list of queries
      */
-    public static void match(ArrayList<String> queryList, double threshold, Analyzer luceneAnalyzer,
+    public static void match(ArrayList<String> queryList, double threshold, String luceneAnalyzerStr,
             String tableName, boolean bool) throws TextDBException, IOException {
 
         List<String> attributeNames = Arrays.asList(MedlineIndexWriter.ABSTRACT);
 
         for (String query : queryList) {
-            FuzzyTokenPredicate predicate = new FuzzyTokenPredicate(query, attributeNames, luceneAnalyzer,
-                    threshold);
-            FuzzyTokenMatcherSourceOperator fuzzyTokenSource = new FuzzyTokenMatcherSourceOperator(predicate, tableName);
+            FuzzyTokenSourcePredicate predicate = new FuzzyTokenSourcePredicate(query, attributeNames, luceneAnalyzerStr,
+                    threshold, tableName, null);
+            FuzzyTokenMatcherSourceOperator fuzzyTokenSource = new FuzzyTokenMatcherSourceOperator(predicate);
 
             long startMatchTime = System.currentTimeMillis();
             fuzzyTokenSource.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -1,9 +1,10 @@
 package edu.uci.ics.textdb.perftest.fuzzytokenmatcher;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,7 +67,6 @@ public class FuzzyTokenMatcherPerformanceTest {
 
         // Reads queries from query file into a list
         ArrayList<String> queries = PerfTestUtils.readQueries(PerfTestUtils.getQueryPath(queryFileName));
-        FileWriter fileWriter = null;
 
         // Gets the current time
         String currentTime = PerfTestUtils.formatTime(System.currentTimeMillis());
@@ -81,7 +81,8 @@ public class FuzzyTokenMatcherPerformanceTest {
                 String tableName = file.getName().replace(".txt", "");
 
                 PerfTestUtils.createFile(PerfTestUtils.getResultPath(csvFile), HEADER);
-                fileWriter = new FileWriter(PerfTestUtils.getResultPath(csvFile), true);
+                BufferedWriter fileWriter = Files.newBufferedWriter
+                        (PerfTestUtils.getResultPath(csvFile), StandardOpenOption.APPEND);
                 fileWriter.append(newLine);
                 fileWriter.append(currentTime + delimiter);
                 fileWriter.append(file.getName() + delimiter);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -1,10 +1,11 @@
 
 package edu.uci.ics.textdb.perftest.keywordmatcher;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -101,7 +102,8 @@ public class KeywordMatcherPerformanceTest {
             KeywordMatchingType opType, String tableName) throws Exception {
         double avgTime = 0.0;
         PerfTestUtils.createFile(PerfTestUtils.getResultPath(resultFile), HEADER);
-        FileWriter fileWriter = new FileWriter(PerfTestUtils.getResultPath(resultFile), true);
+        BufferedWriter fileWriter = Files.newBufferedWriter(
+                PerfTestUtils.getResultPath(resultFile), StandardOpenOption.APPEND);
         fileWriter.append(newLine);
         fileWriter.append(currentTime + delimiter);
         fileWriter.append(recordNum + delimiter);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -1,22 +1,22 @@
 package edu.uci.ics.textdb.perftest.medline;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.ArrayList;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
-import edu.uci.ics.textdb.api.engine.Plan;
-import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.exception.StorageException;
 import edu.uci.ics.textdb.api.field.IField;
 import edu.uci.ics.textdb.api.schema.Attribute;
 import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-import edu.uci.ics.textdb.dataflow.sink.IndexSink;
-import edu.uci.ics.textdb.dataflow.source.FileSourceOperator;
-import edu.uci.ics.textdb.dataflow.utils.DataflowUtils;
+import edu.uci.ics.textdb.storage.DataWriter;
 import edu.uci.ics.textdb.storage.RelationManager;
 import edu.uci.ics.textdb.storage.utils.StorageUtils;
 
@@ -59,39 +59,29 @@ public class MedlineIndexWriter {
 
     public static final Schema SCHEMA_MEDLINE = new Schema(ATTRIBUTES_MEDLINE);
 
-    private static Tuple recordToTuple(String record) throws JSONException, ParseException {
-        JSONObject json = new JSONObject(record);
+    public static Tuple recordToTuple(String record) throws IOException, ParseException {
+        JsonNode jsonNode = new ObjectMapper().readValue(record, JsonNode.class);
         ArrayList<IField> fieldList = new ArrayList<IField>();
         for (Attribute attr : ATTRIBUTES_MEDLINE) {
-            fieldList.add(StorageUtils.getField(attr.getAttributeType(), json.get(attr.getAttributeName()).toString()));
+            fieldList.add(StorageUtils.getField(attr.getAttributeType(), jsonNode.get(attr.getAttributeName()).toString()));
         }
         IField[] fieldArray = new IField[fieldList.size()];
         Tuple tuple = new Tuple(SCHEMA_MEDLINE, fieldList.toArray(fieldArray));
         return tuple;
     }
-
-    /**
-     * This function generates a plan that reads a file using
-     * FileSourceOperator, then writes index to the table using IndexSink.
-     * 
-     * the table must be pre-created (it must already exist)
-     * 
-     * @param filePath,
-     *            path of the file to be read
-     * @param tableName,
-     *            table name of the table to be written into (must already exist)
-     * @return the plan to write a Medline index
-     * @throws TextDBException
-     */
-    public static Plan getMedlineIndexPlan(String filePath, String tableName) throws TextDBException {
-        IndexSink medlineIndexSink = new IndexSink(tableName, false);
-        ISourceOperator fileSourceOperator = new FileSourceOperator(filePath, (s -> recordToTuple(s)),
-                RelationManager.getRelationManager().getTableSchema(tableName));
-        medlineIndexSink.setInputOperator(fileSourceOperator);
-
-        Plan writeIndexPlan = new Plan(medlineIndexSink);
-
-        return writeIndexPlan;
+    
+    public static void writeMedlineIndex(String medlineFilepath, String tableName) throws IOException, StorageException, ParseException {
+        RelationManager relationManager = RelationManager.getRelationManager();
+        DataWriter dataWriter = relationManager.getTableDataWriter(tableName);
+        dataWriter.open();
+        
+        BufferedReader reader = Files.newBufferedReader(Paths.get(medlineFilepath));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            dataWriter.insertTuple(recordToTuple(line));
+        }
+        reader.close();
+        dataWriter.close(); 
     }
 
 }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/medline/MedlineIndexWriter.java
@@ -3,7 +3,7 @@ package edu.uci.ics.textdb.perftest.medline;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.ArrayList;
 
@@ -42,7 +42,7 @@ public class MedlineIndexWriter {
     public static final String ABSTRACT = "abstract";
     public static final String ZIPF_SCORE = "zipf_score";
 
-    public static final Attribute PMID_ATTR = new Attribute(PMID, AttributeType.INTEGER);
+    public static final Attribute PMID_ATTR = new Attribute(PMID, AttributeType.STRING);
     public static final Attribute AFFILIATION_ATTR = new Attribute(AFFILIATION, AttributeType.TEXT);
     public static final Attribute ARTICLE_TITLE_ATTR = new Attribute(ARTICLE_TITLE, AttributeType.TEXT);
     public static final Attribute AUTHORS_ATTR = new Attribute(AUTHORS, AttributeType.TEXT);
@@ -70,15 +70,19 @@ public class MedlineIndexWriter {
         return tuple;
     }
     
-    public static void writeMedlineIndex(String medlineFilepath, String tableName) throws IOException, StorageException, ParseException {
+    public static void writeMedlineIndex(Path medlineFilepath, String tableName) throws IOException, StorageException, ParseException {
         RelationManager relationManager = RelationManager.getRelationManager();
         DataWriter dataWriter = relationManager.getTableDataWriter(tableName);
         dataWriter.open();
         
-        BufferedReader reader = Files.newBufferedReader(Paths.get(medlineFilepath));
+        BufferedReader reader = Files.newBufferedReader(medlineFilepath);
         String line;
         while ((line = reader.readLine()) != null) {
-            dataWriter.insertTuple(recordToTuple(line));
+            try {
+                dataWriter.insertTuple(recordToTuple(line));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
         reader.close();
         dataWriter.close(); 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -1,7 +1,9 @@
 package edu.uci.ics.textdb.perftest.nlpextractor;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -68,7 +70,8 @@ public class NlpExtractorPerformanceTest {
             String tableName = file.getName().replace(".txt", "");
 
             PerfTestUtils.createFile(PerfTestUtils.getResultPath(csvFile), HEADER);
-            FileWriter fileWriter = new FileWriter(PerfTestUtils.getResultPath(csvFile), true);
+            BufferedWriter fileWriter = Files.newBufferedWriter
+                    (PerfTestUtils.getResultPath(csvFile), StandardOpenOption.APPEND);
             fileWriter.append(newLine);
             fileWriter.append(currentTime + delimiter);
             fileWriter.append(file.getName() + delimiter);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -5,17 +5,16 @@ import java.io.FileWriter;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.field.ListField;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-import edu.uci.ics.textdb.dataflow.nlpextrator.NlpExtractor;
-import edu.uci.ics.textdb.dataflow.nlpextrator.NlpPredicate;
-import edu.uci.ics.textdb.dataflow.source.ScanBasedSourceOperator;
+import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityOperator;
+import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityPredicate;
+import edu.uci.ics.textdb.exp.nlp.entity.NlpEntityType;
+import edu.uci.ics.textdb.exp.source.scan.ScanBasedSourceOperator;
+import edu.uci.ics.textdb.exp.source.scan.ScanSourcePredicate;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.*;
 
@@ -73,11 +72,11 @@ public class NlpExtractorPerformanceTest {
             fileWriter.append(newLine);
             fileWriter.append(currentTime + delimiter);
             fileWriter.append(file.getName() + delimiter);
-            matchNLP(tableName, NlpPredicate.NlpTokenType.NE_ALL, new StandardAnalyzer());
-            matchNLP(tableName, NlpPredicate.NlpTokenType.Adjective, new StandardAnalyzer());
-            matchNLP(tableName, NlpPredicate.NlpTokenType.Adverb, new StandardAnalyzer());
-            matchNLP(tableName, NlpPredicate.NlpTokenType.Noun, new StandardAnalyzer());
-            matchNLP(tableName, NlpPredicate.NlpTokenType.Verb, new StandardAnalyzer());
+            matchNLP(tableName, NlpEntityType.NE_ALL);
+            matchNLP(tableName, NlpEntityType.ADJECTIVE);
+            matchNLP(tableName, NlpEntityType.ADVERB);
+            matchNLP(tableName, NlpEntityType.NOUN);
+            matchNLP(tableName, NlpEntityType.VERB);
             fileWriter.append(String.format("%.4f", totalMatchingTime / numOfNlpType));
             fileWriter.append(delimiter);
             fileWriter.append(String.format("%.2f", totalResults * 0.1 / numOfNlpType ));
@@ -91,27 +90,27 @@ public class NlpExtractorPerformanceTest {
     /*
      * This function does match based on tokenType
      */
-    public static void matchNLP(String tableName, NlpPredicate.NlpTokenType tokenType, Analyzer analyzer) throws Exception {
+    public static void matchNLP(String tableName, NlpEntityType tokenType) throws Exception {
 
         List<String> attributeNames = Arrays.asList(MedlineIndexWriter.ABSTRACT);
 
-        ISourceOperator sourceOperator = new ScanBasedSourceOperator(tableName);
+        ISourceOperator sourceOperator = new ScanBasedSourceOperator(new ScanSourcePredicate(tableName));
 
-        NlpPredicate nlpPredicate = new NlpPredicate(tokenType, attributeNames);
-        NlpExtractor nlpExtractor = new NlpExtractor(nlpPredicate);
-        nlpExtractor.setInputOperator(sourceOperator);
+        NlpEntityPredicate nlpEntityPredicate = new NlpEntityPredicate(tokenType, attributeNames, null);
+        NlpEntityOperator nlpEntityOperator = new NlpEntityOperator(nlpEntityPredicate);
+        nlpEntityOperator.setInputOperator(sourceOperator);
 
         long startMatchTime = System.currentTimeMillis();
-        nlpExtractor.open();
+        nlpEntityOperator.open();
         Tuple nextTuple = null;
         int counter = 0;
-        while ((nextTuple = nlpExtractor.getNextTuple()) != null) {
+        while ((nextTuple = nlpEntityOperator.getNextTuple()) != null) {
             ListField<Span> spanListField = nextTuple.getField(SchemaConstants.SPAN_LIST);
             List<Span> spanList = spanListField.getValue();
             counter += spanList.size();
 
         }
-        nlpExtractor.close();
+        nlpEntityOperator.close();
         long endMatchTime = System.currentTimeMillis();
         double matchTime = (endMatchTime - startMatchTime) / 1000.0;
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -1,8 +1,10 @@
 package edu.uci.ics.textdb.perftest.regexmatcher;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,10 +54,7 @@ public class RegexMatcherPerformanceTest {
      * 
      */
     public static void runTest(List<String> regexQueries)
-            throws TextDBException, IOException {
-
-        FileWriter fileWriter = null;
-         
+            throws TextDBException, IOException {         
         // Gets the current time for naming the cvs file
         String currentTime = PerfTestUtils.formatTime(System.currentTimeMillis());
 
@@ -66,11 +65,12 @@ public class RegexMatcherPerformanceTest {
             if (file.getName().startsWith(".")) {
                 continue;
             }
-            String tableName = file.getName().replace(".txt", "") + "_trigram";
+            System.out.println(file.getName());
 
             PerfTestUtils.createFile(PerfTestUtils.getResultPath(csvFile), HEADER);
-            fileWriter = new FileWriter(PerfTestUtils.getResultPath(csvFile),true);
-            matchRegex(regexQueries, tableName);
+            BufferedWriter fileWriter = Files.newBufferedWriter
+                    (PerfTestUtils.getResultPath(csvFile), StandardOpenOption.APPEND);
+            matchRegex(regexQueries, file.getName());
             fileWriter.append("\n");
             fileWriter.append(currentTime + delimiter);
             fileWriter.append(file.getName() + delimiter);

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -11,14 +11,11 @@ import edu.uci.ics.textdb.api.exception.TextDBException;
 import edu.uci.ics.textdb.api.field.ListField;
 import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexMatcherSourceOperator;
+import edu.uci.ics.textdb.exp.regexmatcher.RegexSourcePredicate;
 
-import org.apache.lucene.analysis.Analyzer;
-
-import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
-import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcherSourceOperator;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
-import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 
 /*
  * 
@@ -96,10 +93,8 @@ public class RegexMatcherPerformanceTest {
         for(String regex: regexes){
 	        // analyzer should generate grams all in lower case to build a lower
 	        // case index.
-	        Analyzer luceneAnalyzer = LuceneAnalyzerConstants.getNGramAnalyzer(3);
-	        RegexPredicate regexPredicate = new RegexPredicate(regex, attributeNames, luceneAnalyzer);
-	        
-	        RegexMatcherSourceOperator regexSource = new RegexMatcherSourceOperator(regexPredicate, tableName);
+	        RegexSourcePredicate predicate = new RegexSourcePredicate(regex, attributeNames, tableName, null);
+	        RegexMatcherSourceOperator regexSource = new RegexMatcherSourceOperator(predicate);
 	
 	        long startMatchTime = System.currentTimeMillis();
 	        regexSource.open();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunPerftests.java
@@ -43,7 +43,7 @@ public class RunPerftests {
             PerfTestUtils.setTrigramIndexFolder(args[2]);
             PerfTestUtils.setQueryFolder(args[3]);
         } catch (ArrayIndexOutOfBoundsException e){
-            e.printStackTrace();
+            System.out.println("missing arguments will be set to default");
         }
 
         try {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunTests.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/runme/RunTests.java
@@ -46,7 +46,7 @@ public class RunTests {
             PerfTestUtils.setTrigramIndexFolder(args[3]);
             PerfTestUtils.setQueryFolder(args[4]);
         }catch(ArrayIndexOutOfBoundsException e){
-            e.printStackTrace();
+            System.out.println("missing arguments will be set to default");
         }
 
         try {

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/sample/SampleExtraction.java
@@ -1,40 +1,19 @@
 package edu.uci.ics.textdb.perftest.sample;
 
-import edu.uci.ics.textdb.api.constants.SchemaConstants;
-import edu.uci.ics.textdb.api.constants.DataConstants.KeywordMatchingType;
-import edu.uci.ics.textdb.api.engine.Engine;
-import edu.uci.ics.textdb.api.engine.Plan;
 import edu.uci.ics.textdb.api.field.StringField;
 import edu.uci.ics.textdb.api.field.TextField;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-import edu.uci.ics.textdb.dataflow.common.IJoinPredicate;
-import edu.uci.ics.textdb.dataflow.common.JoinDistancePredicate;
-import edu.uci.ics.textdb.dataflow.common.KeywordPredicate;
-import edu.uci.ics.textdb.dataflow.common.RegexPredicate;
-import edu.uci.ics.textdb.dataflow.join.Join;
-import edu.uci.ics.textdb.dataflow.keywordmatch.KeywordMatcherSourceOperator;
-import edu.uci.ics.textdb.dataflow.nlpextrator.NlpExtractor;
-import edu.uci.ics.textdb.dataflow.nlpextrator.NlpPredicate;
-import edu.uci.ics.textdb.dataflow.projection.ProjectionOperator;
-import edu.uci.ics.textdb.dataflow.projection.ProjectionPredicate;
-import edu.uci.ics.textdb.dataflow.regexmatch.RegexMatcher;
-import edu.uci.ics.textdb.dataflow.sink.FileSink;
-import edu.uci.ics.textdb.dataflow.utils.DataflowUtils;
 import edu.uci.ics.textdb.perftest.promed.PromedSchema;
 import edu.uci.ics.textdb.perftest.utils.PerfTestUtils;
 import edu.uci.ics.textdb.storage.DataWriter;
 import edu.uci.ics.textdb.storage.RelationManager;
 import edu.uci.ics.textdb.storage.constants.LuceneAnalyzerConstants;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.Scanner;
 
 public class SampleExtraction {
@@ -116,58 +95,8 @@ public class SampleExtraction {
      *                    
      */
     public static void extractPersonLocation() throws Exception {
-                
-        String keywordZika = "zika";
-        KeywordPredicate keywordPredicateZika = new KeywordPredicate(keywordZika, Arrays.asList(PromedSchema.CONTENT),
-                new StandardAnalyzer(), KeywordMatchingType.CONJUNCTION_INDEXBASED);
-        
-        KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(
-                keywordPredicateZika, PROMED_SAMPLE_TABLE);
-        
-        ProjectionPredicate projectionPredicateIdAndContent = new ProjectionPredicate(
-                Arrays.asList(SchemaConstants._ID, PromedSchema.ID, PromedSchema.CONTENT));
-        
-        ProjectionOperator projectionOperatorIdAndContent1 = new ProjectionOperator(projectionPredicateIdAndContent);
-        ProjectionOperator projectionOperatorIdAndContent2 = new ProjectionOperator(projectionPredicateIdAndContent);
-
-        String regexPerson = "\\b(A|a|(an)|(An)) .{1,40} ((woman)|(man))\\b";
-        RegexPredicate regexPredicatePerson = new RegexPredicate(regexPerson, Arrays.asList(PromedSchema.CONTENT),
-                LuceneAnalyzerConstants.getNGramAnalyzer(3));
-        RegexMatcher regexMatcherPerson = new RegexMatcher(regexPredicatePerson);
-        
-        NlpPredicate nlpPredicateLocation = new NlpPredicate(NlpPredicate.NlpTokenType.Location, Arrays.asList(PromedSchema.CONTENT));
-        NlpExtractor nlpExtractorLocation = new NlpExtractor(nlpPredicateLocation);
-
-        IJoinPredicate joinPredicatePersonLocation = new JoinDistancePredicate(PromedSchema.CONTENT, 100);
-        Join joinPersonLocation = new Join(joinPredicatePersonLocation);
-        
-        ProjectionPredicate projectionPredicateIdAndSpan = new ProjectionPredicate(
-                Arrays.asList(SchemaConstants._ID, PromedSchema.ID, SchemaConstants.SPAN_LIST));
-        ProjectionOperator projectionOperatorIdAndSpan = new ProjectionOperator(projectionPredicateIdAndSpan);
-         
-        SimpleDateFormat sdf = new SimpleDateFormat("MM-dd-yyyy-HH-mm-ss");
-        FileSink fileSink = new FileSink( 
-                new File(sampleDataFilesDirectory + "/person-location-result-"
-                		+ sdf.format(new Date(System.currentTimeMillis())).toString() + ".txt"));
-
-        fileSink.setToStringFunction((tuple -> DataflowUtils.getTupleString(tuple)));
-
-
-        projectionOperatorIdAndContent1.setInputOperator(keywordSource);
-
-        regexMatcherPerson.setInputOperator(projectionOperatorIdAndContent1);
-
-        projectionOperatorIdAndContent2.setInputOperator(regexMatcherPerson);
-        nlpExtractorLocation.setInputOperator(projectionOperatorIdAndContent2);
-
-        joinPersonLocation.setInnerInputOperator(regexMatcherPerson);
-        joinPersonLocation.setOuterInputOperator(nlpExtractorLocation);
-                      
-        projectionOperatorIdAndSpan.setInputOperator(joinPersonLocation);
-        fileSink.setInputOperator(projectionOperatorIdAndSpan);
-
-        Plan extractPersonPlan = new Plan(fileSink);
-        Engine.getEngine().evaluate(extractPersonPlan);
+        // this sample extraction won't work because the CharacterDistanceJoin hasn't been updated yet
+        // TODO: after Join is fixed, add this sample extraction back.
     }
 
 }

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -1,14 +1,15 @@
 package edu.uci.ics.textdb.perftest.utils;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Scanner;
+import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -46,15 +47,11 @@ public class PerfTestUtils {
      * Checks whether the given file exists. If not, create such a file with a
      * header written into it.
      */
-    public static void createFile(String filePath, String header) throws IOException {
-        File file = new File(filePath);
-        if (!file.exists()) {
-            file.createNewFile();
-            FileWriter fileWriter = new FileWriter(filePath, true);
-            fileWriter.write(header);
-            fileWriter.close();
+    public static void createFile(Path filePath, String header) throws IOException {
+        if (Files.notExists(filePath)) {
+            Files.createFile(filePath);
+            Files.write(filePath, header.getBytes());
         }
-
     }
 
     /*
@@ -163,13 +160,12 @@ public class PerfTestUtils {
     public static void writeStandardAnalyzerIndices() throws Exception {
         File files = new File(fileFolder);
         for (File file : files.listFiles()) {
-            if (file.getName().startsWith(".")) {
-                continue;
-            }
             if (file.isDirectory()) {
                 continue;
             }
-            writeIndex(file.getName(), new StandardAnalyzer(), "standard");
+            if (file.getName().startsWith("abstract")) {
+                writeIndex(file.getName(), new StandardAnalyzer(), "standard");
+            }
         }
     }
 
@@ -210,16 +206,16 @@ public class PerfTestUtils {
         if (indexType.equalsIgnoreCase("trigram")) {
             tableName = tableName + "_trigram";
             relationManager.deleteTable(tableName);
-            relationManager.createTable(tableName, getTrigramIndexPath(tableName), 
+            relationManager.createTable(tableName, getTrigramIndexPath(tableName).toString(), 
                     MedlineIndexWriter.SCHEMA_MEDLINE, LuceneAnalyzerConstants.nGramAnalyzerString(3));
             
-            MedlineIndexWriter.writeMedlineIndex(fileFolder + fileName, tableName);
+            MedlineIndexWriter.writeMedlineIndex(Paths.get(fileFolder, fileName), tableName);
             
         } else if (indexType.equalsIgnoreCase("standard")) {
             relationManager.deleteTable(tableName);
-            relationManager.createTable(tableName, getIndexPath(tableName), 
+            relationManager.createTable(tableName, getIndexPath(tableName).toString(), 
                     MedlineIndexWriter.SCHEMA_MEDLINE, LuceneAnalyzerConstants.standardAnalyzerString());
-            MedlineIndexWriter.writeMedlineIndex(fileFolder + fileName, tableName);
+            MedlineIndexWriter.writeMedlineIndex(Paths.get(fileFolder, fileName), tableName);
         } else {
             System.out.println("Index is not successfully written.");
             System.out.println("IndexType has to be either \"standard\" or \"trigram\"  ");
@@ -232,16 +228,12 @@ public class PerfTestUtils {
      * 
      * @param filePath
      * @return a list of strings
-     * @throws FileNotFoundException
+     * @throws IOException 
      */
-    public static ArrayList<String> readQueries(String filePath) throws FileNotFoundException {
-        ArrayList<String> queries = new ArrayList<String>();
-        Scanner scanner = new Scanner(new File(filePath));
-        while (scanner.hasNextLine()) {
-            queries.add(scanner.nextLine().trim());
-        }
-        scanner.close();
-        return queries;
+    public static ArrayList<String> readQueries(Path queryFilePath) throws IOException {
+        return Files.readAllLines(queryFilePath).stream()
+                .map(str -> str.trim())
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**
@@ -249,8 +241,8 @@ public class PerfTestUtils {
      * @param indexName
      * @return a path of an index in ./index/standard/
      */
-    public static String getIndexPath(String indexName) {
-        return standardIndexFolder + indexName;
+    public static Path getIndexPath(String indexName) {
+        return Paths.get(standardIndexFolder, indexName);
     }
 
     /**
@@ -258,8 +250,8 @@ public class PerfTestUtils {
      * @param indexName
      * @return a path of a trigram index in ./index/trigram/
      */
-    public static String getTrigramIndexPath(String indexName) {
-        return trigramIndexFolder + indexName;
+    public static Path getTrigramIndexPath(String indexName) {
+        return Paths.get(trigramIndexFolder, indexName);
     }
 
     /**
@@ -267,8 +259,8 @@ public class PerfTestUtils {
      * @param resultFileName
      * @return a path of a result file in ./data-files/results/
      */
-    public static String getResultPath(String resultFileName) {
-        return resultFolder + resultFileName;
+    public static Path getResultPath(String resultFileName) {
+        return Paths.get(resultFolder, resultFileName);
     }
 
     /**
@@ -276,8 +268,8 @@ public class PerfTestUtils {
      * @param queryFileName
      * @return a path of a data file in ./data-files/queries/
      */
-    public static String getQueryPath(String queryFileName) {
-        return queryFolder + queryFileName;
+    public static Path getQueryPath(String queryFileName) {
+        return Paths.get(queryFolder, queryFileName);
 
     }
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/utils/PerfTestUtils.java
@@ -14,7 +14,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 import edu.uci.ics.textdb.api.constants.DataConstants.TextdbProject;
-import edu.uci.ics.textdb.api.engine.Engine;
 import edu.uci.ics.textdb.api.utils.Utils;
 import edu.uci.ics.textdb.perftest.medline.MedlineIndexWriter;
 import edu.uci.ics.textdb.storage.RelationManager;
@@ -213,13 +212,14 @@ public class PerfTestUtils {
             relationManager.deleteTable(tableName);
             relationManager.createTable(tableName, getTrigramIndexPath(tableName), 
                     MedlineIndexWriter.SCHEMA_MEDLINE, LuceneAnalyzerConstants.nGramAnalyzerString(3));
-            Engine.getEngine().evaluate(MedlineIndexWriter.getMedlineIndexPlan(fileFolder + fileName, tableName));
+            
+            MedlineIndexWriter.writeMedlineIndex(fileFolder + fileName, tableName);
             
         } else if (indexType.equalsIgnoreCase("standard")) {
             relationManager.deleteTable(tableName);
             relationManager.createTable(tableName, getIndexPath(tableName), 
                     MedlineIndexWriter.SCHEMA_MEDLINE, LuceneAnalyzerConstants.standardAnalyzerString());
-            Engine.getEngine().evaluate(MedlineIndexWriter.getMedlineIndexPlan(fileFolder + fileName, tableName));
+            MedlineIndexWriter.writeMedlineIndex(fileFolder + fileName, tableName);
         } else {
             System.out.println("Index is not successfully written.");
             System.out.println("IndexType has to be either \"standard\" or \"trigram\"  ");

--- a/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
+++ b/textdb/textdb-storage/src/main/java/edu/uci/ics/textdb/storage/RelationManager.java
@@ -2,6 +2,9 @@ package edu.uci.ics.textdb.storage;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,9 +88,15 @@ public class RelationManager {
         if (checkTableExistence(tableName)) {
             throw new StorageException(String.format("Table %s already exists.", tableName));
         }
-        // convert the index directory to its absolute path
+        
+        // create folder if it's not there
+        // and convert the index directory to its absolute path
         try {
-            indexDirectory = new File(indexDirectory).getCanonicalPath();
+            Path indexPath = Paths.get(indexDirectory);
+            if (Files.notExists(indexPath)) {
+                Files.createDirectories(indexPath);
+            }
+            indexDirectory = indexPath.toRealPath().toString();
         } catch (IOException e) {
             throw new StorageException(e);
         }


### PR DESCRIPTION
This PR is part of the plan to remove old `dataflow` module in issue #492 .

This PR updates the `perftest` module to use the new predicates and operators in the `exp` module.