### PR TITLE
[Issue #452] Make the result JSON response more user friendly.

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/tuple/Tuple.java
@@ -6,7 +6,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.uci.ics.textdb.api.constants.JsonConstants;
 import edu.uci.ics.textdb.api.field.IField;
@@ -96,6 +99,14 @@ public class Tuple {
 
     public String toString() {
         return "Tuple [schema=" + schema + ", fields=" + fields + "]";
+    }
+    
+    public ObjectNode getReadableJson() {
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        for (String attrName : this.schema.getAttributeNames()) {
+            objectNode.set(attrName, JsonNodeFactory.instance.pojoNode(this.getField(attrName).getValue()));
+        }
+        return objectNode;
     }
     
 }

--- a/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/NewQueryPlanResource.java
+++ b/textdb/textdb-web/src/main/java/edu/uci/ics/textdb/web/resource/NewQueryPlanResource.java
@@ -1,7 +1,6 @@
 package edu.uci.ics.textdb.web.resource;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
@@ -19,7 +18,6 @@ import edu.uci.ics.textdb.api.engine.Engine;
 import edu.uci.ics.textdb.api.engine.Plan;
 import edu.uci.ics.textdb.api.tuple.Tuple;
 import edu.uci.ics.textdb.exp.plangen.LogicalPlan;
-import edu.uci.ics.textdb.exp.sink.excel.ExcelSink;
 import edu.uci.ics.textdb.exp.sink.tuple.TupleSink;
 import edu.uci.ics.textdb.web.TextdbWebException;
 import edu.uci.ics.textdb.web.response.TextdbWebResponse;
@@ -63,24 +61,6 @@ public class NewQueryPlanResource {
                     arrayNode.add(tuple.getReadableJson());
                 }
                 return new TextdbWebResponse(0, new ObjectMapper().writeValueAsString(arrayNode));
-            } else if (sink instanceof ExcelSink) {
-                ExcelSink excelSink = (ExcelSink) sink;
-                excelSink.open();
-                List<Tuple> results = excelSink.collectAllTuples();
-                excelSink.close();
-                
-                ArrayNode arrayNode = new ObjectMapper().createArrayNode();
-                for (Tuple tuple : results) {
-                    arrayNode.add(tuple.getReadableJson());
-                }
-                
-                ObjectNode resultJson = new ObjectMapper().createObjectNode();
-                String excelFilePath = Paths.get(excelSink.getFilePath()).getFileName().toString();
-                
-                resultJson.put("timeStamp", excelFilePath.substring(0, excelFilePath.length()-".xlsx".length()));
-                resultJson.set("results", arrayNode);
-                
-                return new TextdbWebResponse(0, new ObjectMapper().writeValueAsString(resultJson));
             } else {
                 // execute the plan and return success message
                 Engine.getEngine().evaluate(plan);


### PR DESCRIPTION
The json serialization for the Tuple class is not user-friendly. The backend needs to send a more user-friendly json response to frontend.

Previously, in PR #489 , we added the ability to make the `Tuple` class json serializable. However, the default json serialization for the Tuple class is not user-friendly. 
This PR changes it back to the old format, which is more human readable.

Current:
![screen shot 2017-05-31 at 2 58 49 pm](https://cloud.githubusercontent.com/assets/12578068/26656010/26c98a30-4612-11e7-9f21-17cc7896a0e8.png)

After change:
![screen shot 2017-05-31 at 2 55 59 pm](https://cloud.githubusercontent.com/assets/12578068/26656030/3e94b144-4612-11e7-907b-1f51c9bd5592.png)
