### PR TITLE
[Issue #537] Step 2: Modify Scan-Based Dictionary Matcher to generate a single output tuple for a single input tuple

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
@@ -49,7 +49,10 @@ public class Dictionary {
         }
         return null;
     }
-    
+
+    public boolean isEmpty(){
+        return (dictionaryEntries.isEmpty() || dictionaryEntries == null);
+    }
     /**
      * Reset the cursor to the start of the dictionary.
      */

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
@@ -51,7 +51,7 @@ public class Dictionary {
     }
 
     public boolean isEmpty(){
-        return (dictionaryEntries.isEmpty() || dictionaryEntries == null);
+        return (dictionaryEntries == null || dictionaryEntries.isEmpty());
     }
     /**
      * Reset the cursor to the start of the dictionary.

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
@@ -26,6 +26,7 @@ import java.util.List;
  * Created by Chang on 6/28/17.
  */
 public class DictionaryMatcher extends AbstractSingleInputOperator {
+
     private final DictionaryPredicate predicate;
 
 
@@ -37,6 +38,7 @@ public class DictionaryMatcher extends AbstractSingleInputOperator {
 
     @Override
     protected void setUp() throws TextDBException {
+
         if (inputOperator == null) {
             throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
         }
@@ -46,8 +48,10 @@ public class DictionaryMatcher extends AbstractSingleInputOperator {
         if (predicate.getDictionary().isEmpty()) {
             throw new DataFlowException("Dictionary is empty");
         }
+
         inputSchema = inputOperator.getOutputSchema();
         outputSchema = inputSchema;
+
         if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
             outputSchema = Utils.addAttributeToSchema(outputSchema, SchemaConstants.PAYLOAD_ATTRIBUTE);
         }
@@ -77,6 +81,7 @@ public class DictionaryMatcher extends AbstractSingleInputOperator {
 
     @Override
     public Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException {
+
         if (inputTuple == null) {
             return null;
         }
@@ -93,6 +98,7 @@ public class DictionaryMatcher extends AbstractSingleInputOperator {
         List<Span> matchingResults = new ArrayList<>();
 
         while ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) != null) {
+
             if(predicate.getKeywordMatchingType()== KeywordMatchingType.SUBSTRING_SCANBASED){
                 DataflowUtils.appendSubstringMatchingSpans(inputTuple,predicate.getAttributeNames(), currentDictionaryEntry, matchingResults);
             }
@@ -108,6 +114,7 @@ public class DictionaryMatcher extends AbstractSingleInputOperator {
         if (matchingResults.isEmpty()) {
             return null;
         }
+
         ListField<Span> spanListField = inputTuple.getField(predicate.getSpanListName());
         List<Span> spanList = spanListField.getValue();
         spanList.addAll(matchingResults);

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
@@ -27,16 +27,10 @@ import java.util.List;
  */
 public class DictionaryMatcher extends AbstractSingleInputOperator {
     private final DictionaryPredicate predicate;
-    private int limit;
-    private int offset;
-    private KeywordPredicate keywordPredicate;
-    private KeywordMatcher keywordMatcher;
+
 
     public DictionaryMatcher(DictionaryPredicate predicate) {
         this.predicate = predicate;
-        this.limit = Integer.MAX_VALUE;
-        this.offset = -1;
-
     }
 
     private Schema inputSchema;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcher.java
@@ -1,291 +1,190 @@
 package edu.uci.ics.textdb.exp.dictionarymatcher;
 
-import java.util.ArrayList;
-
 import edu.uci.ics.textdb.api.constants.ErrorMessages;
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.dataflow.IOperator;
 import edu.uci.ics.textdb.api.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.field.ListField;
+import edu.uci.ics.textdb.api.schema.Attribute;
+import edu.uci.ics.textdb.api.schema.AttributeType;
 import edu.uci.ics.textdb.api.schema.Schema;
+import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
-import edu.uci.ics.textdb.exp.keywordmatcher.KeywordPredicate;
+import edu.uci.ics.textdb.api.utils.Utils;
+import edu.uci.ics.textdb.exp.common.AbstractSingleInputOperator;
 import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatcher;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordMatchingType;
+import edu.uci.ics.textdb.exp.keywordmatcher.KeywordPredicate;
+import edu.uci.ics.textdb.exp.utils.DataflowUtils;
 
-public class DictionaryMatcher implements IOperator {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-    private DictionaryPredicate predicate;
-
-    private IOperator inputOperator;
-    private DictionaryTupleCacheOperator cacheOperator;
+/**
+ * Created by Chang on 6/28/17.
+ */
+public class DictionaryMatcher extends AbstractSingleInputOperator {
+    private final DictionaryPredicate predicate;
+    private int limit;
+    private int offset;
+    String currentDictionaryEntry;
     private KeywordPredicate keywordPredicate;
     private KeywordMatcher keywordMatcher;
 
-    private Schema outputSchema;
-
-    String currentDictionaryEntry;
-
-    private int resultCursor;
-    private int limit;
-    private int offset;
-
-    private int cursor = CLOSED;
-
     public DictionaryMatcher(DictionaryPredicate predicate) {
         this.predicate = predicate;
-
-        this.resultCursor = -1;
         this.limit = Integer.MAX_VALUE;
-        this.offset = 0;
+        this.offset = -1;
+
+    }
+
+    private Schema inputSchema;
+
+    @Override
+    protected void setUp() throws TextDBException {
+        if (inputOperator == null) {
+            throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+        }
+        inputSchema = inputOperator.getOutputSchema();
+        predicate.getDictionary().resetCursor();
+        //currentDictionaryEntry = predicate.getDictionary().getNextEntry();
+
+        if (predicate.getDictionary().isEmpty()) {
+            throw new DataFlowException("Dictionary is empty");
+        }
+        inputSchema = inputOperator.getOutputSchema();
+        outputSchema = inputSchema;
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            outputSchema = Utils.addAttributeToSchema(outputSchema, SchemaConstants.PAYLOAD_ATTRIBUTE);
+        }
+        if (inputSchema.containsField(predicate.getSpanListName())) {
+            throw new DataFlowException(ErrorMessages.DUPLICATE_ATTRIBUTE(predicate.getSpanListName(), inputSchema));
+        } else {
+            outputSchema = Utils.addAttributeToSchema(outputSchema,
+                    new Attribute(predicate.getSpanListName(), AttributeType.LIST));
+        }
+
     }
 
     @Override
-    public void open() throws DataFlowException {
-        if (cursor != CLOSED) {
-            return;
-        }
-        try {
-            if (inputOperator == null) {
-                throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
+    protected Tuple computeNextMatchingTuple() throws TextDBException {
+        Tuple inputTuple = null;
+        Tuple resultTuple = null;
+        while ((inputTuple = inputOperator.getNextTuple()) != null) {
+            resultTuple = processOneInputTuple(inputTuple);
+            if (resultTuple != null) {
+                break;
             }
-
-            predicate.getDictionary().resetCursor();
-            currentDictionaryEntry = predicate.getDictionary().getNextEntry();
-            if (currentDictionaryEntry == null) {
-                throw new DataFlowException("Dictionary is empty");
-            }
-
-            keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeNames(),
-                    predicate.getAnalyzerString(), predicate.getKeywordMatchingType(), predicate.getSpanListName());
-
-            keywordMatcher = new KeywordMatcher(keywordPredicate);
-            
-            cacheOperator = new DictionaryTupleCacheOperator();
-            cacheOperator.setInputOperator(inputOperator);
-            
-            keywordMatcher.setInputOperator(cacheOperator);
-
-            cacheOperator.openAll();
-            keywordMatcher.open();
-            outputSchema = keywordMatcher.getOutputSchema();
-
-        } catch (Exception e) {
-            throw new DataFlowException(e.getMessage(), e);
         }
-        cursor = OPENED;
+
+        return resultTuple;
+
     }
 
     @Override
-    public Tuple getNextTuple() throws TextDBException {
-        if (cursor == CLOSED) {
-            throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
-        }
-        if (resultCursor >= limit + offset - 1) {
+    public Tuple processOneInputTuple(Tuple inputTuple) throws TextDBException {
+        if (inputTuple == null) {
             return null;
         }
-
-        Tuple sourceTuple;
-        while (true) {
-            // If there's result from current keywordMatcher, return it.
-            if ((sourceTuple = keywordMatcher.getNextTuple()) != null) {
-                resultCursor++;
-                if (resultCursor >= offset) {
-                    return sourceTuple;
-                }
-                continue;
-            }
-            // If all results from current keywordMatcher are consumed,
-            // advance to next dictionary entry, and
-            // return null if reach the end of dictionary.
-            if ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) == null) {
-                return null;
-            }
-
-            // Update the KeywordMatcher with the new dictionary entry.
-            keywordMatcher.close();
-            
-            keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
-                    predicate.getAttributeNames(),
-                    predicate.getAnalyzerString(), predicate.getKeywordMatchingType(),
-                    predicate.getSpanListName());
-            keywordMatcher = new KeywordMatcher(keywordPredicate);
-            keywordMatcher.setInputOperator(cacheOperator);
-
-            keywordMatcher.open();
+        if (!inputSchema.containsField(SchemaConstants.PAYLOAD)) {
+            inputTuple = DataflowUtils.getSpanTuple(inputTuple.getFields(),
+                    DataflowUtils.generatePayloadFromTuple(inputTuple, predicate.getAnalyzerString()), outputSchema);
         }
+        if (predicate.getSpanListName() != null) {
+            inputTuple = DataflowUtils.getSpanTuple(inputTuple.getFields(), new ArrayList<Span>(), outputSchema);
+        }
+        predicate.getDictionary().resetCursor();
+       // Dictionary dictionary = new Dictionary(predicate.getDictionary().getDictionaryEntries());
+        List<Span> matchingResults = new ArrayList<>();
+       // currentDictionaryEntry = dictionary.getNextEntry();
+        while ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) != null) {
+            if(predicate.getKeywordMatchingType()== KeywordMatchingType.SUBSTRING_SCANBASED){
+                DataflowUtils.appendSubstringMatchingSpans(inputTuple,predicate.getAttributeNames(),currentDictionaryEntry,matchingResults);
+            }
+            else if(predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED){
+                DataflowUtils.appendPhraseMatchingSpans(inputTuple, predicate.getAttributeNames(), currentDictionaryEntry,predicate.getAnalyzerString(), matchingResults);
+            }
+            else if(predicate.getKeywordMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED){
+                DataflowUtils.appendConjunctionMatchingSpans(inputTuple, predicate.getAttributeNames(), currentDictionaryEntry, predicate.getAnalyzerString(), matchingResults);
+            }
+
+        }
+
+
+//            keywordPredicate = new KeywordPredicate(currentDictionaryEntry,
+//                    predicate.getAttributeNames(),
+//                    predicate.getAnalyzerString(), predicate.getKeywordMatchingType(),
+//                    predicate.getSpanListName());
+//            keywordMatcher = new KeywordMatcher(keywordPredicate);
+        // if (this.predicate.getKeywordMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+        //    matchingResults.addAll(keywordMatcher.computeConjunctionMatchingResult(inputTuple));
+        // }
+        // else if (this.predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED) {
+        //     matchingResults = keywordMatcher.computePhraseMatchingResult(inputTuple);
+        // }
+        //else if (this.predicate.getKeywordMatchingType() == KeywordMatchingType.SUBSTRING_SCANBASED) {
+        //     matchingResults = keywordMatcher.computeSubstringMatchingResult(inputTuple);
+        // }
+
+        //keywordMatcher.setUp();
+        //   matchingResults.addAll((List<Span>) keywordMatcher.processOneInputTuple(inputTuple).getField(predicate.getSpanListName()).getValue());
+        //    currentDictionaryEntry=predicate.getDictionary().getNextEntry();
+
+        if (matchingResults.isEmpty()) {
+            return null;
+        }
+        ListField<Span> spanListField = inputTuple.getField(predicate.getSpanListName());
+        List<Span> spanList = spanListField.getValue();
+        spanList.addAll(matchingResults);
+
+        return inputTuple;
+
     }
+
+    private List<Span> matchOneKeywordSubstring(Tuple inputTuple, String currentDictionaryEntry) throws DataFlowException {
+        List<Span> matchingResult = new ArrayList<>();
+        for (String attribute : predicate.getAttributeNames()) {
+            AttributeType attributeType = inputTuple.getSchema().getAttribute(attribute).getAttributeType();
+            String fieldValue = inputTuple.getField(attribute).getValue().toString();
+
+            if (attributeType != AttributeType.STRING && attributeType != AttributeType.TEXT) {
+                throw new DataFlowException("KeywordMatcher: Fields other than STRING and TEXT are not supported yet");
+            }
+
+
+            if (attributeType == AttributeType.STRING) {
+                if (fieldValue.equals(currentDictionaryEntry)) {
+                    matchingResult.add(new Span(attribute, 0, currentDictionaryEntry.length(), currentDictionaryEntry, fieldValue));
+                }
+            }
+
+            if (attributeType == AttributeType.TEXT) {
+                String regex = currentDictionaryEntry.toLowerCase();
+                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
+                while (matcher.find()) {
+                    int start = matcher.start();
+                    int end = matcher.end();
+
+                    matchingResult.add(new Span(attribute, start, end, currentDictionaryEntry, fieldValue.substring(start, end)));
+                }
+            }
+        }
+        return matchingResult;
+    }
+
 
     @Override
-    public void close() throws DataFlowException {
-        if (cursor == CLOSED) {
-            return;
-        }
-        try {
-            if (keywordMatcher != null) {
-                keywordMatcher.close();
-            }
-            if (cacheOperator != null) {
-                cacheOperator.closeAll();
-            }
-        } catch (Exception e) {
-            throw new DataFlowException(e.getMessage(), e);
-        }
-        cursor = CLOSED;
+    protected void cleanUp() throws TextDBException {
+
     }
-    
-    
-    /**
-     * The purpose of this operator is to "cache" the tuples from input operator
-     *   in an in-memory list.
-     * 
-     * The DictionaryMatcher uses a new KeywordMatcher for each entry in the dictionary,
-     *   each keyword matcher would have to get all the tuples from the input operators again and again.
-     * 
-     * This operator caches the tuples in the list, so that the tuples don't have to be produced 
-     *   from the input operator again and again for multiple keyword mathchers.
-     *   
-     * This operators relies on a few assumptions in the implementation of DictionaryMatcher:
-     *   - At any time, only ONE operator (KeywordMatcher) is connected to this cache operator.
-     *   - Multiple operators (KeywordMatchers) are connected to this operator sequentially.
-     *   
-     * @author Zuozhi Wang
-     *
-     */
-    private class DictionaryTupleCacheOperator implements IOperator {
-        
-        private IOperator inputOperator;
-        private Schema outputSchema;
-        
-        private ArrayList<Tuple> inputTupleList = new ArrayList<>();
-        
-        private boolean isOpen = false;
-        private boolean inputAllConsumed = false;
-        private int cachedTupleCursor = 0;
-        
-        /*
-         * openAll() is the actual "open" function for this cache operator.
-         * It will open this operator and its input operator.
-         * 
-         * It's the caller's responsibility to make sure openAll() is called before everything.
-         */
-        public void openAll() throws TextDBException {
-            if (isOpen) {
-                return;
-            }
-            if (inputOperator == null) {
-                throw new DataFlowException(ErrorMessages.INPUT_OPERATOR_NOT_SPECIFIED);
-            }
-            inputOperator.open();
-            outputSchema = inputOperator.getOutputSchema();
-            isOpen = true;
-        }
 
-        /*
-         * When the child operator (KeywordMatcher) calls "open()", we don't want to open the input operator again,
-         * so open() is served as an indicator that a new operator (KeywordMatcher) is connected to this operator.
-         */
-        @Override
-        public void open() throws TextDBException {
-            if (! isOpen) {
-                throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
-            }
-            // reset the cursor
-            cachedTupleCursor = 0;
-        }
-
-        @Override
-        public Tuple getNextTuple() throws TextDBException {
-            if (! isOpen) {
-                throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
-            }
-            // if cursor's next value exceeds the cache's size
-            if (cachedTupleCursor + 1 > inputTupleList.size()) {
-                // if the input operator has been fully consumed, return null
-                if (inputAllConsumed) {
-                    return null;
-                // else, get the next tuple from input operator, 
-                // add it to tuple list, and advance cursor
-                } else {
-                    Tuple tuple = inputOperator.getNextTuple();
-                    if (tuple == null) {
-                        inputAllConsumed = true;
-                    } else {
-                        inputTupleList.add(tuple);
-                        cachedTupleCursor++;
-                    }
-                    return tuple;
-                }
-            // if we can get the tuple from the cache, retrieve it and advance cursor
-            } else {
-                Tuple tuple = inputTupleList.get(cachedTupleCursor);
-                cachedTupleCursor++;
-                return tuple;
-            }
-        }
-        
-        /*
-         * closeAll() is the actual "close" function for this cache operator.
-         * It will close this operator and its input operator, and clear the cache
-         * 
-         * It's the caller's responsibility to make sure closeAll() is called after everything.
-         */
-        public void closeAll() throws TextDBException {
-            if (! isOpen) {
-                return;
-            }
-            inputAllConsumed = true;
-            isOpen = false;
-            cachedTupleCursor = 0;
-            inputTupleList = new ArrayList<>();
-            inputOperator.close();
-        }
-
-        /*
-         * When the child operator (KeywordMatcher) calls "close()", we don't want to close the input operator immediately,
-         * because there might be some tuples that are still not fetched from input operator.
-         * 
-         */
-        @Override
-        public void close() throws TextDBException {
-            if (! isOpen) {
-                throw new DataFlowException(ErrorMessages.OPERATOR_NOT_OPENED);
-            }
-            // reset the cursor
-            cachedTupleCursor = 0;
-        }
-        
-        @Override
-        public Schema getOutputSchema() {
-            return this.outputSchema;
-        }
-        
-        public void setInputOperator(IOperator inputOperator) {
-            this.inputOperator = inputOperator;
-        }
-        
-    }
-    
-    
-
-    @Override
     public Schema getOutputSchema() {
         return outputSchema;
-    }
-
-    public void setLimit(int limit) {
-        this.limit = limit;
-    }
-
-    public int getLimit() {
-        return this.limit;
-    }
-
-    public void setOffset(int offset) {
-        this.offset = offset;
-    }
-
-    public int getOffset() {
-        return this.offset;
     }
 
     public void setInputOperator(IOperator inputOperator) {

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
@@ -170,11 +170,12 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        List<Span> list2 = new ArrayList<Span>();
+       // List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 8, "john Lee", "john Lee");
         Span span2 = new Span("firstName", 0, 5, "bruce", "bruce");
         list1.add(span1);
-        list2.add(span2);
+        list1.add(span2);
+        //list2.add(span2);
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
@@ -185,17 +186,15 @@ public class DictionaryMatcherTest {
                 new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
                 new TextField("Tall Angry"), new ListField<Span>(list1) };
         Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
-        IField[] fields2 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry"), new ListField<Span>(list2) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+        //expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
+       // List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -214,11 +213,11 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        List<Span> list2 = new ArrayList<Span>();
+        //List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 2, "长孙", "长孙");
         Span span2 = new Span("firstName", 0, 2, "无忌", "无忌");
         list1.add(span1);
-        list2.add(span2);
+        list1.add(span2);
         Attribute[] schemaAttributes = new Attribute[TestConstantsChinese.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstantsChinese.ATTRIBUTES_PEOPLE[count];
@@ -229,17 +228,14 @@ public class DictionaryMatcherTest {
                 new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
                 new TextField("北京大学电气工程学院"), new ListField<Span>(list1) };
         Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
-        IField[] fields2 = { new StringField("无忌"), new StringField("长孙"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("北京大学电气工程学院"), new ListField<Span>(list2) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+        //expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
-
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
+       // List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -257,11 +253,11 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        List<Span> list2 = new ArrayList<Span>();
+       // List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 8, "john Lee", "john Lee");
         Span span2 = new Span("firstName", 0, 5, "bruce", "bruce");
         list1.add(span1);
-        list2.add(span2);
+        list1.add(span2);
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
@@ -272,17 +268,14 @@ public class DictionaryMatcherTest {
                 new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
                 new TextField("Tall Angry"), new ListField<Span>(list1) };
         Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
-        IField[] fields2 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry"), new ListField<Span>(list2) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+        //expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
-
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
+     //   List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -300,11 +293,11 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        List<Span> list2 = new ArrayList<Span>();
+        //List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 2, "长孙", "长孙");
         Span span2 = new Span("firstName", 0, 2, "无忌", "无忌");
         list1.add(span1);
-        list2.add(span2);
+        list1.add(span2);
         Attribute[] schemaAttributes = new Attribute[TestConstantsChinese.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstantsChinese.ATTRIBUTES_PEOPLE[count];
@@ -315,17 +308,15 @@ public class DictionaryMatcherTest {
                 new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
                 new TextField("北京大学电气工程学院"), new ListField<Span>(list1) };
         Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
-        IField[] fields2 = { new StringField("无忌"), new StringField("长孙"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("北京大学电气工程学院"), new ListField<Span>(list2) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+      //  expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
+    //    List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1016,63 +1007,221 @@ public class DictionaryMatcherTest {
         Assert.assertTrue(expectedList.containsAll(resultList));
     }
 
-    @Test
-    public void testMatchingWithLimitOffset() throws Exception {
-        ArrayList<String> word = new ArrayList<String>(Arrays.asList("angry"));
-        Dictionary dictionary = new Dictionary(word);
+//    @Test
+//    public void testMatchingWithLimitOffset() throws Exception {
+//        ArrayList<String> word = new ArrayList<String>(Arrays.asList("angry"));
+//        Dictionary dictionary = new Dictionary(word);
+//
+//        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+//        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+//            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+//        }
+//        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
+//
+//        Span span1 = new Span("description", 5, 10, "angry", "Angry");
+//        Span span2 = new Span("description", 6, 11, "angry", "Angry");
+//        Span span3 = new Span("description", 40, 45, "angry", "Angry");
+//        Span span4 = new Span("description", 6, 11, "angry", "angry");
+//
+//        List<Span> list1 = new ArrayList<>();
+//        list1.add(span1);
+//        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+//                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+//                new TextField("Tall Angry"), new ListField<>(list1) };
+//        List<Span> list2 = new ArrayList<>();
+//        list2.add(span2);
+//        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
+//                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
+//                new TextField("White Angry"), new ListField<>(list2) };
+//
+//        List<Span> list3 = new ArrayList<>();
+//        list3.add(span3);
+//        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+//                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+//                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
+//
+//        List<Span> list4 = new ArrayList<>();
+//        list4.add(span4);
+//        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
+//                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
+//                new TextField("Short angry"), new ListField<>(list4) };
+//
+//        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+//        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+//        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
+//        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
+//
+//        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
+//                TestConstants.DESCRIPTION);
+//        List<Tuple> expectedList = new ArrayList<>();
+//        List<Tuple> resultList = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 1);
+//
+//        expectedList.add(tuple1);
+//        expectedList.add(tuple2);
+//        expectedList.add(tuple3);
+//        expectedList.add(tuple4);
+//
+//        Assert.assertEquals(expectedList.size(), 4);
+//        Assert.assertEquals(resultList.size(), 1);
+//        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
+//    }
 
+    /***
+     * Testcases for DictionaryMatcher scan-based, use getScanSourceResults method only.
+     * @throws Exception
+     */
+    @Test
+    public void testMultipleWordQueryInTextFieldUsingScan_1() throws Exception {
+
+        ArrayList<String> names = new ArrayList<String>(Arrays.asList("tall","fair"));
+        Dictionary dictionary = new Dictionary(names);
+
+        // create a data tuple first
+        List<Span> list = new ArrayList<Span>();
+        List<Span> list1 = new ArrayList<Span>();
+        Span span = new Span("description", 0, 4, "tall", "Tall");
+        Span span1 = new Span("description", 5, 9, "fair","Fair");
+        list.add(span);
+        list1.add(span);
+        list1.add(span1);
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
         }
         schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
 
-        Span span1 = new Span("description", 5, 10, "angry", "Angry");
-        Span span2 = new Span("description", 6, 11, "angry", "Angry");
-        Span span3 = new Span("description", 40, 45, "angry", "Angry");
-        Span span4 = new Span("description", 6, 11, "angry", "angry");
-
-        List<Span> list1 = new ArrayList<>();
-        list1.add(span1);
         IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
                 new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry"), new ListField<>(list1) };
-        List<Span> list2 = new ArrayList<>();
-        list2.add(span2);
-        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-                new TextField("White Angry"), new ListField<>(list2) };
-
-        List<Span> list3 = new ArrayList<>();
-        list3.add(span3);
-        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
-
-        List<Span> list4 = new ArrayList<>();
-        list4.add(span4);
-        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
-                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
-                new TextField("Short angry"), new ListField<>(list4) };
-
+                new TextField("Tall Angry"), new ListField<Span>(list) };
+        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
+                new ListField<Span>(list1) };
         Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
         Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
-        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
-        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
-
+        List<Tuple> expectedResults = new ArrayList<Tuple>();
+        expectedResults.add(tuple1);
+        expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
-        List<Tuple> expectedList = new ArrayList<>();
-        List<Tuple> resultList = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 1);
 
-        expectedList.add(tuple1);
-        expectedList.add(tuple2);
-        expectedList.add(tuple3);
-        expectedList.add(tuple4);
-
-        Assert.assertEquals(expectedList.size(), 4);
-        Assert.assertEquals(resultList.size(), 1);
-        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        boolean contains = TestUtils.equals(expectedResults, returnedResults);
+        Assert.assertTrue(contains);
     }
-    
+    @Test
+    public void testMultipleWordQueryInTextFieldUsingScan_2() throws Exception {
+
+        ArrayList<String> names = new ArrayList<String>(Arrays.asList("tall fair"));
+        Dictionary dictionary = new Dictionary(names);
+
+        // create a data tuple first
+        List<Span> list = new ArrayList<Span>();
+        List<Span> list1 = new ArrayList<Span>();
+       // Span span = new Span("description", 0, 4, "tall", "Tall");
+        Span span1 = new Span("description", 0, 9, "tall fair","Tall Fair");
+       // list.add(span);
+       // list1.add(span);
+        list1.add(span1);
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
+
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<Span>(list) };
+        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
+                new ListField<Span>(list1) };
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        List<Tuple> expectedResults = new ArrayList<Tuple>();
+        //expectedResults.add(tuple1);
+        expectedResults.add(tuple2);
+        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
+                TestConstants.DESCRIPTION);
+
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        boolean contains = TestUtils.equals(expectedResults, returnedResults);
+        Assert.assertTrue(contains);
+    }
+
+
+    @Test
+    public void testMultipleWordQueryInStringFieldUsingScan() throws Exception {
+
+        ArrayList<String> names = new ArrayList<String>(Arrays.asList("christian john wayne", "rock bale"));
+        Dictionary dictionary = new Dictionary(names);
+
+        // create a data tuple first
+        List<Span> list1 = new ArrayList<Span>();
+        Span span1 = new Span("firstName", 0, 20, "christian john wayne","christian john wayne");
+        Span span2 = new Span("lastName", 0, 9, "rock bale", "rock bale");
+        // list.add(span);
+        // list1.add(span);
+        list1.add(span1);
+        list1.add(span2);
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
+
+        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
+                new ListField<Span>(list1) };
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        List<Tuple> expectedResults = new ArrayList<Tuple>();
+        //expectedResults.add(tuple1);
+        expectedResults.add(tuple2);
+        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME);
+
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        boolean contains = TestUtils.equals(expectedResults, returnedResults);
+        Assert.assertTrue(contains);
+    }
+    @Test
+    public void testMultipleWordQueryInStringandTestFieldUsingScan() throws Exception {
+
+        ArrayList<String> names = new ArrayList<String>(Arrays.asList("christian john wayne", "rock bale", "fair"));
+        Dictionary dictionary = new Dictionary(names);
+
+        // create a data tuple first
+        List<Span> list1 = new ArrayList<Span>();
+        Span span1 = new Span("firstName", 0, 20, "christian john wayne","christian john wayne");
+        Span span2 = new Span("lastName", 0, 9, "rock bale", "rock bale");
+        Span span3 = new Span("description", 5, 9, "fair","Fair");
+        // list.add(span);
+        // list1.add(span);
+        list1.add(span1);
+        list1.add(span2);
+        list1.add(span3);
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
+
+        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+                new IntegerField(42), new DoubleField(5.99),
+                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
+                new ListField<Span>(list1) };
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        List<Tuple> expectedResults = new ArrayList<Tuple>();
+        //expectedResults.add(tuple1);
+        expectedResults.add(tuple2);
+        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME, TestConstants.DESCRIPTION);
+
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        boolean contains = TestUtils.equals(expectedResults, returnedResults);
+        Assert.assertTrue(contains);
+    }
+
+
+
+
 }

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
@@ -170,12 +170,11 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-       // List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 8, "john Lee", "john Lee");
         Span span2 = new Span("firstName", 0, 5, "bruce", "bruce");
         list1.add(span1);
         list1.add(span2);
-        //list2.add(span2);
+
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
@@ -189,12 +188,12 @@ public class DictionaryMatcherTest {
 
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        //expectedResults.add(tuple2);
+
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
 
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
-       // List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
+
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -213,7 +212,6 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        //List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 2, "长孙", "长孙");
         Span span2 = new Span("firstName", 0, 2, "无忌", "无忌");
         list1.add(span1);
@@ -231,11 +229,9 @@ public class DictionaryMatcherTest {
 
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        //expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
-       // List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -253,7 +249,6 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-       // List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 8, "john Lee", "john Lee");
         Span span2 = new Span("firstName", 0, 5, "bruce", "bruce");
         list1.add(span1);
@@ -271,11 +266,9 @@ public class DictionaryMatcherTest {
 
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-        //expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
-     //   List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -293,7 +286,6 @@ public class DictionaryMatcherTest {
 
         // create a data tuple first
         List<Span> list1 = new ArrayList<Span>();
-        //List<Span> list2 = new ArrayList<Span>();
         Span span1 = new Span("lastName", 0, 2, "长孙", "长孙");
         Span span2 = new Span("firstName", 0, 2, "无忌", "无忌");
         list1.add(span1);
@@ -311,12 +303,11 @@ public class DictionaryMatcherTest {
 
         List<Tuple> expectedResults = new ArrayList<Tuple>();
         expectedResults.add(tuple1);
-      //  expectedResults.add(tuple2);
+
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
 
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
-    //    List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1007,64 +998,64 @@ public class DictionaryMatcherTest {
         Assert.assertTrue(expectedList.containsAll(resultList));
     }
 
-//    @Test
-//    public void testMatchingWithLimitOffset() throws Exception {
-//        ArrayList<String> word = new ArrayList<String>(Arrays.asList("angry"));
-//        Dictionary dictionary = new Dictionary(word);
-//
-//        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
-//        for (int count = 0; count < schemaAttributes.length - 1; count++) {
-//            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
-//        }
-//        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
-//
-//        Span span1 = new Span("description", 5, 10, "angry", "Angry");
-//        Span span2 = new Span("description", 6, 11, "angry", "Angry");
-//        Span span3 = new Span("description", 40, 45, "angry", "Angry");
-//        Span span4 = new Span("description", 6, 11, "angry", "angry");
-//
-//        List<Span> list1 = new ArrayList<>();
-//        list1.add(span1);
-//        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-//                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-//                new TextField("Tall Angry"), new ListField<>(list1) };
-//        List<Span> list2 = new ArrayList<>();
-//        list2.add(span2);
-//        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-//                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-//                new TextField("White Angry"), new ListField<>(list2) };
-//
-//        List<Span> list3 = new ArrayList<>();
-//        list3.add(span3);
-//        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-//                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-//                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
-//
-//        List<Span> list4 = new ArrayList<>();
-//        list4.add(span4);
-//        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
-//                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
-//                new TextField("Short angry"), new ListField<>(list4) };
-//
-//        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
-//        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
-//        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
-//        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
-//
-//        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
-//                TestConstants.DESCRIPTION);
-//        List<Tuple> expectedList = new ArrayList<>();
-//        List<Tuple> resultList = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 1);
-//
-//        expectedList.add(tuple1);
-//        expectedList.add(tuple2);
-//        expectedList.add(tuple3);
-//        expectedList.add(tuple4);
-//
-//        Assert.assertEquals(expectedList.size(), 4);
-//        Assert.assertEquals(resultList.size(), 1);
-//        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
-//    }
+    @Test
+    public void testMatchingWithLimitOffset() throws Exception {
+        ArrayList<String> word = new ArrayList<String>(Arrays.asList("angry"));
+        Dictionary dictionary = new Dictionary(word);
+
+        Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
+        for (int count = 0; count < schemaAttributes.length - 1; count++) {
+            schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
+        }
+        schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
+
+        Span span1 = new Span("description", 5, 10, "angry", "Angry");
+        Span span2 = new Span("description", 6, 11, "angry", "Angry");
+        Span span3 = new Span("description", 40, 45, "angry", "Angry");
+        Span span4 = new Span("description", 6, 11, "angry", "angry");
+
+        List<Span> list1 = new ArrayList<>();
+        list1.add(span1);
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
+                new TextField("Tall Angry"), new ListField<>(list1) };
+        List<Span> list2 = new ArrayList<>();
+        list2.add(span2);
+        IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
+                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
+                new TextField("White Angry"), new ListField<>(list2) };
+
+        List<Span> list3 = new ArrayList<>();
+        list3.add(span3);
+        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
+                new TextField("Lin Clooney is Short and lin clooney is Angry"), new ListField<>(list3) };
+
+        List<Span> list4 = new ArrayList<>();
+        list4.add(span4);
+        IField[] fields4 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42),
+                new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")),
+                new TextField("Short angry"), new ListField<>(list4) };
+
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
+        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        Tuple tuple3 = new Tuple(new Schema(schemaAttributes), fields3);
+        Tuple tuple4 = new Tuple(new Schema(schemaAttributes), fields4);
+
+        List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
+                TestConstants.DESCRIPTION);
+        List<Tuple> expectedList = new ArrayList<>();
+        List<Tuple> resultList = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 1);
+
+        expectedList.add(tuple1);
+        expectedList.add(tuple2);
+        expectedList.add(tuple3);
+        expectedList.add(tuple4);
+
+        Assert.assertEquals(expectedList.size(), 4);
+        Assert.assertEquals(resultList.size(), 1);
+        Assert.assertTrue(TestUtils.containsAll(expectedList, resultList));
+    }
 
     /***
      * Testcases for DictionaryMatcher scan-based, use getScanSourceResults method only.
@@ -1118,28 +1109,19 @@ public class DictionaryMatcherTest {
         // create a data tuple first
         List<Span> list = new ArrayList<Span>();
         List<Span> list1 = new ArrayList<Span>();
-       // Span span = new Span("description", 0, 4, "tall", "Tall");
         Span span1 = new Span("description", 0, 9, "tall fair","Tall Fair");
-       // list.add(span);
-       // list1.add(span);
         list1.add(span1);
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
         for (int count = 0; count < schemaAttributes.length - 1; count++) {
             schemaAttributes[count] = TestConstants.ATTRIBUTES_PEOPLE[count];
         }
         schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
-
-        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry"), new ListField<Span>(list) };
         IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
                 new IntegerField(42), new DoubleField(5.99),
                 new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
                 new ListField<Span>(list1) };
-        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
         Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
         List<Tuple> expectedResults = new ArrayList<Tuple>();
-        //expectedResults.add(tuple1);
         expectedResults.add(tuple2);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
@@ -1160,8 +1142,6 @@ public class DictionaryMatcherTest {
         List<Span> list1 = new ArrayList<Span>();
         Span span1 = new Span("firstName", 0, 20, "christian john wayne","christian john wayne");
         Span span2 = new Span("lastName", 0, 9, "rock bale", "rock bale");
-        // list.add(span);
-        // list1.add(span);
         list1.add(span1);
         list1.add(span2);
         Attribute[] schemaAttributes = new Attribute[TestConstants.ATTRIBUTES_PEOPLE.length + 1];
@@ -1170,14 +1150,13 @@ public class DictionaryMatcherTest {
         }
         schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
 
-        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+        IField[] fields1 = { new StringField("christian john wayne"), new StringField("rock bale"),
                 new IntegerField(42), new DoubleField(5.99),
                 new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
                 new ListField<Span>(list1) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
         List<Tuple> expectedResults = new ArrayList<Tuple>();
-        //expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+        expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME);
 
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
@@ -1195,8 +1174,6 @@ public class DictionaryMatcherTest {
         Span span1 = new Span("firstName", 0, 20, "christian john wayne","christian john wayne");
         Span span2 = new Span("lastName", 0, 9, "rock bale", "rock bale");
         Span span3 = new Span("description", 5, 9, "fair","Fair");
-        // list.add(span);
-        // list1.add(span);
         list1.add(span1);
         list1.add(span2);
         list1.add(span3);
@@ -1206,14 +1183,13 @@ public class DictionaryMatcherTest {
         }
         schemaAttributes[schemaAttributes.length - 1] = RESULTS_ATTRIBUTE;
 
-        IField[] fields2 = { new StringField("christian john wayne"), new StringField("rock bale"),
+        IField[] fields1 = { new StringField("christian john wayne"), new StringField("rock bale"),
                 new IntegerField(42), new DoubleField(5.99),
                 new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair"),
                 new ListField<Span>(list1) };
-        Tuple tuple2 = new Tuple(new Schema(schemaAttributes), fields2);
+        Tuple tuple1 = new Tuple(new Schema(schemaAttributes), fields1);
         List<Tuple> expectedResults = new ArrayList<Tuple>();
-        //expectedResults.add(tuple1);
-        expectedResults.add(tuple2);
+        expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME, TestConstants.DESCRIPTION);
 
         List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
@@ -1058,11 +1058,11 @@ public class DictionaryMatcherTest {
     }
 
     /***
-     * Testcases for DictionaryMatcher scan-based, use getScanSourceResults method only.
+     * Testcases for scan-based DictionaryMatcher, use getScanSourceResults method only.
      * @throws Exception
      */
     @Test
-    public void testMultipleWordQueryInTextFieldUsingScan_1() throws Exception {
+    public void testMultipleWordQueryInTextFieldUsingScan1() throws Exception {
 
         ArrayList<String> names = new ArrayList<String>(Arrays.asList("tall","fair"));
         Dictionary dictionary = new Dictionary(names);
@@ -1101,7 +1101,7 @@ public class DictionaryMatcherTest {
         Assert.assertTrue(contains);
     }
     @Test
-    public void testMultipleWordQueryInTextFieldUsingScan_2() throws Exception {
+    public void testMultipleWordQueryInTextFieldUsingScan2() throws Exception {
 
         ArrayList<String> names = new ArrayList<String>(Arrays.asList("tall fair"));
         Dictionary dictionary = new Dictionary(names);


### PR DESCRIPTION
Use AbstractSingleInputOperator structure to process one tuple at the outer loop. 
Append the result spanlist to include all matching keywords through the dictionary entires.   