### PR TITLE
spanListName is null

### DIFF
--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/dictionarymatcher/DictionaryMatcherPerformanceTest.java
@@ -120,7 +120,7 @@ public class DictionaryMatcherPerformanceTest {
 
         Dictionary dictionary = new Dictionary(queryList);
         DictionarySourcePredicate dictionarySourcePredicate = new DictionarySourcePredicate(dictionary, attributeNames, luceneAnalyzerStr,
-                opType, tableName, null);
+                opType, tableName, SchemaConstants.SPAN_LIST);
         DictionaryMatcherSourceOperator dictionaryMatcher = new DictionaryMatcherSourceOperator(dictionarySourcePredicate);
 
         long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/fuzzytokenmatcher/FuzzyTokenMatcherPerformanceTest.java
@@ -118,7 +118,7 @@ public class FuzzyTokenMatcherPerformanceTest {
 
         for (String query : queryList) {
             FuzzyTokenSourcePredicate predicate = new FuzzyTokenSourcePredicate(query, attributeNames, luceneAnalyzerStr,
-                    threshold, tableName, null);
+                    threshold, tableName, SchemaConstants.SPAN_LIST);
             FuzzyTokenMatcherSourceOperator fuzzyTokenSource = new FuzzyTokenMatcherSourceOperator(predicate);
 
             long startMatchTime = System.currentTimeMillis();

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/keywordmatcher/KeywordMatcherPerformanceTest.java
@@ -140,7 +140,7 @@ public class KeywordMatcherPerformanceTest {
                     luceneAnalyzerStr, 
                     opType, 
                     tableName,
-                    null);
+                    SchemaConstants.SPAN_LIST);
 
             KeywordMatcherSourceOperator keywordSource = new KeywordMatcherSourceOperator(predicate);
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/nlpextractor/NlpExtractorPerformanceTest.java
@@ -99,7 +99,7 @@ public class NlpExtractorPerformanceTest {
 
         ISourceOperator sourceOperator = new ScanBasedSourceOperator(new ScanSourcePredicate(tableName));
 
-        NlpEntityPredicate nlpEntityPredicate = new NlpEntityPredicate(tokenType, attributeNames, null);
+        NlpEntityPredicate nlpEntityPredicate = new NlpEntityPredicate(tokenType, attributeNames, SchemaConstants.SPAN_LIST);
         NlpEntityOperator nlpEntityOperator = new NlpEntityOperator(nlpEntityPredicate);
         nlpEntityOperator.setInputOperator(sourceOperator);
 

--- a/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
+++ b/textdb/textdb-perftest/src/main/java/edu/uci/ics/textdb/perftest/regexmatcher/RegexMatcherPerformanceTest.java
@@ -93,7 +93,7 @@ public class RegexMatcherPerformanceTest {
         for(String regex: regexes){
 	        // analyzer should generate grams all in lower case to build a lower
 	        // case index.
-	        RegexSourcePredicate predicate = new RegexSourcePredicate(regex, attributeNames, tableName, null);
+	        RegexSourcePredicate predicate = new RegexSourcePredicate(regex, attributeNames, tableName, SchemaConstants.SPAN_LIST);
 	        RegexMatcherSourceOperator regexSource = new RegexMatcherSourceOperator(predicate);
 	
 	        long startMatchTime = System.currentTimeMillis();


### PR DESCRIPTION
Repeated bug in perftest fixed. Span list name is given null by mistake to the predicate objects. This bug results in nullPointerException.