### PR TITLE
[Issue #537] Step 1: Refactor KeywordMatcher operator

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/keywordmatcher/KeywordMatcher.java
@@ -29,21 +29,13 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     private final KeywordPredicate predicate;
 
     private Schema inputSchema;
-    
-    private final ArrayList<String> queryTokenList;
-    private final HashSet<String> queryTokenSet;
-    private final ArrayList<String> queryTokensWithStopwords;
+
 
     public KeywordMatcher(KeywordPredicate predicate) {
         this.predicate = predicate;
-        
         this.limit = predicate.getLimit();
         this.offset = predicate.getOffset();
-        this.queryTokenList = DataflowUtils.tokenizeQuery(predicate.getLuceneAnalyzerString(), predicate.getQuery());
-        this.queryTokenSet = new HashSet<>(this.queryTokenList);
-        
-        // TODO: standard analyzer is assumed here, rewrite it to deal with other analyzers
-        this.queryTokensWithStopwords = DataflowUtils.tokenizeQueryWithStopwords(predicate.getQuery());
+
     }
 
     @Override
@@ -89,15 +81,15 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
             inputTuple = DataflowUtils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
         }
 
-        List<Span> matchingResults = null;
+        List<Span> matchingResults = new ArrayList<>();
         if (this.predicate.getMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-            matchingResults = computeConjunctionMatchingResult(inputTuple);
+            DataflowUtils.computeConjunctionMatchingResult(inputTuple, predicate.getAttributeNames(), predicate.getQuery(), predicate.getLuceneAnalyzerString(), matchingResults);
         }
         if (this.predicate.getMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED) {
-            matchingResults = computePhraseMatchingResult(inputTuple);
+            DataflowUtils.computePhraseMatchingResult(inputTuple, predicate.getAttributeNames(), predicate.getQuery(), predicate.getLuceneAnalyzerString(), matchingResults);
         }
         if (this.predicate.getMatchingType() == KeywordMatchingType.SUBSTRING_SCANBASED) {
-            matchingResults = computeSubstringMatchingResult(inputTuple);
+            DataflowUtils.computeSubstringMatchingResult(inputTuple, predicate.getAttributeNames(), predicate.getQuery(), matchingResults);
         }
         if (matchingResults == null) {
             throw new DataFlowException("no matching result is provided");
@@ -117,186 +109,186 @@ public class KeywordMatcher extends AbstractSingleInputOperator {
     protected void cleanUp() {
     }
 
-    private List<Span> computeConjunctionMatchingResult(Tuple inputTuple) throws DataFlowException {
-        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
-        List<Span> payload = payloadField.getValue();
-        List<Span> relevantSpans = filterRelevantSpans(payload);
-        List<Span> matchingResults = new ArrayList<>();
-
-        for (String attributeName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
-            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
-                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
-            }
-
-            // for STRING type, the query should match the fieldValue completely
-            if (attributeType == AttributeType.STRING) {
-                if (fieldValue.equals(predicate.getQuery())) {
-                    Span span = new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
-                    matchingResults.add(span);
-                }
-            }
-
-            // for TEXT type, every token in the query should be present in span
-            // list for this field
-            if (attributeType == AttributeType.TEXT) {
-                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
-                        .collect(Collectors.toList());
-
-                if (isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
-                    matchingResults.addAll(fieldSpanList);
-                }
-            }
-        }
-
-        return matchingResults;
-    }
-
-    private List<Span> computePhraseMatchingResult(Tuple inputTuple) throws DataFlowException {
-        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
-        List<Span> payload = payloadField.getValue();
-        List<Span> relevantSpans = filterRelevantSpans(payload);
-        List<Span> matchingResults = new ArrayList<>();
-
-        for (String attributeName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
-            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
-                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
-            }
-
-            // for STRING type, the query should match the fieldValue completely
-            if (attributeType == AttributeType.STRING) {
-                if (fieldValue.equals(predicate.getQuery())) {
-                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
-                }
-            }
-
-            // for TEXT type, spans need to be reconstructed according to the
-            // phrase query
-            if (attributeType == AttributeType.TEXT) {
-                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
-                        .collect(Collectors.toList());
-
-                if (!isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
-                    // move on to next field if not all query tokens are present
-                    // in the spans
-                    continue;
-                }
-
-                // Sort current field's span list by token offset for later use
-                Collections.sort(fieldSpanList, (span1, span2) -> span1.getTokenOffset() - span2.getTokenOffset());
-
-                List<Integer> queryTokenOffset = new ArrayList<>();
-
-                for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
-                    if (queryTokenList.contains(queryTokensWithStopwords.get(i))) {
-                        queryTokenOffset.add(i);
-                    }
-                }
-
-                int iter = 0; // maintains position of term being checked in
-                              // spanForThisField list
-                while (iter < fieldSpanList.size()) {
-                    if (iter > fieldSpanList.size() - queryTokenList.size()) {
-                        break;
-                    }
-
-                    // Verify if span in the spanForThisField correspond to our
-                    // phrase query, ie relative position offsets should be
-                    // similar
-                    // and the value should be same.
-                    boolean isMismatchInSpan = false;// flag to check if a
-                                                     // mismatch in spans occurs
-
-                    // To check all the terms in query are verified
-                    for (int i = 0; i < queryTokenList.size() - 1; i++) {
-                        Span first = fieldSpanList.get(iter + i);
-                        Span second = fieldSpanList.get(iter + i + 1);
-                        if (!(second.getTokenOffset() - first.getTokenOffset() == queryTokenOffset.get(i + 1)
-                                - queryTokenOffset.get(i) && first.getValue().equalsIgnoreCase(queryTokenList.get(i))
-                                && second.getValue().equalsIgnoreCase(queryTokenList.get(i + 1)))) {
-                            iter++;
-                            isMismatchInSpan = true;
-                            break;
-                        }
-                    }
-
-                    if (isMismatchInSpan) {
-                        continue;
-                    }
-
-                    int combinedSpanStartIndex = fieldSpanList.get(iter).getStart();
-                    int combinedSpanEndIndex = fieldSpanList.get(iter + queryTokenList.size() - 1).getEnd();
-
-                    Span combinedSpan = new Span(attributeName, combinedSpanStartIndex, combinedSpanEndIndex, predicate.getQuery(),
-                            fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
-                    matchingResults.add(combinedSpan);
-                    iter = iter + queryTokenList.size();
-                }
-            }
-        }
-
-        return matchingResults;
-    }
-
-    private List<Span> computeSubstringMatchingResult(Tuple inputTuple) throws DataFlowException {
-        List<Span> matchingResults = new ArrayList<>();
-
-        for (String attributeName : this.predicate.getAttributeNames()) {
-            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
-            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
-
-            // types other than TEXT and STRING: throw Exception for now
-            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
-                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
-            }
-
-            // for STRING type, the query should match the fieldValue completely
-            if (attributeType == AttributeType.STRING) {
-                if (fieldValue.equals(predicate.getQuery())) {
-                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
-                }
-            }
-
-            if (attributeType == AttributeType.TEXT) {
-                String regex = predicate.getQuery().toLowerCase();
-                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
-                while (matcher.find()) {
-                    int start = matcher.start();
-                    int end = matcher.end();
-
-                    matchingResults.add(new Span(attributeName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
-                }
-            }
-
-        }
-        return matchingResults;
-    }
-
-    private boolean isAllQueryTokensPresent(List<Span> fieldSpanList, Set<String> queryTokenSet) {
-        Set<String> fieldSpanKeys = fieldSpanList.stream().map(span -> span.getKey()).collect(Collectors.toSet());
-
-        return fieldSpanKeys.equals(queryTokenSet);
-    }
-
-    private List<Span> filterRelevantSpans(List<Span> spanList) {
-        List<Span> relevantSpans = new ArrayList<>();
-        Iterator<Span> iterator = spanList.iterator();
-        while (iterator.hasNext()) {
-            Span span = iterator.next();
-            if (queryTokenSet.contains(span.getKey())) {
-                relevantSpans.add(span);
-            }
-        }
-        return relevantSpans;
-    }
+//    public List<Span> computeConjunctionMatchingResult(Tuple inputTuple) throws DataFlowException {
+//        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
+//        List<Span> payload = payloadField.getValue();
+//        List<Span> relevantSpans = filterRelevantSpans(payload);
+//        List<Span> matchingResults = new ArrayList<>();
+//
+//        for (String attributeName : this.predicate.getAttributeNames()) {
+//            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+//            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+//
+//            // types other than TEXT and STRING: throw Exception for now
+//            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+//                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+//            }
+//
+//            // for STRING type, the query should match the fieldValue completely
+//            if (attributeType == AttributeType.STRING) {
+//                if (fieldValue.equals(predicate.getQuery())) {
+//                    Span span = new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue);
+//                    matchingResults.add(span);
+//                }
+//            }
+//
+//            // for TEXT type, every token in the query should be present in span
+//            // list for this field
+//            if (attributeType == AttributeType.TEXT) {
+//                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+//                        .collect(Collectors.toList());
+//
+//                if (isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
+//                    matchingResults.addAll(fieldSpanList);
+//                }
+//            }
+//        }
+//
+//        return matchingResults;
+//    }
+//
+//    public List<Span> computePhraseMatchingResult(Tuple inputTuple) throws DataFlowException {
+//        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
+//        List<Span> payload = payloadField.getValue();
+//        List<Span> relevantSpans = filterRelevantSpans(payload);
+//        List<Span> matchingResults = new ArrayList<>();
+//
+//        for (String attributeName : this.predicate.getAttributeNames()) {
+//            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+//            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+//
+//            // types other than TEXT and STRING: throw Exception for now
+//            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+//                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+//            }
+//
+//            // for STRING type, the query should match the fieldValue completely
+//            if (attributeType == AttributeType.STRING) {
+//                if (fieldValue.equals(predicate.getQuery())) {
+//                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+//                }
+//            }
+//
+//            // for TEXT type, spans need to be reconstructed according to the
+//            // phrase query
+//            if (attributeType == AttributeType.TEXT) {
+//                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+//                        .collect(Collectors.toList());
+//
+//                if (!isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
+//                    // move on to next field if not all query tokens are present
+//                    // in the spans
+//                    continue;
+//                }
+//
+//                // Sort current field's span list by token offset for later use
+//                Collections.sort(fieldSpanList, (span1, span2) -> span1.getTokenOffset() - span2.getTokenOffset());
+//
+//                List<Integer> queryTokenOffset = new ArrayList<>();
+//
+//                for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
+//                    if (queryTokenList.contains(queryTokensWithStopwords.get(i))) {
+//                        queryTokenOffset.add(i);
+//                    }
+//                }
+//
+//                int iter = 0; // maintains position of term being checked in
+//                              // spanForThisField list
+//                while (iter < fieldSpanList.size()) {
+//                    if (iter > fieldSpanList.size() - queryTokenList.size()) {
+//                        break;
+//                    }
+//
+//                    // Verify if span in the spanForThisField correspond to our
+//                    // phrase query, ie relative position offsets should be
+//                    // similar
+//                    // and the value should be same.
+//                    boolean isMismatchInSpan = false;// flag to check if a
+//                                                     // mismatch in spans occurs
+//
+//                    // To check all the terms in query are verified
+//                    for (int i = 0; i < queryTokenList.size() - 1; i++) {
+//                        Span first = fieldSpanList.get(iter + i);
+//                        Span second = fieldSpanList.get(iter + i + 1);
+//                        if (!(second.getTokenOffset() - first.getTokenOffset() == queryTokenOffset.get(i + 1)
+//                                - queryTokenOffset.get(i) && first.getValue().equalsIgnoreCase(queryTokenList.get(i))
+//                                && second.getValue().equalsIgnoreCase(queryTokenList.get(i + 1)))) {
+//                            iter++;
+//                            isMismatchInSpan = true;
+//                            break;
+//                        }
+//                    }
+//
+//                    if (isMismatchInSpan) {
+//                        continue;
+//                    }
+//
+//                    int combinedSpanStartIndex = fieldSpanList.get(iter).getStart();
+//                    int combinedSpanEndIndex = fieldSpanList.get(iter + queryTokenList.size() - 1).getEnd();
+//
+//                    Span combinedSpan = new Span(attributeName, combinedSpanStartIndex, combinedSpanEndIndex, predicate.getQuery(),
+//                            fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
+//                    matchingResults.add(combinedSpan);
+//                    iter = iter + queryTokenList.size();
+//                }
+//            }
+//        }
+//
+//        return matchingResults;
+//    }
+//
+//    public List<Span> computeSubstringMatchingResult(Tuple inputTuple) throws DataFlowException {
+//        List<Span> matchingResults = new ArrayList<>();
+//
+//        for (String attributeName : this.predicate.getAttributeNames()) {
+//            AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+//            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+//
+//            // types other than TEXT and STRING: throw Exception for now
+//            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+//                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+//            }
+//
+//            // for STRING type, the query should match the fieldValue completely
+//            if (attributeType == AttributeType.STRING) {
+//                if (fieldValue.equals(predicate.getQuery())) {
+//                    matchingResults.add(new Span(attributeName, 0, predicate.getQuery().length(), predicate.getQuery(), fieldValue));
+//                }
+//            }
+//
+//            if (attributeType == AttributeType.TEXT) {
+//                String regex = predicate.getQuery().toLowerCase();
+//                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+//                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
+//                while (matcher.find()) {
+//                    int start = matcher.start();
+//                    int end = matcher.end();
+//
+//                    matchingResults.add(new Span(attributeName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
+//                }
+//            }
+//
+//        }
+//        return matchingResults;
+//    }
+//
+//    private boolean isAllQueryTokensPresent(List<Span> fieldSpanList, Set<String> queryTokenSet) {
+//        Set<String> fieldSpanKeys = fieldSpanList.stream().map(span -> span.getKey()).collect(Collectors.toSet());
+//
+//        return fieldSpanKeys.equals(queryTokenSet);
+//    }
+//
+//    private List<Span> filterRelevantSpans(List<Span> spanList) {
+//        List<Span> relevantSpans = new ArrayList<>();
+//        Iterator<Span> iterator = spanList.iterator();
+//        while (iterator.hasNext()) {
+//            Span span = iterator.next();
+//            if (queryTokenSet.contains(span.getKey())) {
+//                relevantSpans.add(span);
+//            }
+//        }
+//        return relevantSpans;
+//    }
 
     public KeywordPredicate getPredicate() {
         return this.predicate;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
@@ -286,10 +286,12 @@ public class DataflowUtils {
             }
 
             if (attributeType == AttributeType.TEXT) {
-                               
-                for(int i = 0 ; i < fieldValue.toLowerCase().length(); i++){
+                
+                String fieldValueLowerCase = fieldValue.toLowerCase();
+                String queryKeywordLowerCase = queryKeyword.toLowerCase();
+                for(int i = 0 ; i < fieldValueLowerCase.length(); i++){
                 	int index = -1;
-                	if((index = fieldValue.toLowerCase().indexOf(queryKeyword.toLowerCase(),i)) != -1){
+                	if((index = fieldValueLowerCase.indexOf(queryKeywordLowerCase,i)) != -1){
                 		matchingResults.add(new Span(attributeName, index, index + queryKeyword.length(), queryKeyword, 
                 				fieldValue.substring(index, index + queryKeyword.length())));
                 		i = index + 1;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
@@ -266,7 +266,7 @@ public class DataflowUtils {
      * @param matchingResults
      * @throws DataFlowException
      */
-    public static void computeSubstringMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, List<Span> matchingResults) throws DataFlowException {
+    public static void appendSubstringMatchingSpans(Tuple inputTuple, List<String> attributeNames, String queryKeyword, List<Span> matchingResults) throws DataFlowException {
 
 
         for (String attributeName : attributeNames) {
@@ -302,7 +302,7 @@ public class DataflowUtils {
         }
     }
 
-    public static void computeConjunctionMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
+    public static void appendConjunctionMatchingSpans(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
         ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
         List<Span> payload = payloadField.getValue();
         List<String> queryTokenList = tokenizeQuery(luceneAnalyzerString, queryKeyword);
@@ -349,7 +349,7 @@ public class DataflowUtils {
      * @return
      * @throws DataFlowException
      */
-    public static void computePhraseMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
+    public static void appendPhraseMatchingSpans(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
         ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
         List<Span> payload = payloadField.getValue();
         List<String> queryTokenList = tokenizeQuery(luceneAnalyzerString, queryKeyword);

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
@@ -2,8 +2,9 @@ package edu.uci.ics.textdb.exp.utils;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -174,9 +175,10 @@ public class DataflowUtils {
     /**
      * Transform a list of spans into string
      * 
-     * @param tuple
+     * @param spanList
      * @return string representation of a list of spans
      */
+
     public static String getSpanListString(List<Span> spanList) {
         StringBuilder sb = new StringBuilder();
 
@@ -192,9 +194,10 @@ public class DataflowUtils {
     /**
      * Transform a span into string
      * 
-     * @param tuple
+     * @param span
      * @return string representation of a span
      */
+
     public static String getSpanString(Span span) {
         StringBuilder sb = new StringBuilder();
 
@@ -254,5 +257,199 @@ public class DataflowUtils {
 
         return payload;
     }
+
+    /***
+     *
+     * @param inputTuple
+     * @param attributeNames
+     * @param queryKeyword
+     * @param matchingResults
+     * @throws DataFlowException
+     */
+    public static void computeSubstringMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, List<Span> matchingResults) throws DataFlowException {
+
+
+        for (String attributeName : attributeNames) {
+            //  AttributeType attributeType = this.inputSchema.getAttribute(attributeName).getAttributeType();
+            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+            AttributeType attributeType = inputTuple.getSchema().getAttribute(attributeName).getAttributeType();
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(queryKeyword)) {
+                    matchingResults.add(new Span(attributeName, 0, queryKeyword.length(), queryKeyword, fieldValue));
+                }
+            }
+
+            if (attributeType == AttributeType.TEXT) {
+                for (int i = -1; (i = fieldValue.toLowerCase().indexOf(queryKeyword.toLowerCase(),i+1)) != -1;) {
+                    matchingResults.add(new Span(attributeName, i, i + queryKeyword.length(), queryKeyword, fieldValue.substring(i, i + queryKeyword.length())));
+
+                }
+
+            }
+        }
+    }
+
+    public static void computeConjunctionMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
+        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
+        List<String> queryTokenList = tokenizeQuery(luceneAnalyzerString, queryKeyword);
+        Set<String> queryTokenSet = new HashSet<>(queryTokenList);
+        List<Span> relevantSpans = filterRelevantSpans(payload,queryTokenSet);
+
+        for (String attributeName : attributeNames) {
+            AttributeType attributeType = inputTuple.getSchema().getAttribute(attributeName).getAttributeType();
+            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(queryKeyword)) {
+                    Span span = new Span(attributeName, 0, queryKeyword.length(), queryKeyword, fieldValue);
+                    matchingResults.add(span);
+                }
+            }
+
+            // for TEXT type, every token in the query should be present in span
+            // list for this field
+            if (attributeType == AttributeType.TEXT) {
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+                        .collect(Collectors.toList());
+
+                if (isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
+                    matchingResults.addAll(fieldSpanList);
+                }
+            }
+        }
+    }
+
+    /***
+     *
+     * @param inputTuple
+     * @param attributeNames
+     * @param queryKeyword
+     * @param luceneAnalyzerString
+     * @param matchingResults
+     * @return
+     * @throws DataFlowException
+     */
+    public static void computePhraseMatchingResult(Tuple inputTuple, List<String> attributeNames, String queryKeyword, String luceneAnalyzerString, List<Span> matchingResults) throws DataFlowException {
+        ListField<Span> payloadField = inputTuple.getField(SchemaConstants.PAYLOAD);
+        List<Span> payload = payloadField.getValue();
+        List<String> queryTokenList = tokenizeQuery(luceneAnalyzerString, queryKeyword);
+        Set<String> queryTokenSet = new HashSet<>(queryTokenList);
+        List<Span> relevantSpans = filterRelevantSpans(payload, queryTokenSet);
+        List<String> queryTokensWithStopwords = DataflowUtils.tokenizeQueryWithStopwords(queryKeyword);
+
+        for (String attributeName : attributeNames) {
+            AttributeType attributeType = inputTuple.getSchema().getAttribute(attributeName).getAttributeType();
+            String fieldValue = inputTuple.getField(attributeName).getValue().toString();
+
+            // types other than TEXT and STRING: throw Exception for now
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+            // for STRING type, the query should match the fieldValue completely
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(queryKeyword)) {
+                    matchingResults.add(new Span(attributeName, 0, queryKeyword.length(), queryKeyword, fieldValue));
+                }
+            }
+
+            // for TEXT type, spans need to be reconstructed according to the
+            // phrase query
+            if (attributeType == AttributeType.TEXT) {
+                List<Span> fieldSpanList = relevantSpans.stream().filter(span -> span.getAttributeName().equals(attributeName))
+                        .collect(Collectors.toList());
+
+                if (!isAllQueryTokensPresent(fieldSpanList, queryTokenSet)) {
+                    // move on to next field if not all query tokens are present
+                    // in the spans
+                    continue;
+                }
+
+                // Sort current field's span list by token offset for later use
+                Collections.sort(fieldSpanList, (span1, span2) -> span1.getTokenOffset() - span2.getTokenOffset());
+
+                List<Integer> queryTokenOffset = new ArrayList<>();
+
+                for (int i = 0; i < queryTokensWithStopwords.size(); i++) {
+                    if (queryTokenList.contains(queryTokensWithStopwords.get(i))) {
+                        queryTokenOffset.add(i);
+                    }
+                }
+
+                int iter = 0; // maintains position of term being checked in
+                // spanForThisField list
+                while (iter < fieldSpanList.size()) {
+                    if (iter > fieldSpanList.size() - queryTokenList.size()) {
+                        break;
+                    }
+
+                    // Verify if span in the spanForThisField correspond to our
+                    // phrase query, ie relative position offsets should be
+                    // similar
+                    // and the value should be same.
+                    boolean isMismatchInSpan = false;// flag to check if a
+                    // mismatch in spans occurs
+
+                    // To check all the terms in query are verified
+                    for (int i = 0; i < queryTokenList.size() - 1; i++) {
+                        Span first = fieldSpanList.get(iter + i);
+                        Span second = fieldSpanList.get(iter + i + 1);
+                        if (!(second.getTokenOffset() - first.getTokenOffset() == queryTokenOffset.get(i + 1)
+                                - queryTokenOffset.get(i) && first.getValue().equalsIgnoreCase(queryTokenList.get(i))
+                                && second.getValue().equalsIgnoreCase(queryTokenList.get(i + 1)))) {
+                            iter++;
+                            isMismatchInSpan = true;
+                            break;
+                        }
+                    }
+
+                    if (isMismatchInSpan) {
+                        continue;
+                    }
+
+                    int combinedSpanStartIndex = fieldSpanList.get(iter).getStart();
+                    int combinedSpanEndIndex = fieldSpanList.get(iter + queryTokenList.size() - 1).getEnd();
+
+                    Span combinedSpan = new Span(attributeName, combinedSpanStartIndex, combinedSpanEndIndex, queryKeyword,
+                            fieldValue.substring(combinedSpanStartIndex, combinedSpanEndIndex));
+                    matchingResults.add(combinedSpan);
+                    iter = iter + queryTokenList.size();
+                }
+            }
+        }
+
+    }
+
+    private static boolean isAllQueryTokensPresent(List<Span> fieldSpanList, Set<String> queryTokenSet) {
+        Set<String> fieldSpanKeys = fieldSpanList.stream().map(span -> span.getKey()).collect(Collectors.toSet());
+
+        return fieldSpanKeys.equals(queryTokenSet);
+    }
+
+    private static List<Span> filterRelevantSpans(List<Span> spanList, Set<String> queryTokenSet) {
+        List<Span> relevantSpans = new ArrayList<>();
+        Iterator<Span> iterator = spanList.iterator();
+        while (iterator.hasNext()) {
+            Span span = iterator.next();
+            if (queryTokenSet.contains(span.getKey())) {
+                relevantSpans.add(span);
+            }
+        }
+        return relevantSpans;
+    }
+
 
 }

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/utils/DataflowUtils.java
@@ -286,9 +286,16 @@ public class DataflowUtils {
             }
 
             if (attributeType == AttributeType.TEXT) {
-                for (int i = -1; (i = fieldValue.toLowerCase().indexOf(queryKeyword.toLowerCase(),i+1)) != -1;) {
-                    matchingResults.add(new Span(attributeName, i, i + queryKeyword.length(), queryKeyword, fieldValue.substring(i, i + queryKeyword.length())));
-
+                               
+                for(int i = 0 ; i < fieldValue.toLowerCase().length(); i++){
+                	int index = -1;
+                	if((index = fieldValue.toLowerCase().indexOf(queryKeyword.toLowerCase(),i)) != -1){
+                		matchingResults.add(new Span(attributeName, index, index + queryKeyword.length(), queryKeyword, 
+                				fieldValue.substring(index, index + queryKeyword.length())));
+                		i = index + 1;
+                	}else{
+                		break;
+                	}
                 }
 
             }


### PR DESCRIPTION
As the first step of Issue 537, we make two changes in this PR:

- Move the logic of three types of matching to the Utils package so that the code can be used by the `DictionaryMatcher`;

- Currently we use a regex `Pattern` to do substring matching.  A better implementation should be using `indexOf()` that doesn't require a regex.

```
            if (attributeType == AttributeType.TEXT) {
                String regex = predicate.getQuery().toLowerCase();
                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
                while (matcher.find()) {
                    int start = matcher.start();
                    int end = matcher.end();

                    matchingResults.add(new Span(attributeName, start, end, predicate.getQuery(), fieldValue.substring(start, end)));
                }

```