### PR TITLE
Fix a bug where dictionary matcher will skip a tuple

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
@@ -199,7 +199,7 @@ public class DictionaryMatcher implements IOperator {
                 throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
             }
             // if cursor's next value exceeds the cache's size
-            if (cachedTupleCursor + 1 >= inputTupleList.size()) {
+            if (cachedTupleCursor + 1 > inputTupleList.size()) {
                 // if the input operator has been fully consumed, return null
                 if (inputAllConsumed) {
                     return null;


### PR DESCRIPTION
This PR fixes a bug where DictionaryMatcher skips an input tuple.

The reasons is that DictionaryMatcher's internal DictionaryCacheOperator wrongly calculates the cursor and the list of the cached results, leading to the last tuple in the cached list not being returned. 