### PR TITLE
Reveal the spanListName option in the frontend

### DIFF
--- a/textdb/textdb-angular-gui/app/sidebar/side-bar.component.ts
+++ b/textdb/textdb-angular-gui/app/sidebar/side-bar.component.ts
@@ -22,7 +22,7 @@ export class SideBarComponent {
   operatorId: number;
   operatorTitle: string;
 
-  hiddenList: string[] = ["operatorType", "luceneAnalyzer", "matchingType", "spanListName"];
+  hiddenList: string[] = ["operatorType", "luceneAnalyzer", "matchingType"];
 
   selectorList: string[] = ["matchingType", "nlpEntityType", "splitType", "sampleType", "compareNumber", "aggregationType"].concat(this.hiddenList);
 


### PR DESCRIPTION
After the labeled regex PR is merged into master, we need to reveal the spanListName field to let users specify the spanListName in frontend. 

This PR makes `spanListName` available again on frontend.