### PR TITLE
[Issue #537] Step3: Modify the source-based dictionary matcher to generate a single output tuple for a single input tuple.

### DIFF
--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
@@ -3,12 +3,15 @@ package edu.uci.ics.textdb.api.utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.exception.TextDBException;
+import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
 import junit.framework.Assert;
 
@@ -53,7 +56,9 @@ public class TestUtils {
         
         return tupleList.containsAll(containsTupleList);
     }
-    
+
+
+
     /**
      * Returns true if the two tuple lists are equivalent (order doesn't matter)
      * 
@@ -73,6 +78,8 @@ public class TestUtils {
         
         return expectedResults.containsAll(exactResults) && exactResults.containsAll(expectedResults);
     }
+
+
 
     /**
      * Compare two tuple lists for given attribute values

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
@@ -53,7 +53,6 @@ public class TestUtils {
         
         return tupleList.containsAll(containsTupleList);
     }
-
     /**
      * Returns true if the two tuple lists are equivalent (order doesn't matter)
      * 

--- a/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
+++ b/textdb/textdb-api/src/main/java/edu/uci/ics/textdb/api/utils/TestUtils.java
@@ -3,15 +3,12 @@ package edu.uci.ics.textdb.api.utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.exception.TextDBException;
-import edu.uci.ics.textdb.api.span.Span;
 import edu.uci.ics.textdb.api.tuple.Tuple;
 import junit.framework.Assert;
 
@@ -57,8 +54,6 @@ public class TestUtils {
         return tupleList.containsAll(containsTupleList);
     }
 
-
-
     /**
      * Returns true if the two tuple lists are equivalent (order doesn't matter)
      * 
@@ -78,8 +73,6 @@ public class TestUtils {
         
         return expectedResults.containsAll(exactResults) && exactResults.containsAll(expectedResults);
     }
-
-
 
     /**
      * Compare two tuple lists for given attribute values

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -1,10 +1,8 @@
 
 package edu.uci.ics.textdb.exp.dictionarymatcher;
 
-import java.security.Key;
+
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import edu.uci.ics.textdb.api.constants.ErrorMessages;
 import edu.uci.ics.textdb.api.constants.SchemaConstants;

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -50,13 +50,13 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     private Map<String, Tuple> resultMap; //To store results for earlier dictionary entries for CONJUNCTION and PHRASE.
     private Iterator resultIterator;
 
-    private int cursor = CLOSED;  //Flag for computing matching result for CONJUNCTION and PHRASE.
+    private int cursor = CLOSED;  //Flag for computing matching results for CONJUNCTION and PHRASE.
 
     /**
      * Constructs a DictionaryMatcher with a dictionary predicate.
      *
      * Performs SUBSTRING_SCAN, PHRASE_INDEX, or CONJUNCTION_INDEX
-     * depends on the dictionary predicate.
+     * depending on the dictionary predicate.
      *
      * DictionaryOperatorType.SUBSTRING_SCAN: <br>
      * Scan the tuples using ScanSourceOperator followed by a Dictionary Matcher. <br>
@@ -65,8 +65,8 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      *
      * DictionaryOperatorType.PHRASE_INDEX, CONJUNCTION_INDEX: <br>
      * Loop through the dictionary entries.
-     * For each entry, use a index-based KeywordMatcher to get the matching results.
-     * Maintain a HashMap </Tuple_ID, Tuple> to add in all the matching results
+     * For each entry, use an index-based KeywordMatcher to get the matching results.
+     * Maintain a HashMap </Tuple_ID, Tuple> to add all the matching results
      * into the spanlist of each input tuple.
      *
      * CONJUNCTION_INDEX corresponds to KeywordOperatorType.BASIC, which
@@ -106,7 +106,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
             if (predicate.getKeywordMatchingType() == KeywordMatchingType.SUBSTRING_SCANBASED) {
 
-                // For Substring matching, create a scan source operator followed by a dictionary matcher:
+                // For Substring matching, create a scan source operator followed by a dictionary matcher.
 
                 indexSource = new ScanBasedSourceOperator(new ScanSourcePredicate(predicate.getTableName()));
 
@@ -119,7 +119,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
 
             } else {
                 // For other keyword matching types (CONJUNCTION and PHRASE),
-                // create a index-based keyword source operator.
+                // create an index-based keyword source operator.
 
                 keywordSource = new KeywordMatcherSourceOperator(new KeywordSourcePredicate(
                         currentDictionaryEntry,
@@ -131,7 +131,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                 keywordSource.open();
 
                 // Other keyword matching types uses a KeywordMatcher, so the
-                // output schema is the same as keywordMatcher's schema
+                // output schema is the same as keywordMatcher's schema.
 
                 inputSchema = keywordSource.getOutputSchema();
                 outputSchema = keywordSource.getOutputSchema();
@@ -156,8 +156,8 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
         }
         if (predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED
                 || predicate.getKeywordMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
-            // For each dictionary entry, get all result from KeywordMatcher.
 
+            // For each dictionary entry, get all results from KeywordMatcher.
             if(cursor == CLOSED){
 
                 resultMap = new HashMap<>();

--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherSourceOperator.java
@@ -1,12 +1,13 @@
 
 package edu.uci.ics.textdb.exp.dictionarymatcher;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.security.Key;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.uci.ics.textdb.api.constants.ErrorMessages;
+import edu.uci.ics.textdb.api.constants.SchemaConstants;
 import edu.uci.ics.textdb.api.dataflow.ISourceOperator;
 import edu.uci.ics.textdb.api.exception.DataFlowException;
 import edu.uci.ics.textdb.api.exception.TextDBException;
@@ -34,6 +35,7 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     private ISourceOperator indexSource;
     
     private KeywordMatcherSourceOperator keywordSource;
+    private DictionaryMatcher dictionaryMatcher;
 
     private Schema inputSchema;
     private Schema outputSchema;
@@ -46,7 +48,11 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     private int resultCursor;
     private int limit;
     private int offset;
+    private KeywordMatchingType keywordMatchingType;
 
+
+    private Map<String, Tuple> tupleMap;
+    private Iterator mapIterator;
     /**
      * Constructs a DictionaryMatcher with a dictionary predicate
      * 
@@ -54,11 +60,14 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * 
      */
     public DictionaryMatcherSourceOperator(DictionarySourcePredicate predicate) {
+
         this.resultCursor = -1;
         this.limit = Integer.MAX_VALUE;
         this.offset = 0;
         this.predicate = predicate;
+
     }
+
 
     /**
      * @about Opens dictionary matcher. Must call open() before calling
@@ -68,26 +77,31 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
     public void open() throws DataFlowException {
         try {
             currentDictionaryEntry = predicate.getDictionary().getNextEntry();
+
             if (currentDictionaryEntry == null) {
                 throw new DataFlowException("Dictionary is empty");
             }
 
-            if (predicate.getKeywordMatchingType() == KeywordMatchingType.SUBSTRING_SCANBASED) {
+            if (predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED) {
+                keywordMatchingType = KeywordMatchingType.PHRASE_INDEXBASED;
+            } else if (predicate.getKeywordMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED){
+                keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
+            } else{
+                keywordMatchingType = KeywordMatchingType.SUBSTRING_SCANBASED;
+            }
+
+
+            if (keywordMatchingType == KeywordMatchingType.SUBSTRING_SCANBASED) {
+
                 // For Substring matching, create a scan source operator.
                 indexSource = new ScanBasedSourceOperator(new ScanSourcePredicate(predicate.getTableName()));
-                indexSource.open();
 
-                // Substring matching's output schema needs to contains span
-                // list.
-                inputSchema = indexSource.getOutputSchema();
-                outputSchema = inputSchema;
-                if (inputSchema.containsField(predicate.getSpanListName())) {
-                    throw new DataFlowException(ErrorMessages.DUPLICATE_ATTRIBUTE(
-                            predicate.getSpanListName(), inputSchema));
-                }
-                outputSchema = Utils.addAttributeToSchema(outputSchema, 
-                        new Attribute(predicate.getSpanListName(), AttributeType.LIST));
+                dictionaryMatcher = new DictionaryMatcher(new DictionaryPredicate(predicate.getDictionary(), predicate.getAttributeNames(),
+                        predicate.getAnalyzerString(), predicate.getKeywordMatchingType(), predicate.getSpanListName()));
 
+                dictionaryMatcher.setInputOperator(indexSource);
+                dictionaryMatcher.open();
+                outputSchema = dictionaryMatcher.getOutputSchema();
 
             } else {
                 // For other keyword matching types (conjunction and phrase),
@@ -102,14 +116,21 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
                         predicate.getSpanListName()));
                 keywordSource.open();
 
+                tupleMap = new HashMap<>();
+                computeMatchingResult(tupleMap);
+                mapIterator = tupleMap.entrySet().iterator();
+
                 // Other keyword matching types uses a KeywordMatcher, so the
                 // output schema is the same as keywordMatcher's schema
+
                 inputSchema = keywordSource.getOutputSchema();
                 outputSchema = keywordSource.getOutputSchema();
             }
 
         } catch (Exception e) {
+
             throw new DataFlowException(e.getMessage(), e);
+
         }
     }
 
@@ -122,13 +143,14 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      * 
      *        DictionaryOperatorType.SCAN: <br>
      *        Scan the tuples using ScanSourceOperator. <br>
-     *        For each tuple, loop through the dictionary and find results. <br>
-     *        We assume the dictionary is smaller than the data at the source
-     *        operator, we treat the data source as the outer relation to reduce
-     *        the number of disk IOs. <br>
+     *        For each tuple, loop through the dictionary and find results with
+     *        DictionaryMatcher. <br>
      * 
      *        DictionaryOperatorType.KEYWORD_BASIC, KEYWORD_PHRASE: <br>
-     *        Use KeywordMatcher to find results. <br>
+     *        Loop through the dictionary entries.
+     *        For each entry, use a index-based KeywordMatcher to find the results.
+     *        Maintain a HashMap </Tuple_ID, Tuple> to add in all the matching results
+     *        into the spanlist of each input tuple.
      * 
      *        KEYWORD_BASIC corresponds to KeywordOperatorType.BASIC, which
      *        performs keyword search on the document. The input query is
@@ -142,68 +164,48 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
      */
     @Override
     public Tuple getNextTuple() throws TextDBException {
+
         if (resultCursor >= limit + offset - 1) {
             return null;
         }
-        if (predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED
-                || predicate.getKeywordMatchingType() == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
+        if (keywordMatchingType == KeywordMatchingType.PHRASE_INDEXBASED
+                || keywordMatchingType == KeywordMatchingType.CONJUNCTION_INDEXBASED) {
             // For each dictionary entry,
             // get all result from KeywordMatcher.
 
             while (true) {
-                // If there's result from current keywordMatcher, return it.
-                if ((sourceTuple = keywordSource.getNextTuple()) != null) {
+
+                if (mapIterator.hasNext()) {
                     resultCursor++;
                     if (resultCursor >= offset) {
-                        return sourceTuple;
+                              return ((Map.Entry<String, Tuple>) mapIterator.next()).getValue();
                     }
+
                     continue;
-                }
-                // If all results from current keywordMatcher are consumed,
-                // advance to next dictionary entry, and
-                // return null if reach the end of dictionary.
-                if ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) == null) {
+
+                } else{
                     return null;
                 }
 
-                // Construct a new KeywordMatcher with the new dictionary entry.
-                KeywordMatchingType keywordMatchingType;
-                if (predicate.getKeywordMatchingType() == KeywordMatchingType.PHRASE_INDEXBASED) {
-                    keywordMatchingType = KeywordMatchingType.PHRASE_INDEXBASED;
-                } else {
-                    keywordMatchingType = KeywordMatchingType.CONJUNCTION_INDEXBASED;
-                }
-
-                keywordSource.close();
-
-                KeywordSourcePredicate keywordSourcePredicate = new KeywordSourcePredicate(currentDictionaryEntry,
-                        predicate.getAttributeNames(),
-                        predicate.getAnalyzerString(), keywordMatchingType,
-                        predicate.getTableName(),
-                        predicate.getSpanListName());
-
-                keywordSource = new KeywordMatcherSourceOperator(keywordSourcePredicate);
-                keywordSource.open();
             }
         }
         // Substring matching (based on scan)
         else {
-            Tuple sourceTuple;
-            Tuple resultTuple = null;
-            while ((sourceTuple = indexSource.getNextTuple()) != null) {
-                sourceTuple = DataflowUtils.getSpanTuple(sourceTuple.getFields(), new ArrayList<Span>(), outputSchema);
 
-                resultTuple = computeMatchingResult(currentDictionaryEntry, sourceTuple);
-                if (resultTuple != null) {
+            while(true) {
+
+                if ((sourceTuple = dictionaryMatcher.getNextTuple()) != null) {
                     resultCursor++;
-                }
-                if (resultTuple != null && resultCursor >= offset) {
-                    break;
-                }
+                    if(resultCursor >= offset) {
+                        return sourceTuple;
+                    }
+                    continue;
+
+                }else return null;
             }
-            return resultTuple;
         }
     }
+
 
     public void setLimit(int limit) {
         this.limit = limit;
@@ -221,65 +223,49 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
         return this.offset;
     }
 
-    /*
-     * Advance the cursor of dictionary. if reach the end of the dictionary,
-     * advance the cursor of tuples and reset dictionary
+    /***
+     *  Maintain a HashMap </Tuple_ID, Tuple> to compute all the keyword
+     *  matching results for each tuple.
+     *
+     * @param tupleMap
      */
-    private void advanceDictionaryCursor() throws TextDBException {
-        if ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) != null) {
-            return;
-        }
-        predicate.getDictionary().resetCursor();
-        currentDictionaryEntry = predicate.getDictionary().getNextEntry();
-    }
 
-    /*
-     * Match the key against the Tuple. if there's no match, returns the
-     * original Tuple object, if there's a match, return a new Tuple
-     * with span list added
-     */
-    private Tuple computeMatchingResult(String key, Tuple sourceTuple) throws TextDBException {
+    private void computeMatchingResult(Map<String, Tuple> tupleMap){
+        Tuple inputTuple;
+        while(true) {
+            while((inputTuple = keywordSource.getNextTuple()) != null){
 
-        List<String> attributeNames = predicate.getAttributeNames();
-        List<Span> matchingResults = new ArrayList<>();
+                String key = inputTuple.getField(SchemaConstants._ID).getValue().toString();
+                if(tupleMap.containsKey(key)) {
 
-        for (String attributeName : attributeNames) {
-            String fieldValue = sourceTuple.getField(attributeName).getValue().toString();
-            AttributeType attributeType = inputSchema.getAttribute(attributeName).getAttributeType();
+                    ListField<Span> spanListField = tupleMap.get(key).getField(predicate.getSpanListName());
+                    List<Span> spanList = spanListField.getValue();
+                    spanList.addAll((List<Span>) inputTuple.getField(predicate.getSpanListName()).getValue());
 
-            // if attribute type is not TEXT, then key needs to match the
-            // fieldValue exactly
-            if (attributeType != AttributeType.TEXT) {
-                if (fieldValue.equals(key)) {
-                    matchingResults.add(new Span(attributeName, 0, fieldValue.length(), key, fieldValue));
+                }else {
+
+                    tupleMap.put(key, inputTuple);
                 }
-            }
-            // if attribute type is TEXT, then key can match a substring of
-            // fieldValue
-            else {
-                String regex = key.toLowerCase();
-                Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-                Matcher matcher = pattern.matcher(fieldValue.toLowerCase());
-                while (matcher.find()) {
-                    int start = matcher.start();
-                    int end = matcher.end();
 
-                    matchingResults.add(new Span(attributeName, start, end, key, fieldValue.substring(start, end)));
-                }
             }
+
+            if ((currentDictionaryEntry = predicate.getDictionary().getNextEntry()) == null) {
+                 return;
+            }
+
+            keywordSource.close();
+
+            KeywordSourcePredicate keywordSourcePredicate = new KeywordSourcePredicate(currentDictionaryEntry,
+                    predicate.getAttributeNames(),
+                    predicate.getAnalyzerString(), keywordMatchingType,
+                    predicate.getTableName(),
+                    predicate.getSpanListName());
+
+            keywordSource = new KeywordMatcherSourceOperator(keywordSourcePredicate);
+            keywordSource.open();
+
         }
 
-        advanceDictionaryCursor();
-
-        if (matchingResults.size() == 0) {
-            return null;
-        }
-
-        ListField<Span> spanListField = sourceTuple.getField(predicate.getSpanListName());
-        List<Span> spanList = spanListField.getValue();
-        spanList.addAll(matchingResults);
-
-        return sourceTuple;
     }
 
     /**
@@ -293,6 +279,10 @@ public class DictionaryMatcherSourceOperator implements ISourceOperator {
             }
             if (indexSource != null) {
                 indexSource.close();
+            }
+
+            if (dictionaryMatcher != null){
+                dictionaryMatcher.close();
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
+++ b/textdb/textdb-exp/src/test/java/edu/uci/ics/textdb/exp/dictionarymatcher/DictionaryMatcherTest.java
@@ -192,8 +192,7 @@ public class DictionaryMatcherTest {
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
-
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -231,7 +230,7 @@ public class DictionaryMatcherTest {
         expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.CONJUNCTION_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -268,7 +267,7 @@ public class DictionaryMatcherTest {
         expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -307,7 +306,7 @@ public class DictionaryMatcherTest {
         List<String> attributeNames = Arrays.asList(TestConstantsChinese.FIRST_NAME, TestConstantsChinese.LAST_NAME,
                 TestConstantsChinese.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(CHINESE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1045,7 +1044,7 @@ public class DictionaryMatcherTest {
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
         List<Tuple> expectedList = new ArrayList<>();
-        List<Tuple> resultList = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 1);
+        List<Tuple> resultList = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.PHRASE_INDEXBASED, 1, 3);
 
         expectedList.add(tuple1);
         expectedList.add(tuple2);
@@ -1096,7 +1095,7 @@ public class DictionaryMatcherTest {
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1126,7 +1125,7 @@ public class DictionaryMatcherTest {
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME,
                 TestConstants.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1159,7 +1158,7 @@ public class DictionaryMatcherTest {
         expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }
@@ -1192,7 +1191,7 @@ public class DictionaryMatcherTest {
         expectedResults.add(tuple1);
         List<String> attributeNames = Arrays.asList(TestConstants.FIRST_NAME, TestConstants.LAST_NAME, TestConstants.DESCRIPTION);
 
-        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getScanSourceResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED, Integer.MAX_VALUE, 0);
+        List<Tuple> returnedResults = DictionaryMatcherTestHelper.getQueryResults(PEOPLE_TABLE, dictionary, attributeNames, KeywordMatchingType.SUBSTRING_SCANBASED);
         boolean contains = TestUtils.equals(expectedResults, returnedResults);
         Assert.assertTrue(contains);
     }


### PR DESCRIPTION
In the source-based dictionary matcher, for keyword type substring: use a scan source operator connecting with a dictionary matcher to generate the result. 
For keyword type phrase and conjunction: maintain a hashmap <Tuple_ID, Tuple>.  Loop through the dictionary entries. For each entire, create a new keywordsourceoperator to generate all the matching results and add into the hashmap.  
Iterate over the hashmap to generate a single output tuple for a single input tuple.