### PR TITLE
Make DictionaryMatcher ignore empty strings in dictionary

### DIFF
--- a/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
+++ b/textdb/textdb-exp/src/main/java/edu/uci/ics/textdb/exp/dictionarymatcher/Dictionary.java
@@ -30,7 +30,13 @@ public class Dictionary {
             @JsonProperty(value = PropertyNameConstants.DICTIONARY_ENTRIES, required = true)
             Collection<String> dictionaryEntries) {
         // Using LinkedHashSet so that getNextValue() returns the words in order.
-        this.dictionaryEntries = new LinkedHashSet<>(dictionaryEntries);
+    	this.dictionaryEntries = new LinkedHashSet<>();
+    	for(String entry: dictionaryEntries){
+    		if(! entry.trim().equals("")){
+    			this.dictionaryEntries.add(entry.trim());
+    		}
+    	}
+        
         this.dictionaryIterator = this.dictionaryEntries.iterator();
     }
     


### PR DESCRIPTION
The issue is that the Dictionary class accepts empty string as dictionary entry. The constructor is modified to check for this and filter out the inputs.