### PR TITLE
Fix a bug where Nlp Sentence Splitter would normalize and escape some characters

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/splitter/NlpSplitOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/nlp/splitter/NlpSplitOperator.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 import edu.stanford.nlp.process.DocumentPreprocessor;
+import edu.stanford.nlp.process.PTBTokenizer;
 import edu.stanford.nlp.ling.HasWord;
 import edu.stanford.nlp.ling.Sentence;
 
@@ -158,6 +159,7 @@ public class NlpSplitOperator implements IOperator {
         String inputText = inputTuple.<IField>getField(predicate.getInputAttributeName()).getValue().toString();
         Reader reader = new StringReader(inputText);
         DocumentPreprocessor documentPreprocessor = new DocumentPreprocessor(reader);
+        documentPreprocessor.setTokenizerFactory(PTBTokenizer.PTBTokenizerFactory.newCoreLabelTokenizerFactory("ptb3Escaping=false"));
         List<Span> sentenceList = new ArrayList<Span>();
         
         int start = 0; int end = 0; 


### PR DESCRIPTION
By default, Stanford NLP enables the features that will transform, normalize and escape some tokens (called PTB3 token transforms). (see https://nlp.stanford.edu/software/tokenizer.html)

The default option does many things, including re-writing parentheses to `-LRB-, -RRB-`, re-writing brackets to `-LCB-, -LRB-, -RCB-, -RRB-`. Since we only want Stanford NLP to split, not re-write. This PR turns off that option.